### PR TITLE
Cr 267 aiohttp session bug

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -52,7 +52,7 @@ class BaseConfig:
 
     REDIS_PORT = env("REDIS_PORT", default="7379")
 
-    ABSOLUTE_SESSION_AGE = env("ABSOLUTE_SESSION_AGE", default="600")
+    SESSION_AGE = env("SESSION_AGE", default="600")
 
 
 class ProductionConfig(BaseConfig):
@@ -80,7 +80,7 @@ class DevelopmentConfig:
 
     REDIS_PORT = env("REDIS_PORT", default="7379")
 
-    ABSOLUTE_SESSION_AGE = env("ABSOLUTE_SESSION_AGE", default="600")
+    SESSION_AGE = env("SESSION_AGE", default="600")
 
 
 class TestingConfig:
@@ -103,4 +103,4 @@ class TestingConfig:
 
     REDIS_PORT = ""
 
-    ABSOLUTE_SESSION_AGE = ""
+    SESSION_AGE = ""

--- a/app/session.py
+++ b/app/session.py
@@ -1,16 +1,45 @@
 import logging
+import time
 
 from asyncio import get_event_loop
 from aioredis import create_pool, RedisError
-from aiohttp_session import session_middleware
+from aiohttp_session import session_middleware, Session
 from aiohttp_session.redis_storage import RedisStorage
 from structlog import wrap_logger
 
 
 logger = wrap_logger(logging.getLogger("respondent-home"))
 
+# Please see https://github.com/aio-libs/aiohttp-session/issues/344
+# Anomalous behaviour can arise where you have a valid session cookie from the client as if a session was created by
+# a previous request but cannot retrieve the session data in Redis, although the data will be in Redis. This behaviour
+# was introduced with Pull Request: https://github.com/aio-libs/aiohttp-session/pull/331
+# Monkey patch aiohttp_session Session.__init__ method to remove suspect behaviour.
+
+
+def aiohttp_session_pr_331_rollback(self, identity, *, data, new, max_age=None):
+    self._changed = False
+    self._mapping = {}
+    self._identity = identity if data != {} else None
+    self._new = new
+    self._new = new if data != {} else True
+    self._max_age = max_age
+    created = data.get('created', None) if data else None
+    session_data = data.get('session', None) if data else None
+
+    if self._new or created is None:
+        self._created = int(time.time())
+    else:
+        self._created = created
+
+    if session_data is not None:
+        self._mapping.update(session_data)
+
 
 def setup(app_config):
+    # Monkey patch aiohttp_session.py Session.__init__ method to remove PR 331 as above
+    Session.__init__ = aiohttp_session_pr_331_rollback
+
     loop = get_event_loop()
     redis_pool = loop.run_until_complete(make_redis_pool(app_config["REDIS_SERVER"], app_config["REDIS_PORT"]))
     return session_middleware(RedisStorage(redis_pool, cookie_name='RH_SESSION',

--- a/app/session.py
+++ b/app/session.py
@@ -43,7 +43,7 @@ def setup(app_config):
     loop = get_event_loop()
     redis_pool = loop.run_until_complete(make_redis_pool(app_config["REDIS_SERVER"], app_config["REDIS_PORT"]))
     return session_middleware(RedisStorage(redis_pool, cookie_name='RH_SESSION',
-                                           max_age=int(app_config["ABSOLUTE_SESSION_AGE"])))
+                                           max_age=int(app_config["SESSION_AGE"])))
 
 
 async def make_redis_pool(host, port):

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -148,7 +148,7 @@ class RHTestCase(AioHTTPTestCase):
     def session_storage(self, app_config):
         self.assertIn("REDIS_SERVER", app_config)
         self.assertIn("REDIS_PORT", app_config)
-        self.assertIn("ABSOLUTE_SESSION_AGE", app_config)
+        self.assertIn("SESSION_AGE", app_config)
         return session_middleware(SimpleCookieStorage(cookie_name='RH_SESSION'))
 
     async def get_application(self):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -20,7 +20,7 @@ class TestCreateApp(AioHTTPTestCase):
     def session_storage(self, app_config):
         self.assertIn("REDIS_SERVER", app_config)
         self.assertIn("REDIS_PORT", app_config)
-        self.assertIn("ABSOLUTE_SESSION_AGE", app_config)
+        self.assertIn("SESSION_AGE", app_config)
         return session_middleware(SimpleCookieStorage(cookie_name='RH_SESSION'))
 
     async def get_application(self):


### PR DESCRIPTION
# Motivation and Context
As recorded [here](https://github.com/aio-libs/aiohttp-session/issues/344) there is an issue with aiohttp-session which leads to what has been termed at the top of the link a _magic session_. We use Redis as the store for session data, only passing a key back to the browser in a cookie. To ensure orphaned session data is not left accumulating in Redis by any unusual client behaviour the max-age parameter is used.

It appears the max-age parameter was used as an idle time-out for the session cookie and redis data. The redis_storage.save_session method calls save_cookie which sets the max-age and recalculates expires on the cookie sent back to the browser. Redis_storage.save_session also resets the expire time of the data in Redis. 

This [behaviour was queried](https://github.com/aio-libs/aiohttp-session/issues/332) as not being reflective of what was understood by setting max-age. The response seems to have been to [prompt this Pull Request](https://github.com/aio-libs/aiohttp-session/pull/331). This refactors the aiohttp_session.__init__py Session class constructor to set the session data to None if a period greater than max-age has passed since the session has been created. The session cookie can still be valid, the data still in Redis with these aspects acting like an idle timeout, but the session data _magically_ disappears when the client returns and the Session object is created.

# What has changed
In Session.py setup function where RedisStorage is returned as session middleware I have monkey patched the Session class constructor to remove the change introduced by PR 331 above so the Session does not act in an anamolous inconsistent way. 

# How to test?
Can be tested as described in the JIRA ticket:

- Adjust the SESSION_AGE in the application configuration to a period like a minute e.g. 60 and run the application

- Enter valid UAC, this will create and store the UAC data in the session.

- Wait for a few seconds e.g. 20, then enter the URL or use the browser back arrow to go back to the UAC entry page.

- Enter the UAC again, this will have the original session cookie as long as the session timeout has not been exceeded. The session will be updated with the UAC data again.

- On the page "Is your address correct" click the radio button "Yes, this address is correct".

- Submit by clicking the "Save and continue" button only after the session expiry time, but prior to the sum of the session expiry time and wait in the second step above.

- Rather than forwarding to EQ the UI would return to the normal UAC access code page to renter the UAC. Now it should correctly go to EQ.

To expire the session and get a session expiry message:

- Enter valid UAC, this will create and store the UAC data in the session.

- On the page "Is your address correct" click the radio button "Yes, this address is correct".

- Submit by clicking the "Save and continue" button only after the session expiry time, the application should return to the UAC entry page with an error message that the session has expired. 

# Note
The aiohttp-session RedisStorage max-age parameter does not act as a true idle timeout. It only resets the cookie and redis expiry if the session data is updated, if the client moves around pages but the session data is not touched the session will time out in max-age.