### PR TITLE
CR-18 CEN-0045 Address Confirmation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,3 +6,4 @@ BAD_CODE_TYPE_MSG = {'text': 'Please re-enter your access code and try again.', 
 BAD_RESPONSE_MSG = {'text': 'There was an error, please enter your access code and try again.', "clickable": True, "level": "ERROR", "type": "SYSTEM_RESPONSE_ERROR"}  # NOQA
 INVALID_CODE_MSG = {'text': 'Please re-enter your access code and try again.', "clickable": True, "level": "ERROR", "type": "INVALID_CODE"}  # NOQA
 NOT_AUTHORIZED_MSG = {'text': 'There was a problem connecting to this study. Please try again later.', "level": "ERROR", "type": "SYSTEM_AUTH_ERROR"}  # NOQA
+ADDRESS_CHECK_MSG = {'text': 'Please check and confirm address.', "level": "ERROR", "type": "ADDRESS_CONFIRMATION_ERROR"}

--- a/app/eq.py
+++ b/app/eq.py
@@ -72,7 +72,7 @@ def build_response_id(case_id, collex_id, iac):
 
 class EqPayloadConstructor(object):
 
-    def __init__(self, case: dict, app: Application, iac: str):
+    def __init__(self, case: dict, attributes: dict, app: Application, iac: str):
         """
         Creates the payload needed to communicate with EQ, built from the Case, Collection Exercise, Sample,
         and Collection Instrument services
@@ -90,6 +90,11 @@ class EqPayloadConstructor(object):
             raise InvalidEqPayLoad("IAC is empty")
 
         self._iac = iac
+
+        if not attributes:
+            raise InvalidEqPayLoad("Attributes is empty")
+
+        self._sample_attributes = attributes
 
         try:
             self._case_id = case["id"]
@@ -162,12 +167,6 @@ class EqPayloadConstructor(object):
 
         self._collex_events = await self._get_collection_exercise_events()
         self._collex_event_dates = self._get_collex_event_dates()
-        self._sample_attributes = await self._get_sample_attributes_by_id()
-
-        try:
-            self._sample_attributes = self._sample_attributes["attributes"]
-        except KeyError:
-            raise InvalidEqPayLoad(f"Could not retrieve attributes for case {self._case_id}")
 
         try:
             self._country_code = self._sample_attributes["COUNTRY"]
@@ -189,6 +188,8 @@ class EqPayloadConstructor(object):
             "period_id": self._collex_period_id,  # required by eQ
             "form_type": self._form_type,  # required by eQ ('2' for lms_2 schema)
             "collection_exercise_sid": self._collex_id,  # required by eQ
+            "region_code": "GB-ENG",
+            "sexual_identity": True,
             "ru_ref": self._sample_unit_ref,  # required by eQ
             "case_id": self._case_id,  # not required by eQ but useful for downstream
             "case_ref": self._case_ref,  # not required by eQ but useful for downstream

--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -20,7 +20,7 @@ def create_error_middleware(overrides):
             resp = await handler(request)
             override = overrides.get(resp.status)
             return await override(request) if override else resp
-        except web.HTTPNotFound as ex:
+        except web.HTTPNotFound:
             index_resource = request.app.router['Index:get']
             if request.path + '/' == index_resource.canonical:
                 logger.debug('Redirecting to index', path=request.path)

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -152,7 +152,7 @@ class Index:
         except KeyError:
             raise InvalidEqPayLoad(f"Could not retrieve attributes for case {self._case_id}")
 
-        logger.debug("Address Conformation displayed", client_ip=self.client_ip)
+        logger.debug("Address Confirmation displayed", client_ip=self.client_ip)
         session = await get_session(request)
         session["attributes"] = attributes
         session["case"] = case

--- a/app/sample.py
+++ b/app/sample.py
@@ -1,0 +1,47 @@
+import logging
+
+from aiohttp import ClientError
+from aiohttp.web import Application
+from structlog import wrap_logger
+from .exceptions import InvalidEqPayLoad
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+async def get_sample_attributes(sample_unit_id: str, app: Application):
+    url = f"{app['SAMPLE_URL']}/samples/" + sample_unit_id + "/attributes"
+    logger.debug(f"Making GET request to {url}")
+    async with app.http_session_pool.get(url, auth=app["SAMPLE_AUTH"]) as response:
+        try:
+            response.raise_for_status()
+        except ClientError as ex:
+            logger.error("Error retrieving sample attributes", sample_unit_id=sample_unit_id, url=str(response.url),
+                         status_code=response.status)
+            raise ex
+        else:
+            logger.debug("Successfully retrieved sample attributes", sample_unit_id=sample_unit_id,
+                         url=str(response.url))
+        return await response.json()
+
+
+class Address(object):
+
+    def __init__(self, sample_attributes: dict, case_id: str):
+        sample_attributes = {k.lower(): v for k, v in sample_attributes.items()}
+        try:
+            self._address_line1 = sample_attributes["address_line1"]
+        except KeyError:
+            raise InvalidEqPayLoad(f"No address_line1 for case {case_id}")
+        self._address_line2 = sample_attributes["address_line2"]
+        self._town_name = sample_attributes["town_name"]
+        self._locality = sample_attributes["locality"]
+        self._postcode = sample_attributes["postcode"]
+
+    def to_dict(self) -> dict:
+        return {
+            'address_line1': self._address_line1,
+            'address_line2': self._address_line2,
+            'town_name': self._town_name,
+            'locality': self._locality,
+            'postcode': self._postcode
+        }

--- a/app/templates/address-confirmation.html
+++ b/app/templates/address-confirmation.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{% set messages_dict=dict(get_flashed_messages()|groupby('level')) %}
+{% block title %}{% if 'ERROR' in messages_dict %}Error - {{ super() }}{% else %}{{ super() }}{% endif %}{% endblock %}
+{% block content %}
+  {% if messages_dict %}
+    {% include "partials/messages.html" with context %}
+  {% endif %}
+  <div>
+    <h2 class="saturn u-mt-l u-mb-m">Is your address correct?</h2>
+    <form action="{{ url('AddressConfirmation:post') }}" class="form qa-questionnaire-form" role="form" method="post" novalidate>
+           <div class="group" id="household-and-accommodation">
+               <div class="block" id="address-check">
+                  <div class="section" id="address-check-section">
+                     <div class="question" id="address-check-question">
+                     <div class="question__guidance">
+                        <div class="panel panel--simple panel--info">
+                            {{ ADDRESS_LINE1 }}<br>
+                            {{ ADDRESS_LINE2 }}<br>
+                            {{ TOWN_NAME }}<br>
+                            {{ LOCALITY }}<br>
+                            {{ POSTCODE }}
+                        </div>
+                     </div>
+                     </div>
+                      <div class="question__answers">
+                          <div class="question__answer">
+                              <div class="answer answer--radio" id="container-address-check-answer">
+                                  <div class="answer__fields js-fields">
+                                     <div class="{% if 'ERROR' in messages_dict %} panel panel--simple panel--error {% endif %} u-mb-l">
+                                      <div class="field field--radio field--multiplechoice">
+                                          <fieldset>
+                                              <div class="field__item js-focusable-box">
+                                                  <input class="input input--radio js-focusable" id="address-check-answer-0" type="radio" value="Yes"
+                                                         name="address-check-answer">
+                                                  <label class="label label--inline venus" id="label-address-check-answer-0" for="address-check-answer-0">
+                                                      <span class="u-vh u-mt-s">Or, </span>
+                                                        Yes, this address is correct
+                                                      <span class="u-vh">. Selecting this will uncheck all other answers</span>
+                                                  </label>
+                                              </div>
+                                              <div class="field__item js-focusable-box">
+                                                  <input class="input input--radio js-focusable" id="address-check-answer-1" type="radio" value="No"
+                                                         name="address-check-answer">
+                                                  <label class="label label--inline venus" id="label-address-check-answer-1" for="address-check-answer-1">
+                                                      <span class="u-vh u-mt-s">Or, </span>
+                                                        No, I need to change this address
+                                                      <span class="u-vh">. Selecting this will uncheck all other answers</span>
+                                                  </label>
+                                              </div>
+                                          </fieldset>
+                                      </div>
+                                     </div>
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+               </div>
+            </div>
+        <button class="btn u-mb-s" data-qa="btn-submit" type="submit" name="action[save_continue]">Save and continue</button>
+    </form>
+  </div>
+{% endblock %}

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -13,13 +13,14 @@ from . import RHTestCase
 class TestEq(RHTestCase):
 
     def test_create_eq_constructor(self):
-        self.assertIsInstance(EqPayloadConstructor(self.case_json, self.app, self.iac_code), EqPayloadConstructor)
+        self.assertIsInstance(EqPayloadConstructor(
+            self.case_json, self.sample_attributes_json, self.app, self.iac_code), EqPayloadConstructor)
 
     def test_create_eq_constructor_missing_iac(self):
         iac_code = ''
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(self.case_json, self.app, iac_code)
+            EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, iac_code)
         self.assertIn('IAC is empty', ex.exception.message)
 
     def test_create_eq_constructor_missing_case_id(self):
@@ -27,7 +28,7 @@ class TestEq(RHTestCase):
         del case_json['id']
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(case_json, self.app, self.iac_code)
+            EqPayloadConstructor(case_json, self.sample_attributes_json, self.app, self.iac_code)
         self.assertIn('No case id in supplied case JSON', ex.exception.message)
 
     def test_create_eq_constructor_missing_case_ref(self):
@@ -35,7 +36,7 @@ class TestEq(RHTestCase):
         del case_json['caseRef']
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(case_json, self.app, self.iac_code)
+            EqPayloadConstructor(case_json, self.sample_attributes_json, self.app, self.iac_code)
         self.assertIn('No case ref in supplied case JSON', ex.exception.message)
 
     def test_create_eq_constructor_missing_sample_unit_ref(self):
@@ -43,7 +44,7 @@ class TestEq(RHTestCase):
         del case_json['caseGroup']['sampleUnitRef']
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(case_json, self.app, self.iac_code)
+            EqPayloadConstructor(case_json, self.sample_attributes_json, self.app, self.iac_code)
         self.assertIn(f'Could not retrieve sample unit ref for case {self.case_id}', ex.exception.message)
 
     def test_create_eq_constructor_missing_ci_id(self):
@@ -51,7 +52,7 @@ class TestEq(RHTestCase):
         del case_json['collectionInstrumentId']
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(case_json, self.app, self.iac_code)
+            EqPayloadConstructor(case_json, self.sample_attributes_json, self.app, self.iac_code)
         self.assertIn(f'No collectionInstrumentId value for case id {self.case_id}', ex.exception.message)
 
     def test_create_eq_constructor_missing_ce_id(self):
@@ -59,7 +60,7 @@ class TestEq(RHTestCase):
         del case_json["caseGroup"]["collectionExerciseId"]
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(case_json, self.app, self.iac_code)
+            self.sample_attributes_json,
         self.assertIn(f'No collection id for case id {self.case_id}', ex.exception.message)
 
     def test_create_eq_constructor_missing_sample_unit_id(self):
@@ -67,8 +68,8 @@ class TestEq(RHTestCase):
         del case_json["sampleUnitId"]
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(case_json, self.app, self.iac_code)
-        self.assertIn(f'No sample unit id for case {self.case_id}', ex.exception.message)
+            EqPayloadConstructor(case_json, self.sample_attributes_json, self.app, self.iac_code)
+            self.assertIn(f'No sample unit id for case {self.case_id}', ex.exception.message)
 
     @unittest_run_loop
     async def test_build(self):
@@ -86,7 +87,8 @@ class TestEq(RHTestCase):
                 mocked.get(self.survey_url, payload=self.survey_json)
 
                 with self.assertLogs('app.eq', 'INFO') as cm:
-                    payload = await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                    payload = await EqPayloadConstructor(
+                        self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
                 self.assertLogLine(cm, '', payload=payload)
 
         mocked_uuid4.assert_called()
@@ -104,7 +106,8 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await eq.EqPayloadConstructor(
+                    self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
             self.assertIn(f"Collection instrument {self.collection_instrument_id} type is not EQ", ex.exception.message)
 
     @unittest_run_loop
@@ -116,7 +119,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
             self.assertIn(f"No Collection Instrument type for {self.collection_instrument_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -128,7 +131,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve classifiers for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -140,7 +143,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve eq_id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -152,7 +155,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve form_type for eq_id {self.eq_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -165,7 +168,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_exercise_url, payload=ce_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve period id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -178,7 +181,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_exercise_url, payload=ce_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve ce id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -193,7 +196,7 @@ class TestEq(RHTestCase):
             mocked.get(self.sample_attributes_url, payload=sample_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve country_code for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -210,7 +213,8 @@ class TestEq(RHTestCase):
             mocked.get(self.sample_attributes_url, payload=sample_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await eq.EqPayloadConstructor(self.case_json, self.app, self.iac_code).build()
+                await eq.EqPayloadConstructor(
+                    self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
             self.assertIn(f'Could not retrieve attributes for case {self.case_id}', ex.exception.message)
 
     def test_find_event_date_by_tag(self):


### PR DESCRIPTION
# Motivation and Context
A request was made to add a screen to RH for a respondent to be able to confirm an address. This was for a January deadline. Please see screenshot below. This work is covered by user story Cen-0045 Address Confirmation providing traceability to the user requirements.

# What has changed
The RH being run for the LMS pilot has been cloned to this repository and the required page added. I have attempted to use the same css classes and structure as used previously and in EQ, and picked up from the ONS CDN. When the Census branding has been established these class display characteristics can change and hopefully RH and EQ will have the same look and feel and branding.

Previously the respondent was only required to enter a UAC. With the requirement to add further interaction with the respondent state needed to be maintained between requests. At present the session state uses AES encrptyed cookie storage. This avoids any dependency on Redis but can be refactored to use Redis when further design on the interface with EQ and RM is implemented. The application structure also needed to change slightly, but again more refactoring may follow further design of RM and EQ interfaces.

At present the application is very chatty, detracting from its requirement to service large request volumes. It makes 5 requests to other services some of which may be removed for Census, e.g. collection instrument service, collection exercise service, sample service? How this information is used in EQ and RM service interaction needs to be reviewed and further design undertaken before RH can be refactored further. Please see below notes on present service interaction and EQ payload use of data with example data returned from services:
  
IAC details from IAC service:
{'caseId': 'e3f223f4-485d-45d1-98fa-1e176740dc9e', 'caseRef': '1000000000000004', 'iac': 'xftkn6thvn89', 'active': True, 'questionSet': None, 'lastUsedDateTime': 1543231499623}

Case details from case service using caseId from above:
{'state': 'ACTIONABLE', 'id': 'e3f223f4-485d-45d1-98fa-1e176740dc9e', 'actionPlanId': 'f1cd4fd0-356c-49a2-a060-753076dba8e1', 'collectionInstrumentId': 'a8c1bb61-15eb-4e91-979b-f757ac950e5d', 'partyId': None, 'sampleUnitId': '12781d04-cd3d-4a0f-8ddd-7919d743d22f', 'iac': None, 'caseRef': '1000000000000004', 'createdBy': 'SYSTEM', 'sampleUnitType': 'H', 'createdDateTime': '2018-11-02T15:48:28.864Z', 'caseGroup': {'collectionExerciseId': '87461e7f-b520-4f72-8053-ddc226b9186c', 'id': 'f4afa206-506d-4960-8df3-7a5d62dd7e12', 'partyId': None, 'sampleUnitRef': 'OHS000004', 'sampleUnitType': 'H', 'caseGroupStatus': 'INPROGRESS'}, 'responses': [], 'caseEvents': None}

Sample attributes, which contain address, from sample service:
{'TLA': 'OHS', 'UPRN': '123459', 'COUNTRY': 'E', 'LOCALITY': 'Hampshire', 'POSTCODE': 'PO15 5RR', 'REFERENCE': '000004', 'TOWN_NAME': 'Titchfield', 'ADDRESS_LINE1': 'Office for National Statistics', 'ADDRESS_LINE2': 'Segensworth Road', 'ORGANISATION_NAME': ''}

Collection Instrument details from collection instrument service using collection instrument ID from case:
{'businesses': [], 'classifiers': {'collection_exercise': '87461e7f-b520-4f72-8053-ddc226b9186c', 'eq_id': 'census', 'form_type': 'household'}, 'exercises': ['87461e7f-b520-4f72-8053-ddc226b9186c'], 'file_name': 'household', 'id': 'a8c1bb61-15eb-4e91-979b-f757ac950e5d', 'len': None, 'stamp': 'Fri, 02 Nov 2018 15:48:20 GMT', 'survey': '028363da-cec5-4825-a3ef-44eb35f02c4c', 'type': 'EQ'}

Collection Exercise details from collection exercise service:
{'id': '87461e7f-b520-4f72-8053-ddc226b9186c', 'surveyId': '028363da-cec5-4825-a3ef-44eb35f02c4c', 'name': None, 'actualExecutionDateTime': '2018-11-02T15:48:25.222Z', 'scheduledExecutionDateTime': '2018-07-23T00:00:00.000Z', 'scheduledStartDateTime': '2018-07-23T00:00:00.000Z', 'actualPublishDateTime': None, 'periodStartDateTime': '2018-07-23T00:00:00.000Z', 'periodEndDateTime': '2020-07-31T00:00:00.000Z', 'scheduledReturnDateTime': '2018-08-04T00:00:00.000Z', 'scheduledEndDateTime': '2020-07-31T00:00:00.000Z', 'executedBy': None, 'state': 'LIVE', 'caseTypes': [{'actionPlanId': 'f1cd4fd0-356c-49a2-a060-753076dba8e1', 'sampleUnitType': 'H'}], 'exerciseRef': '1', 'userDescription': 'Test 1', 'created': '2018-11-02T15:42:47.477Z', 'updated': '2018-11-02T15:48:27.991Z', 'deleted': None, 'validationErrors': None, 'events': [{'id': 'e6e4b3cb-8c62-4e17-a01a-c2e7e17b5599', 'collectionExerciseId': '87461e7f-b520-4f72-8053-ddc226b9186c', 'tag': 'mps', 'timestamp': '2018-07-23T00:00:00.000Z'}, {'id': 'c5260817-07c7-48b5-9d49-bba07c30fee5', 'collectionExerciseId': '87461e7f-b520-4f72-8053-ddc226b9186c', 'tag': 'go_live', 'timestamp': '2018-07-24T00:00:00.000Z'}, {'id': '821f8353-9dff-49f1-9fde-4aabc1be85aa', 'collectionExerciseId': '87461e7f-b520-4f72-8053-ddc226b9186c', 'tag': 'return_by', 'timestamp': '2018-08-04T00:00:00.000Z'}, {'id': '8a77238b-1a45-4f32-909a-1a9da5850b03', 'collectionExerciseId': '87461e7f-b520-4f72-8053-ddc226b9186c', 'tag': 'exercise_end', 'timestamp': '2020-07-31T00:00:00.000Z'}, {'id': '07db11f0-8307-44e1-9f27-f2c6e75a7742', 'collectionExerciseId': '87461e7f-b520-4f72-8053-ddc226b9186c', 'tag': 'ref_period_start', 'timestamp': '2018-07-24T00:00:00.000Z'}, {'id': 'f3422930-a071-42f0-b358-d055edab4592', 'collectionExerciseId': '87461e7f-b520-4f72-8053-ddc226b9186c', 'tag': 'ref_period_end', 'timestamp': '2018-08-04T00:00:00.000Z'}]}

Need to agree the payload and JWE token sent to EQ to optimise above. At the moment details such as below are sent to EQ:
- user_id,sample unitId from case details
- eq_id, currently “census” taken from collection_instrument details
- period_id,  exerciseRef taken from collection exercise
- form_type, e.g. household taken from collection instrument details
- collection_exercise_sid, id taken from collection exercise details 
- region_code? something like GB-ENG? Currently I don’t think provided in what EQ expects? Need
to tie up Sample Country details?
- ru_ref, sample unit reference from case details
- case_id, from case details, not required by EQ but this or case_ref presumably used to notify RM of completed case?
- case_ref, from case details 
- country_code, from sample service
- language_code, currently hard coded, need to understand where to get this?
- display_address, formed from address information from sample service
- response_id, hash of case Id, collection exercise Id and and UAC
- all the sample attributes from the sample service, which includes all address fields are also added to the payload
- all event dates from the collection exercise service are also added to the payload

# How to test?
Tested against all other services running in Docker. Unit tests amended for changes. 

# Links
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=CRM&title=Cen-0045%2C+Address+Confirmation

# Screenshots (if appropriate): 
![image](https://user-images.githubusercontent.com/21059227/49152999-52da5e80-f30c-11e8-860b-fe2016286837.png)

