### PR TITLE
Made switch

### DIFF
--- a/app/handlers.py
+++ b/app/handlers.py
@@ -64,7 +64,7 @@ class View:
         raise HTTPFound(f"{app['EQ_URL']}/session?token={token}")
 
 
-@routes.view('/')
+@routes.view('/start/')
 class Index(View):
 
     def __init__(self):
@@ -172,7 +172,7 @@ class Index(View):
         return aiohttp_jinja2.render_template("address-confirmation.html", self._request, attributes)
 
 
-@routes.view('/address-confirmation')
+@routes.view('/start/address-confirmation')
 class AddressConfirmation(View):
 
     @aiohttp_jinja2.template('address-confirmation.html')
@@ -214,7 +214,7 @@ class AddressConfirmation(View):
             return attributes
 
 
-@routes.view('/address-edit')
+@routes.view('/start/address-edit')
 class AddressEdit(View):
 
     def get_address_details(self, data: dict, attributes: dict):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -67,8 +67,8 @@ class TestCreateAppURLPathPrefix(TestCase):
         app = create_app(self.config)
         self.assertEqual(app['URL_PATH_PREFIX'], url_prefix)
 
-        self.assertEqual(app.router['Index:get'].canonical, '/url-path-prefix/')
-        self.assertEqual(app.router['Index:post'].canonical, '/url-path-prefix/')
+        self.assertEqual(app.router['Index:get'].canonical, '/url-path-prefix/start/')
+        self.assertEqual(app.router['Index:post'].canonical, '/url-path-prefix/start/')
         self.assertEqual(app.router['Info:get'].canonical, '/info')
 
     def test_create_app_without_url_path_prefix(self):
@@ -79,8 +79,8 @@ class TestCreateAppURLPathPrefix(TestCase):
         app = create_app(self.config)
         self.assertEqual(app['URL_PATH_PREFIX'], '')
 
-        self.assertEqual(app.router['Index:get'].canonical, '/')
-        self.assertEqual(app.router['Index:post'].canonical, '/')
+        self.assertEqual(app.router['Index:get'].canonical, '/start/')
+        self.assertEqual(app.router['Index:post'].canonical, '/start/')
         self.assertEqual(app.router['Info:get'].canonical, '/info')
 
 


### PR DESCRIPTION
Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Change to shift the starting url of RHUI to '/start' (from '/') to prevent conflicts when site served as part of final website.

# What has changed
Routes for Index, address confirmation and address edit have all been updated to include '/start' at the front of their 'urls' in 'handlers.py'
No refactoring required.
Only required updates to existing tests to include /start
Note that going directly to service root ('/') will now result in a 404 when run locally.

# How to test?
Tests as usual via make test, or manually running.
Visual check of resulting web pages in local version.

# Links
None

# Screenshots (if appropriate):
None