### PR TITLE
Implement new value for survey in eq launch request

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -85,8 +85,8 @@ class EqPayloadConstructor(object):
             "questionnaire_id": self._questionnaire_id,
             "eq_id": "census",  # for 19.9 hardcoded as will not be needed for new payload but still needed for original
             "period_id": "1",  # for 19.9 hardcoded as will not be needed for new payload but still needed for original
-            "form_type": "individual_gb_eng"  # for 19.9 hardcoded as will not be needed for new payload but still needed for original
-
+            "form_type": "individual_gb_eng",  # for 19.9 hardcoded as will not be needed for new payload but still needed for original
+            "survey": "CENSUS"  # hardcoded for census
         }
 
         return self._payload

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -219,6 +219,7 @@ class RHTestCase(AioHTTPTestCase):
         self.case_id = self.uac_json['caseId']
         self.collection_exercise_id = self.uac_json['collectionExerciseId']
         self.eq_id = "census"
+        self.survey = "CENSUS"
         self.form_type = "individual_gb_eng"
         self.jti = str(uuid.uuid4())
         self.uac_code = ''.join([str(n) for n in range(13)])
@@ -250,7 +251,8 @@ class RHTestCase(AioHTTPTestCase):
             "questionnaire_id": self.questionnaire_id,
             "eq_id": self.eq_id,
             "period_id": self.period_id,
-            "form_type": self.form_type
+            "form_type": self.form_type,
+            "survey": self.survey
  }
 
         self.rhsvc_url = (


### PR DESCRIPTION
Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Update to provide EQ with required field and hardcoded value for 'survey'

# What has changed
Addition of hard-coded survey field and value

# How to test?
Updated existing tests

# Links

# Screenshots (if appropriate):