### PR TITLE
Spellcheck added for UAC

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -23,17 +23,17 @@
                             <div class="fieldgroup__fields">
                               <div class="field field--input field--code">
                                 <label class="label mercury u-vh" for="iac1">Enter the first four characters of the access code</label>
-                                <input pattern="^[a-zA-Z0-9]{4}$" maxlength="4" data-qa="input-text" id="iac1" name="iac1" class="input input--text" value=""
+                                <input pattern="^[a-zA-Z0-9]{4}$" maxlength="4" spellcheck="false" data-qa="input-text" id="iac1" name="iac1" class="input input--text" value=""
                                   type="text" autocomplete="off" required>
                               </div>
                               <div class="field field--input field--code">
                                 <label class="label mercury u-vh" for="iac2">Enter the next four characters of the access code</label>
-                                <input pattern="^[a-zA-Z0-9]{4}$" maxlength="4" data-qa="input-text" id="iac2" name="iac2" class="input input--text" value=""
+                                <input pattern="^[a-zA-Z0-9]{4}$" maxlength="4" spellcheck="false"  data-qa="input-text" id="iac2" name="iac2" class="input input--text" value=""
                                   type="text" autocomplete="off" required>
                               </div>
                               <div class="field field--input field--code">
                                 <label class="label mercury u-vh" for="iac3">Enter the last four characters of the access code</label>
-                                <input pattern="^[a-zA-Z0-9]{4}$" maxlength="4" data-qa="input-text" id="iac3" name="iac3" class="input input--text" value=""
+                                <input pattern="^[a-zA-Z0-9]{4}$" maxlength="4"  spellcheck="false" data-qa="input-text" id="iac3" name="iac3" class="input input--text" value=""
                                   type="text" autocomplete="off" required>
                               </div>
                             </div>


### PR DESCRIPTION
# Motivation and Context
When entering the UAC in Safari autocorrect was changing one of the set of four characters to a word.
E.g tjwn was being changed to town.

# What has changed
index.html has been changed and spellcheck="false"
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
Screenshots show what happened what happened before and after. Before the change an error message was displayed and afterwards the questionnaire was presented.
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
Page before change (tjwn gets autocorrected to town)

![image](https://user-images.githubusercontent.com/21056640/50904619-ad410180-1418-11e9-9a35-06f83679f828.png)

Page presented when UAC has been autocorrected (presents an error message)

![image](https://user-images.githubusercontent.com/21056640/50904828-38ba9280-1419-11e9-84a2-eba9a7d13cf4.png)

Page when spellcheck has been set to false

![image](https://user-images.githubusercontent.com/21056640/50904794-26d8ef80-1419-11e9-8c9e-31dfb4ab4600.png)

Page presented when UAC has not been autocorrected ( address confirmation screen)

![image](https://user-images.githubusercontent.com/21056640/50904862-453eeb00-1419-11e9-8566-5a5dce1c3788.png)


