### PR TITLE
Execute Respondent Home under a dedicated non-root user account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,8 @@ WORKDIR /app
 COPY . /app
 EXPOSE 9092
 RUN pip3 install pipenv && pipenv install --deploy --system
-
-CMD ["python3", "run.py"]
+RUN groupadd -g 984 respondenthome && \
+    useradd -r -u 984 -g respondenthome respondenthome
+USER respondenthome
+ENTRYPOINT ["python3"]
+CMD ["run.py"]


### PR DESCRIPTION
# Motivation and Context
The principle of using least privilege should be followed when executing code within containers. Specifically, not running as root.

# What has changed
The Dockerfile has been changed:

* Create a dedicated non-root user account for executing the Python code
* Set `python3` as the `ENTRYPOINT` to match the RM Python microservices

# How to test?
I tested this change by creating a differently tagged Docker image and deploying to my Kubernetes cluster. I verified that:

* The pod started successfully
* The Kubernetes readiness and liveness probes succeeded
* There were no errors in the container logs
* `exec`-ing into the container showed the Python process running as the expected non-root user account