### PR TITLE
CR-432 Security enhancements

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,3 +16,4 @@ MOBILE_ENTER_MSG = {'text': 'Enter a valid UK mobile number to continue', "level
 MOBILE_CHECK_MSG = {'text': 'Please check and confirm your mobile number.', "level": "ERROR", "type": "MOBILE_CONFIRMATION_ERROR", "field": "mobile"}  # NOQA
 POSTCODE_INVALID_MSG = {'text': 'Enter a valid UK postcode to continue', "level": "ERROR", "type": "POSTCODE_ENTER_ERROR", "field": "postcode"}  # NOQA
 ADDRESS_SELECT_CHECK_MSG = {'text': 'Select an address', "level": "ERROR", "type": "ADDRESS_SELECT_CHECK_MSG", "field": "address-select"}  # NOQA
+VALIDATION_FAILURE_MSG = {'text': 'Session timed out or permission denied', "level": "ERROR", "type": "VALIDATION_FAILURE_MSG", "field": "uac"}  # NOQA

--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -26,6 +26,8 @@ def create_error_middleware(overrides):
                 logger.debug('Redirecting to index', path=request.path)
                 raise web.HTTPMovedPermanently(index_resource.url_for())
             return await not_found_error(request)
+        except web.HTTPForbidden:
+            return await forbidden(request)
         except InactiveCaseError:
             return await inactive_case(request)
         except ExerciseClosedError as ex:
@@ -75,6 +77,10 @@ async def response_error(request):
 
 async def not_found_error(request):
     return aiohttp_jinja2.render_template("404.html", request, {}, status=404)
+
+
+async def forbidden(request):
+    return aiohttp_jinja2.render_template("index.html", request, {}, status=403)
 
 
 def setup(app):

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -225,13 +225,14 @@ class AddressConfirmation(View):
 
         return aiohttp_jinja2.render_template("address-confirmation.html", self._request, attributes)
 
+    @aiohttp_jinja2.template('address-confirmation.html')
     async def post(self, request):
         """
         Address Confirmation flow. If correct address will build EQ payload and send to EQ.
         """
         await check_permission(request)
-        data = await request.post()
         self._request = request
+        data = await request.post()
 
         session = await get_session(request)
         try:
@@ -302,6 +303,7 @@ class AddressEdit(View):
 
         return aiohttp_jinja2.render_template("address-edit.html", request, attributes)
 
+    @aiohttp_jinja2.template('address-edit.html')
     async def post(self, request):
         """
         Address Edit flow. Edited address details.

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -19,6 +19,7 @@ from .exceptions import InactiveCaseError
 from .eq import EqPayloadConstructor
 from .flash import flash
 from .exceptions import InvalidEqPayLoad
+from .security import remember, check_permission
 from collections import namedtuple
 
 logger = wrap_logger(logging.getLogger("respondent-home"))
@@ -158,7 +159,6 @@ class Index(View):
     async def get(self, _):
         return {}
 
-    @aiohttp_jinja2.template('index.html')
     async def post(self, request):
         """
         Forward to Address confirmation
@@ -181,9 +181,11 @@ class Index(View):
             if ex.status == 404:
                 logger.warn("Attempt to use an invalid access code", client_ip=self._client_ip)
                 flash(self._request, INVALID_CODE_MSG)
-                return aiohttp_jinja2.render_template("index.html", self._request, {}, status=202)
+                return aiohttp_jinja2.render_template("index.html", self._request, {}, status=401)
             else:
                 raise ex
+
+        await remember(uac_json["caseId"], request)
 
         # TODO: case is active, will need to look at for UACs handed out in field but not associated with address
         self.validate_case(uac_json)
@@ -200,21 +202,37 @@ class Index(View):
         session["attributes"] = attributes
         session["case"] = uac_json
 
-        return aiohttp_jinja2.render_template("address-confirmation.html", self._request, attributes)
+        raise HTTPFound(self._request.app.router['AddressConfirmation:get'].url_for())
 
 
 @routes.view('/start/address-confirmation')
 class AddressConfirmation(View):
 
     @aiohttp_jinja2.template('address-confirmation.html')
+    async def get(self, request):
+        """
+        Address Confirmation get.
+        """
+        await check_permission(request)
+        self._request = request
+
+        session = await get_session(request)
+        try:
+            attributes = session["attributes"]
+        except KeyError:
+            flash(self._request, SESSION_TIMEOUT_MSG)
+            raise HTTPFound(self._request.app.router['Index:get'].url_for())
+
+        return aiohttp_jinja2.render_template("address-confirmation.html", self._request, attributes)
+
     async def post(self, request):
         """
         Address Confirmation flow. If correct address will build EQ payload and send to EQ.
         """
+        await check_permission(request)
         data = await request.post()
         self._request = request
 
-        self.check_session()
         session = await get_session(request)
         try:
             attributes = session["attributes"]
@@ -236,7 +254,7 @@ class AddressConfirmation(View):
             await self.call_questionnaire(case, attributes, request.app)
 
         elif address_confirmation == 'No':
-            return aiohttp_jinja2.render_template("address-edit.html", request, attributes)
+            raise HTTPFound(self._request.app.router['AddressEdit:get'].url_for())
 
         else:
             # catch all just in case, should never get here
@@ -268,14 +286,30 @@ class AddressEdit(View):
         return attributes
 
     @aiohttp_jinja2.template('address-edit.html')
+    async def get(self, request):
+        """
+        Address Edit get.
+        """
+        await check_permission(request)
+        self._request = request
+
+        session = await get_session(request)
+        try:
+            attributes = session["attributes"]
+        except KeyError:
+            flash(self._request, SESSION_TIMEOUT_MSG)
+            raise HTTPFound(self._request.app.router['Index:get'].url_for())
+
+        return aiohttp_jinja2.render_template("address-edit.html", request, attributes)
+
     async def post(self, request):
         """
         Address Edit flow. Edited address details.
         """
+        await check_permission(request)
         data = await request.post()
         self._request = request
 
-        self.check_session()
         session = await get_session(request)
         try:
             attributes = session["attributes"]

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -214,7 +214,10 @@ class RHTestCase(AioHTTPTestCase):
         self.get_index = self.app.router['Index:get'].url_for()
         self.get_info = self.app.router['Info:get'].url_for()
         self.post_index = self.app.router['Index:post'].url_for()
+        self.get_address_confirmation = self.app.router['AddressConfirmation:get'].url_for()
         self.post_address_confirmation = self.app.router['AddressConfirmation:post'].url_for()
+        self.get_address_edit = self.app.router['AddressEdit:get'].url_for()
+        self.post_address_edit = self.app.router['AddressEdit:post'].url_for()
         self.case_id = self.uac_json['caseId']
         self.collection_exercise_id = self.uac_json['collectionExerciseId']
         self.eq_id = "census"

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1,5 +1,6 @@
 import json
 import datetime
+
 from unittest import mock
 from urllib.parse import urlsplit, parse_qs
 
@@ -12,6 +13,7 @@ from app import (
     POSTCODE_INVALID_MSG)
 from app.exceptions import InactiveCaseError, InvalidEqPayLoad
 from app.handlers import Index, WebChat
+
 
 from . import RHTestCase, build_eq_raises, skip_encrypt
 
@@ -34,8 +36,8 @@ class TestHandlers(RHTestCase):
 
             response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
 
-        self.assertEqual(response.status, 200)
-        self.assertIn('Is this address correct', str(await response.content.read()))
+        self.assertEqual(response.status, 302)
+        self.assertIn('/start/address-confirmation', response.headers['Location'])
 
     @skip_encrypt
     @unittest_run_loop
@@ -45,7 +47,8 @@ class TestHandlers(RHTestCase):
             mocked.post(self.rhsvc_url_surveylaunched)
 
             response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
-            self.assertEqual(response.status, 200)
+            self.assertEqual(response.status, 302)
+            self.assertIn('/start/address-confirmation', response.headers['Location'])
 
             with self.assertLogs('respondent-home', 'DEBUG') as logs_home:
                 response = await self.client.request("POST", self.post_address_confirmation, allow_redirects=False,
@@ -72,7 +75,8 @@ class TestHandlers(RHTestCase):
             mocked.post(self.rhsvc_url_surveylaunched)
 
             response = await self.client.request("POST", self.post_index, allow_redirects=False, data=self.form_data)
-            self.assertEqual(response.status, 200)
+            self.assertEqual(response.status, 302)
+            self.assertIn('/start/address-confirmation', response.headers['Location'])
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
                 # decorator makes URL constructor raise InvalidEqPayLoad when build() is called in handler
@@ -189,7 +193,7 @@ class TestHandlers(RHTestCase):
                 response = await self.client.request("POST", self.post_index, data=self.form_data)
             self.assertLogLine(cm, "Attempt to use an invalid access code", client_ip=None)
 
-        self.assertEqual(response.status, 202)
+        self.assertEqual(response.status, 401)
         self.assertMessagePanel(INVALID_CODE_MSG, str(await response.content.read()))
 
     @unittest_run_loop
@@ -582,7 +586,8 @@ class TestHandlers(RHTestCase):
     async def test_post_request_access_code_bad_postcode(self):
 
         with self.assertLogs('respondent-home', 'WARNING') as cm:
-            response = await self.client.request("POST", self.post_requestcode, data=self.request_code_form_data_invalid)
+            response = await self.client.request("POST", self.post_requestcode,
+                                                 data=self.request_code_form_data_invalid)
         self.assertLogLine(cm, "Attempt to use an invalid postcode")
 
         self.assertEqual(response.status, 200)
@@ -594,7 +599,8 @@ class TestHandlers(RHTestCase):
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
 
             with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request("POST", self.post_requestcode, data=self.request_code_form_data_valid)
+                response = await self.client.request("POST", self.post_requestcode,
+                                                     data=self.request_code_form_data_valid)
             self.assertLogLine(cm, "Valid postcode")
 
             self.assertEqual(response.status, 200)
@@ -608,7 +614,8 @@ class TestHandlers(RHTestCase):
             mocked_get_ai_postcode.return_value = self.ai_postcode_no_results
 
             with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request("POST", self.post_requestcode, data=self.request_code_form_data_valid)
+                response = await self.client.request("POST", self.post_requestcode,
+                                                     data=self.request_code_form_data_valid)
                 self.assertLogLine(cm, "Valid postcode")
 
                 self.assertEqual(response.status, 200)
@@ -640,7 +647,8 @@ class TestHandlers(RHTestCase):
             mocked.get(self.addressindexsvc_url + self.postcode_valid, exception=ClientConnectionError('Failed'))
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", self.post_requestcode, data=self.request_code_form_data_valid)
+                response = await self.client.request("POST", self.post_requestcode,
+                                                     data=self.request_code_form_data_valid)
             self.assertLogLine(cm, "Client failed to connect", url=self.addressindexsvc_url + self.postcode_valid)
 
         self.assertEqual(response.status, 500)
@@ -652,7 +660,8 @@ class TestHandlers(RHTestCase):
             mocked.get(self.addressindexsvc_url + self.postcode_valid, status=500)
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", self.post_requestcode, data=self.request_code_form_data_valid)
+                response = await self.client.request("POST", self.post_requestcode,
+                                                     data=self.request_code_form_data_valid)
             self.assertLogLine(cm, "Error in response", status_code=500)
 
         self.assertEqual(response.status, 500)
@@ -664,7 +673,8 @@ class TestHandlers(RHTestCase):
             mocked.get(self.addressindexsvc_url + self.postcode_valid, status=503)
 
             with self.assertLogs('respondent-home', 'ERROR') as cm:
-                response = await self.client.request("POST", self.post_requestcode, data=self.request_code_form_data_valid)
+                response = await self.client.request("POST", self.post_requestcode,
+                                                     data=self.request_code_form_data_valid)
             self.assertLogLine(cm, "Error in response", status_code=503)
 
         self.assertEqual(response.status, 500)
@@ -676,7 +686,8 @@ class TestHandlers(RHTestCase):
             mocked.get(self.addressindexsvc_url + self.postcode_valid, status=403)
 
             with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request("POST", self.post_requestcode, data=self.request_code_form_data_valid)
+                response = await self.client.request("POST", self.post_requestcode,
+                                                     data=self.request_code_form_data_valid)
             self.assertLogLine(cm, "Error in response", status_code=403)
 
             self.assertEqual(response.status, 500)
@@ -688,7 +699,8 @@ class TestHandlers(RHTestCase):
             mocked.get(self.addressindexsvc_url + self.postcode_valid, status=401)
 
             with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request("POST", self.post_requestcode, data=self.request_code_form_data_valid)
+                response = await self.client.request("POST", self.post_requestcode,
+                                                     data=self.request_code_form_data_valid)
             self.assertLogLine(cm, "Error in response", status_code=401)
 
             self.assertEqual(response.status, 500)
@@ -700,8 +712,42 @@ class TestHandlers(RHTestCase):
             mocked.get(self.addressindexsvc_url + self.postcode_valid, status=400)
 
             with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request("POST", self.post_requestcode, data=self.request_code_form_data_valid)
+                response = await self.client.request("POST", self.post_requestcode,
+                                                     data=self.request_code_form_data_valid)
             self.assertLogLine(cm, "Error in response", status_code=400)
 
             self.assertEqual(response.status, 500)
             self.assertIn('Sorry, something went wrong', str(await response.content.read()))
+
+    @unittest_run_loop
+    async def test_get_address_confirmation_direct_access(self):
+        with self.assertLogs('respondent-home', 'WARN') as cm:
+            response = await self.client.request("GET", self.get_address_confirmation, allow_redirects=False)
+        self.assertLogLine(cm, "Permission denied")
+        self.assertEqual(response.status, 403)
+        self.assertIn('Enter the 16 character code printed on the letter', str(await response.content.read()))
+
+    @unittest_run_loop
+    async def test_post_address_confirmation_direct_access(self):
+        with self.assertLogs('respondent-home', 'WARN') as cm:
+            response = await self.client.request("POST", self.post_address_confirmation, allow_redirects=False,
+                                                 data=self.address_confirmation_data)
+        self.assertLogLine(cm, "Permission denied")
+        self.assertEqual(response.status, 403)
+        self.assertIn('Enter the 16 character code printed on the letter', str(await response.content.read()))
+
+    @unittest_run_loop
+    async def test_get_address_edit_direct_access(self):
+        with self.assertLogs('respondent-home', 'WARN') as cm:
+            response = await self.client.request("GET", self.get_address_edit, allow_redirects=False)
+        self.assertLogLine(cm, "Permission denied")
+        self.assertEqual(response.status, 403)
+        self.assertIn('Enter the 16 character code printed on the letter', str(await response.content.read()))
+
+    @unittest_run_loop
+    async def test_post_address_edit_direct_access(self):
+        with self.assertLogs('respondent-home', 'WARN') as cm:
+            response = await self.client.request("GET", self.post_address_edit, allow_redirects=False)
+        self.assertLogLine(cm, "Permission denied")
+        self.assertEqual(response.status, 403)
+        self.assertIn('Enter the 16 character code printed on the letter', str(await response.content.read()))


### PR DESCRIPTION
# Motivation and Context
UAC authentication failure returns HTTP status 401, previously 202. Required for brute force attack protection.

Previously the RH UI consisted of a page to enter the UAC, a page to confirm the address and a page to edit the address. All these pages required the client to have authenticated with a UAC. The existence of the required data in the session, only obtained after a correct UAC was entered, was taken as proof the client had authenticated.

RH UI now contains a mixture of pages where the client may, or may not have authenticated with a UAC. Additionally the pages where the user has not authenticated may also carry session data. The previous method of checking the session for expected data to confirm authentication did not separate the concerns of checking page permissions and validation of the session data.

# What has changed
Methods to remember identity, forget identity and check permissions added to secure pages as required. After authentication "remember" is called with an identity to remember the client. Every secure page should call "check_permission" at the start of the handler. At present "forget_identity" is not called but committed here to clearly show the intended implementation should this behaviour be required.

Handlers have been added for GET address confirmation and GET address edit to provide a location where "check_permission" can be called on accessing these pages, and to resolve anomalous URLs being presented to the client.

Unit tests have been added to check for access without authentication to any page which at present should be secure. An HTTP status 403 is sent to the client with the page for entry of the UAC rendered.

# How to test?
Test by running the unit tests or trying to directly access a secure page without having first entered a UAC and created a session where remember has been called.