### PR TITLE
Cr 115 message for uac auth failure

### DIFF
--- a/app/templates/partials/messages.html
+++ b/app/templates/partials/messages.html
@@ -26,19 +26,21 @@
             {% endif %}
           </li>
         </ul>
-      </div>
+
       {% endfor %}
-      Or please call for advice on one of these numbers:
-      <ul class="list list--bare">
-        <li>England 0800 141 2021
-        </li>
-        <li>Wales 0800 169 2021
-        </li>
-        <li>Northern Ireland 0800 328 2021
-        </li>
-        <li>Language 0800 587 2021
-        </li>
-    </ul>
+        <p></p>
+        Or please call for advice on one of these numbers:
+        <ul class="list list--bare">
+          <li>  0800 141 2021  England
+          </li>
+          <li>  0800 169 2021  Wales
+          </li>
+          <li>  0800 328 2021  Northern Ireland
+          </li>
+          <li>  0800 587 2021  Language
+          </li>
+        </ul>
+        </div>
     </div>
 
     {% elif group=='INFO' %}

--- a/app/templates/partials/messages.html
+++ b/app/templates/partials/messages.html
@@ -27,20 +27,23 @@
           </li>
         </ul>
 
+        {% if message.type !='ADDRESS_CONFIRMATION_ERROR' %}
+          <p></p>
+          Or please call for advice on one of these numbers:
+          <ul class="list list--bare">
+            <li>  0800 141 2021  England
+            </li>
+            <li>  0800 169 2021  Wales
+            </li>
+            <li>  0800 328 2021  Northern Ireland
+            </li>
+            <li>  0800 587 2021  Language
+            </li>
+          </ul>
+        {% endif %}
+      </div>
+
       {% endfor %}
-        <p></p>
-        Or please call for advice on one of these numbers:
-        <ul class="list list--bare">
-          <li>  0800 141 2021  England
-          </li>
-          <li>  0800 169 2021  Wales
-          </li>
-          <li>  0800 328 2021  Northern Ireland
-          </li>
-          <li>  0800 587 2021  Language
-          </li>
-        </ul>
-        </div>
     </div>
 
     {% elif group=='INFO' %}

--- a/app/templates/partials/messages.html
+++ b/app/templates/partials/messages.html
@@ -18,7 +18,9 @@
         <ul class="list list--bare">
           <li class="list__item mars">
             {% if message.clickable %}
-              {{loop.index}}) <a class="js-inpagelink" href="#access-code-answer">{{ message.text }}</a>
+              {{loop.index}}) <a class="js-inpagelink" href="#access-code-answer">
+                                {{ message.text }}
+                              </a>
             {% else %}
               {{ message.text }}
             {% endif %}
@@ -26,6 +28,17 @@
         </ul>
       </div>
       {% endfor %}
+      Or please call for advice on one of these numbers:
+      <ul class="list list--bare">
+        <li>England 0800 141 2021
+        </li>
+        <li>Wales 0800 169 2021
+        </li>
+        <li>Northern Ireland 0800 328 2021
+        </li>
+        <li>Language 0800 587 2021
+        </li>
+    </ul>
     </div>
 
     {% elif group=='INFO' %}

--- a/app/templates/partials/messages.html
+++ b/app/templates/partials/messages.html
@@ -31,13 +31,13 @@
           <p></p>
           Or please call for advice on one of these numbers:
           <ul class="list list--bare">
-            <li>  0800 141 2021  England
+            <li>  0800 141 2021   England
             </li>
-            <li>  0800 169 2021  Wales
+            <li>  0800 169 2021   Wales
             </li>
-            <li>  0800 328 2021  Northern Ireland
+            <li>  0800 328 2021   Northern Ireland
             </li>
-            <li>  0800 587 2021  Language
+            <li>  0800 587 2021   Translation
             </li>
           </ul>
         {% endif %}


### PR DESCRIPTION
# Motivation and Context
As a Respondent I want to the view contact centre information on UAC authentication failure So that I can contact a CC agent. 

# What has changed
The messages.html has been changed to give phone numbers, after error messages, where applicable. The numbers are as follows:

England 
0800 141 2021

Wales 
0800 169 2021

Northern Ireland 
0800 328 2021

Translation 
0800 587 2021 

# How to test?
Run census-rh-ui locally and check that any error messages will show the phone numbers underneath (with the exception of the address confirmation error, which occurs when a user tries to move away from that screen without selecting a bullet point) 

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-115 

