### PR TITLE
Code update and additional unit tests to regex the uac submission

### DIFF
--- a/app/handlers.py
+++ b/app/handlers.py
@@ -138,7 +138,9 @@ class Index(View):
         else:
             combined = ''
 
-        if len(combined) < expected_length:
+        uac_validation_pattern = re.compile(r'^[a-z0-9]{16}$')
+
+        if (len(combined) < expected_length) or not (uac_validation_pattern.fullmatch(combined)):
             raise TypeError
         return combined
 

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -85,16 +85,13 @@ class TestHandlers(RHTestCase):
         self.assertIn('Sorry, something went wrong', str(await response.content.read()))
 
     @unittest_run_loop
-    async def test_post_index_blank(self):
+    async def test_post_index_invalid_blank(self):
         form_data = self.form_data.copy()
         del form_data['uac']
 
-        with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            mocked.get(self.rhsvc_url, payload=self.uac_json)
-
-            with self.assertLogs('respondent-home', 'WARNING') as cm:
-                response = await self.client.request("POST", self.post_index, data=form_data)
-            self.assertLogLine(cm, "Attempt to use a malformed access code")
+        with self.assertLogs('respondent-home', 'WARNING') as cm:
+            response = await self.client.request("POST", self.post_index, data=form_data)
+        self.assertLogLine(cm, "Attempt to use a malformed access code")
 
         self.assertEqual(response.status, 200)
         self.assertMessagePanel(BAD_CODE_MSG, str(await response.content.read()))
@@ -104,12 +101,9 @@ class TestHandlers(RHTestCase):
         form_data = self.form_data.copy()
         form_data['uac'] = 'http://www.census.gov.uk/'
 
-        with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            mocked.get(self.rhsvc_url, payload=self.uac_json)
-
-            with self.assertLogs('respondent-home', 'WARNING') as cm:
-                response = await self.client.request("POST", self.post_index, data=form_data)
-            self.assertLogLine(cm, "Attempt to use a malformed access code")
+        with self.assertLogs('respondent-home', 'WARNING') as cm:
+            response = await self.client.request("POST", self.post_index, data=form_data)
+        self.assertLogLine(cm, "Attempt to use a malformed access code")
 
         self.assertEqual(response.status, 200)
         self.assertMessagePanel(BAD_CODE_MSG, str(await response.content.read()))
@@ -119,12 +113,9 @@ class TestHandlers(RHTestCase):
         form_data = self.form_data.copy()
         form_data['uac'] = 'rT~l34u8{?nm4£#f'
 
-        with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            mocked.get(self.rhsvc_url, payload=self.uac_json)
-
-            with self.assertLogs('respondent-home', 'WARNING') as cm:
-                response = await self.client.request("POST", self.post_index, data=form_data)
-            self.assertLogLine(cm, "Attempt to use a malformed access code")
+        with self.assertLogs('respondent-home', 'WARNING') as cm:
+            response = await self.client.request("POST", self.post_index, data=form_data)
+        self.assertLogLine(cm, "Attempt to use a malformed access code")
 
         self.assertEqual(response.status, 200)
         self.assertMessagePanel(BAD_CODE_MSG, str(await response.content.read()))

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -85,9 +85,39 @@ class TestHandlers(RHTestCase):
         self.assertIn('Sorry, something went wrong', str(await response.content.read()))
 
     @unittest_run_loop
-    async def test_post_index_malformed(self):
+    async def test_post_index_blank(self):
         form_data = self.form_data.copy()
         del form_data['uac']
+
+        with aioresponses(passthrough=[str(self.server._root)]) as mocked:
+            mocked.get(self.rhsvc_url, payload=self.uac_json)
+
+            with self.assertLogs('respondent-home', 'WARNING') as cm:
+                response = await self.client.request("POST", self.post_index, data=form_data)
+            self.assertLogLine(cm, "Attempt to use a malformed access code")
+
+        self.assertEqual(response.status, 200)
+        self.assertMessagePanel(BAD_CODE_MSG, str(await response.content.read()))
+
+    @unittest_run_loop
+    async def test_post_index_invalid_text_url(self):
+        form_data = self.form_data.copy()
+        form_data['uac'] = 'http://www.census.gov.uk/'
+
+        with aioresponses(passthrough=[str(self.server._root)]) as mocked:
+            mocked.get(self.rhsvc_url, payload=self.uac_json)
+
+            with self.assertLogs('respondent-home', 'WARNING') as cm:
+                response = await self.client.request("POST", self.post_index, data=form_data)
+            self.assertLogLine(cm, "Attempt to use a malformed access code")
+
+        self.assertEqual(response.status, 200)
+        self.assertMessagePanel(BAD_CODE_MSG, str(await response.content.read()))
+
+    @unittest_run_loop
+    async def test_post_index_invalid_text_random(self):
+        form_data = self.form_data.copy()
+        form_data['uac'] = 'rT~l34u8{?nm4£#f'
 
         with aioresponses(passthrough=[str(self.server._root)]) as mocked:
             mocked.get(self.rhsvc_url, payload=self.uac_json)


### PR DESCRIPTION
Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Change to check submitted UAC is in appropriate format

# What has changed
Addition of regex in UAC validation, and matching tests

# How to test?
1 modified and 2 new unit tests added to check for blank and invalid values

# Links
None

# Screenshots (if appropriate):
None