### PR TITLE
Cdtt460 tests unit

### DIFF
--- a/app/sample.py
+++ b/app/sample.py
@@ -22,4 +22,3 @@ async def get_sample_attributes(sample_unit_id: str, app: Application):
             logger.debug("Successfully retrieved sample attributes", sample_unit_id=sample_unit_id,
                          url=str(response.url))
         return await response.json()
-

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -215,6 +215,7 @@ class RHTestCase(AioHTTPTestCase):
         self.get_cookies_privacy = self.app.router['CookiesPrivacy:get'].url_for()
         self.get_contact_us = self.app.router['ContactUs:get'].url_for()
         self.post_index = self.app.router['Index:post'].url_for()
+        self.post_address_confirmation = self.app.router['AddressConfirmation:post'].url_for()
 
         self.action_plan_id = self.case_json['actionPlanId']
         self.case_id = self.case_json['id']
@@ -300,6 +301,10 @@ class RHTestCase(AioHTTPTestCase):
 
         self.form_data = {
             'iac1': self.iac1, 'iac2': self.iac2, 'iac3': self.iac3, 'action[save_continue]': '',
+        }
+
+        self.address_confirmation_data = {
+            'address-check-answer': 'Yes', 'action[save_continue]': ''
         }
 
         class DummyConstructor:

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -231,6 +231,7 @@ class RHTestCase(AioHTTPTestCase):
         self.iac1, self.iac2, self.iac3 = self.iac_code[:4], self.iac_code[4:8], self.iac_code[8:]
         self.iac_json = {'active': '1', 'caseId': self.case_id}
         self.sample_unit_id = self.sample_attributes_json['id']
+        self.sample_unit_attributes = self.sample_attributes_json['attributes']
         self.sample_unit_ref = self.case_json['caseGroup']['sampleUnitRef']
         self.sample_unit_type = self.case_json['sampleUnitType']
         self.survey_id = self.survey_json['id']
@@ -264,7 +265,9 @@ class RHTestCase(AioHTTPTestCase):
             "country": self.sample_attributes_json['attributes']['COUNTRY'],
             "country_code": self.sample_attributes_json['attributes']['COUNTRY'],
             "reference": self.sample_attributes_json['attributes']['REFERENCE'],
-            "response_id": self.response_id
+            "response_id": self.response_id,
+            "region_code": 'GB-ENG',
+            "sexual_identity": True
         }
 
         self.case_url = (

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -198,8 +198,6 @@ class TestEq(RHTestCase):
 
     @unittest_run_loop
     async def test_build_raises_InvalidEqPayLoad_missing_attributes(self):
-        sample_json = self.sample_attributes_json.copy()
-        del sample_json['attributes']
 
         from app import eq  # NB: local import to avoid overwriting the patched version for some tests
 
@@ -210,8 +208,8 @@ class TestEq(RHTestCase):
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
                 await eq.EqPayloadConstructor(
-                    self.case_json, self.sample_unit_attributes, self.app, self.iac_code).build()
-            self.assertIn(f'Could not retrieve attributes for case {self.case_id}', ex.exception.message)
+                    self.case_json, None, self.app, self.iac_code).build()
+            self.assertIn('Attributes is empty', ex.exception.message)
 
     def test_find_event_date_by_tag(self):
         find_mandatory_date = functools.partial(EqPayloadConstructor._find_event_date_by_tag, mandatory=True)

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -60,7 +60,7 @@ class TestEq(RHTestCase):
         del case_json["caseGroup"]["collectionExerciseId"]
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            self.sample_attributes_json,
+            EqPayloadConstructor(case_json, self.sample_attributes_json, self.app, self.iac_code)
         self.assertIn(f'No collection id for case id {self.case_id}', ex.exception.message)
 
     def test_create_eq_constructor_missing_sample_unit_id(self):
@@ -83,12 +83,10 @@ class TestEq(RHTestCase):
                 mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
                 mocked.get(self.collection_exercise_url, payload=self.collection_exercise_json)
                 mocked.get(self.collection_exercise_events_url, payload=self.collection_exercise_events_json)
-                mocked.get(self.sample_attributes_url, payload=self.sample_attributes_json)
-                mocked.get(self.survey_url, payload=self.survey_json)
 
                 with self.assertLogs('app.eq', 'INFO') as cm:
                     payload = await EqPayloadConstructor(
-                        self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
+                        self.case_json, self.sample_unit_attributes, self.app, self.iac_code).build()
                 self.assertLogLine(cm, '', payload=payload)
 
         mocked_uuid4.assert_called()
@@ -107,7 +105,7 @@ class TestEq(RHTestCase):
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
                 await eq.EqPayloadConstructor(
-                    self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
+                    self.case_json, self.sample_unit_attributes, self.app, self.iac_code).build()
             self.assertIn(f"Collection instrument {self.collection_instrument_id} type is not EQ", ex.exception.message)
 
     @unittest_run_loop
@@ -119,7 +117,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.sample_unit_attributes, self.app, self.iac_code).build()
             self.assertIn(f"No Collection Instrument type for {self.collection_instrument_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -131,7 +129,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.sample_unit_attributes, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve classifiers for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -143,7 +141,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.sample_unit_attributes, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve eq_id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -155,7 +153,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=ci_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.sample_unit_attributes, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve form_type for eq_id {self.eq_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -168,7 +166,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_exercise_url, payload=ce_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.sample_unit_attributes, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve period id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -181,7 +179,7 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_exercise_url, payload=ce_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.sample_unit_attributes, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve ce id for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -193,10 +191,9 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
             mocked.get(self.collection_exercise_url, payload=self.collection_exercise_json)
             mocked.get(self.collection_exercise_events_url, payload=self.collection_exercise_events_json)
-            mocked.get(self.sample_attributes_url, payload=sample_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
-                await EqPayloadConstructor(self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
+                await EqPayloadConstructor(self.case_json, self.sample_unit_attributes, self.app, self.iac_code).build()
             self.assertIn(f"Could not retrieve country_code for case {self.case_id}", ex.exception.message)
 
     @unittest_run_loop
@@ -210,11 +207,10 @@ class TestEq(RHTestCase):
             mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
             mocked.get(self.collection_exercise_url, payload=self.collection_exercise_json)
             mocked.get(self.collection_exercise_events_url, payload=self.collection_exercise_events_json)
-            mocked.get(self.sample_attributes_url, payload=sample_json)
 
             with self.assertRaises(InvalidEqPayLoad) as ex:
                 await eq.EqPayloadConstructor(
-                    self.case_json, self.sample_attributes_json, self.app, self.iac_code).build()
+                    self.case_json, self.sample_unit_attributes, self.app, self.iac_code).build()
             self.assertIn(f'Could not retrieve attributes for case {self.case_id}', ex.exception.message)
 
     def test_find_event_date_by_tag(self):

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -120,10 +120,15 @@ class TestHandlers(RHTestCase):
         with aioresponses(passthrough=[str(self.server._root)]) as mocked:
             mocked.get(self.iac_url, payload=self.iac_json)
             mocked.get(self.case_url, payload=self.case_json)
+            mocked.get(self.sample_attributes_url, payload=self.sample_attributes_json)
             mocked.get(self.collection_instrument_url, exception=ClientConnectionError('Failed'))
 
+            response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+            self.assertEqual(response.status, 200)
+
             with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_address_confirmation, allow_redirects=False,
+                                                     data=self.address_confirmation_data)
             self.assertLogLine(cm, "Service connection error", message='Failed')
 
         self.assertEqual(response.status, 500)
@@ -133,19 +138,20 @@ class TestHandlers(RHTestCase):
     @unittest_run_loop
     async def test_post_index_with_build(self):
         with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            # mocks for initial data setup in post
             mocked.get(self.iac_url, payload=self.iac_json)
             mocked.get(self.case_url, payload=self.case_json)
             mocked.post(self.case_events_url)
-            # mocks for the payload builder
             mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
             mocked.get(self.collection_exercise_url, payload=self.collection_exercise_json)
             mocked.get(self.collection_exercise_events_url, payload=self.collection_exercise_events_json)
             mocked.get(self.sample_attributes_url, payload=self.sample_attributes_json)
-            mocked.get(self.survey_url, payload=self.survey_json)
+
+            response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+            self.assertEqual(response.status, 200)
 
             with self.assertLogs('respondent-home', 'INFO') as logs_home, self.assertLogs('app.eq', 'INFO') as logs_eq:
-                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_address_confirmation, allow_redirects=False,
+                                                     data=self.address_confirmation_data)
             self.assertLogLine(logs_home, 'Redirecting to eQ')
 
         self.assertEqual(response.status, 302)
@@ -163,20 +169,20 @@ class TestHandlers(RHTestCase):
     @unittest_run_loop
     async def test_post_index_build_closed_ce(self):
         with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            # mocks for initial data setup in post
             mocked.get(self.iac_url, payload=self.iac_json)
             mocked.get(self.case_url, payload=self.case_json)
             mocked.post(self.case_events_url)
-            # mocks for the payload builder
             mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
             mocked.get(self.collection_exercise_url, payload=self.collection_exercise_json)
             mocked.get(self.collection_exercise_events_url, payload=self.closed_ce_events_json)
             mocked.get(self.sample_attributes_url, payload=self.sample_attributes_json)
-            mocked.get(self.survey_url, payload=self.survey_json)
+
+            response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+            self.assertEqual(response.status, 200)
 
             with self.assertLogs('respondent-home', 'INFO') as logs_home:
-                response = await self.client.request("POST", self.post_index, allow_redirects=False,
-                                                     data=self.form_data)
+                response = await self.client.request("POST", self.post_address_confirmation, allow_redirects=False,
+                                                     data=self.address_confirmation_data)
             self.assertLogLine(logs_home,
                                'Attempt to access collection exercise that has already ended',
                                collex_id=self.collection_exercise_id)
@@ -188,14 +194,17 @@ class TestHandlers(RHTestCase):
     @unittest_run_loop
     async def test_post_index_build_raises_InvalidEqPayLoad(self):
         with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            # mocks for initial data setup in post
             mocked.get(self.iac_url, payload=self.iac_json)
             mocked.get(self.case_url, payload=self.case_json)
-            mocked.post(self.case_events_url)
+            mocked.get(self.sample_attributes_url, payload=self.sample_attributes_json)
+
+            response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+            self.assertEqual(response.status, 200)
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
                 # decorator makes URL constructor raise InvalidEqPayLoad when build() is called in handler
-                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_address_confirmation, allow_redirects=False,
+                                                     data=self.address_confirmation_data)
             self.assertLogLine(cm, "Service failed to build eQ payload")
 
         # then error handler catches exception and renders error.html
@@ -205,15 +214,17 @@ class TestHandlers(RHTestCase):
     @unittest_run_loop
     async def test_post_index_with_build_ci_500(self):
         with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            # mocks for initial data setup in post
             mocked.get(self.iac_url, payload=self.iac_json)
             mocked.get(self.case_url, payload=self.case_json)
-            mocked.post(self.case_events_url)
-            # mocks for the payload builder
+            mocked.get(self.sample_attributes_url, payload=self.sample_attributes_json)
             mocked.get(self.collection_instrument_url, status=500)
 
+            response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+            self.assertEqual(response.status, 200)
+
             with self.assertLogs('app.eq', 'ERROR') as cm:
-                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_address_confirmation, allow_redirects=False,
+                                                     data=self.address_confirmation_data)
             self.assertLogLine(cm, "Error in response", status_code=500)
 
         self.assertEqual(response.status, 500)
@@ -222,15 +233,17 @@ class TestHandlers(RHTestCase):
     @unittest_run_loop
     async def test_post_index_with_build_ci_400(self):
         with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            # mocks for initial data setup in post
             mocked.get(self.iac_url, payload=self.iac_json)
             mocked.get(self.case_url, payload=self.case_json)
-            mocked.post(self.case_events_url)
-            # mocks for the payload builder
+            mocked.get(self.sample_attributes_url, payload=self.sample_attributes_json)
             mocked.get(self.collection_instrument_url, status=400)
 
+            response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+            self.assertEqual(response.status, 200)
+
             with self.assertLogs('app.eq', 'ERROR') as cm:
-                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_address_confirmation, allow_redirects=False,
+                                                     data=self.address_confirmation_data)
             self.assertLogLine(cm, "Error in response", status_code=400)
 
         self.assertEqual(response.status, 500)
@@ -239,16 +252,18 @@ class TestHandlers(RHTestCase):
     @unittest_run_loop
     async def test_post_index_with_build_ce_503(self):
         with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            # mocks for initial data setup in post
             mocked.get(self.iac_url, payload=self.iac_json)
             mocked.get(self.case_url, payload=self.case_json)
-            mocked.post(self.case_events_url)
-            # mocks for the payload builder
+            mocked.get(self.sample_attributes_url, payload=self.sample_attributes_json)
             mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
             mocked.get(self.collection_exercise_url, status=503)
 
+            response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+            self.assertEqual(response.status, 200)
+
             with self.assertLogs('app.eq', 'ERROR') as cm:
-                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_address_confirmation, allow_redirects=False,
+                                                     data=self.address_confirmation_data)
             self.assertLogLine(cm, "Error in response", status_code=503)
 
         self.assertEqual(response.status, 500)
@@ -257,17 +272,19 @@ class TestHandlers(RHTestCase):
     @unittest_run_loop
     async def test_post_index_with_build_events_404(self):
         with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            # mocks for initial data setup in post
             mocked.get(self.iac_url, payload=self.iac_json)
             mocked.get(self.case_url, payload=self.case_json)
-            mocked.post(self.case_events_url)
-            # mocks for the payload builder
+            mocked.get(self.sample_attributes_url, payload=self.sample_attributes_json)
             mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
             mocked.get(self.collection_exercise_url, payload=self.collection_exercise_json)
             mocked.get(self.collection_exercise_events_url, status=404)
 
+            response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+            self.assertEqual(response.status, 200)
+
             with self.assertLogs('app.eq', 'ERROR') as cm:
-                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_address_confirmation, allow_redirects=False,
+                                                     data=self.address_confirmation_data)
             self.assertLogLine(cm, "Error in response", status_code=404)
 
         self.assertEqual(response.status, 500)
@@ -291,19 +308,20 @@ class TestHandlers(RHTestCase):
     @unittest_run_loop
     async def test_post_index_with_build_case_event_500(self):
         with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            # mocks for initial data setup in post
             mocked.get(self.iac_url, payload=self.iac_json)
             mocked.get(self.case_url, payload=self.case_json)
-            # mocks for the payload builder
+            mocked.get(self.sample_attributes_url, payload=self.sample_attributes_json)
             mocked.get(self.collection_instrument_url, payload=self.collection_instrument_json)
             mocked.get(self.collection_exercise_url, payload=self.collection_exercise_json)
             mocked.get(self.collection_exercise_events_url, payload=self.collection_exercise_events_json)
-            mocked.get(self.sample_attributes_url, payload=self.sample_attributes_json)
-            mocked.get(self.survey_url, payload=self.survey_json)
+
             mocked.post(self.case_events_url, status=500)
+            response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+            self.assertEqual(response.status, 200)
 
             with self.assertLogs('app.case', 'ERROR') as cm:
-                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
+                response = await self.client.request("POST", self.post_address_confirmation, allow_redirects=False,
+                                                     data=self.address_confirmation_data)
             self.assertLogLine(cm, "Error posting case event", status_code=500, case_id=self.case_id)
 
         self.assertEqual(response.status, 500)
@@ -324,37 +342,6 @@ class TestHandlers(RHTestCase):
         self.assertEqual(response.status, 200)
         self.assertMessagePanel(BAD_RESPONSE_MSG, str(await response.content.read()))
 
-    @unittest_run_loop
-    async def test_post_index_sampleUnitType_missing(self):
-        case_json = self.case_json.copy()
-        del case_json['sampleUnitType']
-
-        with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            mocked.get(self.iac_url, payload=self.iac_json)
-            mocked.get(self.case_url, payload=case_json)
-
-            with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
-            self.assertLogLine(cm, 'sampleUnitType missing from case response')
-
-        self.assertEqual(response.status, 200)
-        self.assertMessagePanel(BAD_RESPONSE_MSG, str(await response.content.read()))
-
-    @unittest_run_loop
-    async def test_post_index_sampleUnitType_B_error(self):
-        case_json = self.case_json.copy()
-        case_json['sampleUnitType'] = 'B'
-
-        with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            mocked.get(self.iac_url, payload=self.iac_json)
-            mocked.get(self.case_url, payload=case_json)
-
-            with self.assertLogs('respondent-home', 'WARN') as cm:
-                response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
-            self.assertLogLine(cm, 'Attempt to use unexpected sample unit type', sample_unit_type='B')
-
-        self.assertEqual(response.status, 200)
-        self.assertMessagePanel(BAD_CODE_TYPE_MSG, str(await response.content.read()))
 
     @unittest_run_loop
     async def test_post_index_malformed(self):


### PR DESCRIPTION
# Motivation and Context
Fix unit tests broken by adding address-confirmation page to respondent home application.

# What has changed
The addition of an address-confirmation and address-edit page required a small degree of restructuring to the code which broke some unit tests. This PR fixes the original unit tests to reflect the changes.  

# How to test?
Run 'make test'. 

# Links
In looking into the warnings created running the unit tests the work identified  [technical debt](https://github.com/ONSdigital/respondent-home-ui/issues/85) removing use of a deprecated approach for routing in the aiohttp framework. 