### PR TITLE
CDTT-960 Logging Sensitive Data

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -111,8 +111,6 @@ class EqPayloadConstructor(object):
         except KeyError:
             raise InvalidEqPayLoad(f"Could not retrieve sample unit ref for case {self._case_id}")
 
-        logger.info("Creating payload for JWT", case_id=self._case_id, tx_id=self._tx_id)
-
         try:
             self._ci_id = case["collectionInstrumentId"]
         except KeyError:
@@ -175,6 +173,8 @@ class EqPayloadConstructor(object):
 
         response_id = build_response_id(self._case_id, self._collex_id, self._iac)
 
+        logger.debug("Creating payload for JWT", case_id=self._case_id, tx_id=self._tx_id)
+
         # TODO: Remove hardcoded language variables for payload when they become available in RAS/RM
         self._language_code = 'en'  # sample attributes do not currently have language details
 
@@ -211,8 +211,6 @@ class EqPayloadConstructor(object):
             [(key, value) for key, value in self._collex_event_dates.items() if value is not None]
         )
 
-        logger.info(payload=self._payload)
-
         return self._payload
 
     @staticmethod
@@ -241,7 +239,7 @@ class EqPayloadConstructor(object):
 
     async def _make_request(self, request: Request):
         method, url, auth, func = request
-        logger.info(f"Making {method} request to {url} and handling with {func.__name__}")
+        logger.debug(f"Making {method} request to {url} and handling with {func.__name__}")
         async with self._app.http_session_pool.request(method, url, auth=auth) as resp:
             func(resp)
             return await resp.json()

--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -45,12 +45,12 @@ def create_error_middleware(overrides):
 
 
 async def inactive_case(request):
-    logger.info("Attempt to use an inactive access code")
+    logger.warn("Attempt to use an inactive access code")
     return aiohttp_jinja2.render_template("completed.html", request, {})
 
 
 async def ce_closed(request, collex_id):
-    logger.info("Attempt to access collection exercise that has already ended", collex_id=collex_id)
+    logger.warn("Attempt to access collection exercise that has already ended", collex_id=collex_id)
     return aiohttp_jinja2.render_template("closed.html", request, {})
 
 

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -57,7 +57,7 @@ class View:
         description = f"Census Instrument launched for case {case['id']}"
         await post_case_event(case['id'], 'EQ_LAUNCH', description, app)
 
-        logger.info('Redirecting to eQ', client_ip=self._client_ip)
+        logger.debug('Redirecting to eQ', client_ip=self._client_ip)
         raise HTTPFound(f"{app['EQ_URL']}/session?token={token}")
 
 
@@ -100,7 +100,7 @@ class Index(View):
                     if resp.status == 404:
                         raise InvalidIACError
                     elif resp.status in (401, 403):
-                        logger.info("Unauthorized access to IAC service attempted", client_ip=self._client_ip)
+                        logger.warn("Unauthorized access to IAC service attempted", client_ip=self._client_ip)
                         flash(self._request, NOT_AUTHORIZED_MSG)
                         return self.redirect()
                     elif 400 <= resp.status < 500:
@@ -144,7 +144,7 @@ class Index(View):
         try:
             iac_json = await self.get_iac_details()
         except InvalidIACError:
-            logger.info("Attempt to use an invalid access code", client_ip=self._client_ip)
+            logger.warn("Attempt to use an invalid access code", client_ip=self._client_ip)
             flash(self._request, INVALID_CODE_MSG)
             return aiohttp_jinja2.render_template("index.html", self._request, {}, status=202)
 

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -84,10 +84,10 @@ class TestEq(RHTestCase):
                 mocked.get(self.collection_exercise_url, payload=self.collection_exercise_json)
                 mocked.get(self.collection_exercise_events_url, payload=self.collection_exercise_events_json)
 
-                with self.assertLogs('app.eq', 'INFO') as cm:
+                with self.assertLogs('app.eq', 'DEBUG') as cm:
                     payload = await EqPayloadConstructor(
                         self.case_json, self.sample_unit_attributes, self.app, self.iac_code).build()
-                self.assertLogLine(cm, '', payload=payload)
+                self.assertLogLine(cm, 'Creating payload for JWT', case_id=self.case_id, tx_id=self.jti)
 
         mocked_uuid4.assert_called()
         mocked_time.assert_called()

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -7,7 +7,7 @@ from aiohttp.test_utils import unittest_run_loop
 from aioresponses import aioresponses
 
 from app import (
-    BAD_CODE_MSG, BAD_CODE_TYPE_MSG, BAD_RESPONSE_MSG, INVALID_CODE_MSG, NOT_AUTHORIZED_MSG)
+    BAD_CODE_MSG, BAD_RESPONSE_MSG, INVALID_CODE_MSG, NOT_AUTHORIZED_MSG)
 from app.exceptions import InactiveCaseError
 from app.handlers import Index
 
@@ -149,7 +149,7 @@ class TestHandlers(RHTestCase):
             response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 200)
 
-            with self.assertLogs('respondent-home', 'INFO') as logs_home, self.assertLogs('app.eq', 'INFO') as logs_eq:
+            with self.assertLogs('respondent-home', 'DEBUG') as logs_home:
                 response = await self.client.request("POST", self.post_address_confirmation, allow_redirects=False,
                                                      data=self.address_confirmation_data)
             self.assertLogLine(logs_home, 'Redirecting to eQ')
@@ -159,7 +159,6 @@ class TestHandlers(RHTestCase):
         self.assertTrue(redirected_url.startswith(self.app['EQ_URL']), redirected_url)  # outputs url on fail
         _, _, _, query, *_ = urlsplit(redirected_url)  # we only care about the query string
         token = json.loads(parse_qs(query)['token'][0])  # convert token to dict
-        self.assertLogLine(logs_eq, '', payload=token)  # make sure the payload is logged somewhere
         self.assertEqual(self.eq_payload.keys(), token.keys())  # fail early if payload keys differ
         for key in self.eq_payload.keys():
             if key in ['jti', 'tx_id', 'iat', 'exp']:


### PR DESCRIPTION
# Motivation and Context
The application was logging the entire payload of the JWT sent to EQ.  This was a security risk with potentially sensitive data being logged with the associated address, if included in the payload. This logging was removed.  

# What has changed
Minor changes. Logging of JWT payload removed, inspection of logged data to ensure no sensitive data logged. Review of log levels, particularly INFO to avoid clutter in production logs and highlight WARN or ERROR. 

# How to test?
Run unit tests. Check logging when running application.
