### PR TITLE
RH9_Assisted_Digital

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -14,7 +14,7 @@ Request = namedtuple("Request", ["method", "path", "auth", "func"])
 
 class EqPayloadConstructor(object):
 
-    def __init__(self, case: dict, attributes: dict, app: Application):
+    def __init__(self, case: dict, attributes: dict, app: Application, adlocation: str):
         """
         Creates the payload needed to communicate with EQ, built from the RH service
         """
@@ -28,6 +28,13 @@ class EqPayloadConstructor(object):
             raise InvalidEqPayLoad("Attributes is empty")
 
         self._sample_attributes = attributes
+
+        if adlocation:
+            self._channel = 'ad'
+            self._user_id = adlocation
+        else:
+            self._channel = 'rh'
+            self._user_id = ''
 
         try:
             self._case_id = case["caseId"]
@@ -80,8 +87,8 @@ class EqPayloadConstructor(object):
             "display_address": self.build_display_address(self._sample_attributes),
             "response_id": self._response_id,
             "account_service_url": self._account_service_url,  # required for save/continue
-            "channel": "rh",  # from claims sent from RH channel will always by rh,
-            "user_id": "1234567890",  # for 19.9 will be hardcoded. This will be set to empty when eq reasdy to accept as empty
+            "channel": self._channel,
+            "user_id": self._user_id,
             "questionnaire_id": self._questionnaire_id,
             "eq_id": "census",  # for 19.9 hardcoded as will not be needed for new payload but still needed for original
             "period_id": "1",  # for 19.9 hardcoded as will not be needed for new payload but still needed for original

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -227,7 +227,6 @@ class RHTestCase(AioHTTPTestCase):
         self.uac_code = ''.join([str(n) for n in range(13)])
         self.uac1, self.uac2, self.uac3, self.uac4 = self.uac_code[:4], self.uac_code[4:8], self.uac_code[8:12], self.uac_code[12:]
         self.period_id = "1"
-        self.user_id = "1234567890"
         self.uac = self.uac_json['uac']
         self.uprn = self.uac_json['address']['uprn']
         self.response_id = self.uac_json['questionnaireId']
@@ -249,13 +248,18 @@ class RHTestCase(AioHTTPTestCase):
             "response_id": self.response_id,
             "account_service_url": f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}",
             "channel": self.channel,
-            "user_id": "1234567890",
+            "user_id": "",
             "questionnaire_id": self.questionnaire_id,
             "eq_id": self.eq_id,
             "period_id": self.period_id,
             "form_type": self.form_type,
             "survey": self.survey
- }
+        }
+        self.survey_launched_json = {
+            "questionnaireId": self.questionnaire_id,
+            "caseId": self.case_id,
+            "agentId": ''
+        }
 
         self.rhsvc_url = (
             f"{self.app['RHSVC_URL']}/uacs/{self.uac}"

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -10,14 +10,14 @@ class TestEq(RHTestCase):
 
     def test_create_eq_constructor(self):
         self.assertIsInstance(EqPayloadConstructor(
-            self.uac_json, self.uac_json['address'], self.app), EqPayloadConstructor)
+            self.uac_json, self.uac_json['address'], self.app, None), EqPayloadConstructor)
 
     def test_create_eq_constructor_missing_case_id(self):
         uac_json = self.uac_json.copy()
         del uac_json['caseId']
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(uac_json, self.uac_json['address'], self.app )
+            EqPayloadConstructor(uac_json, self.uac_json['address'], self.app, None)
         self.assertIn('No case id in supplied case JSON', ex.exception.message)
 
     def test_create_eq_constructor_missing_ce_id(self):
@@ -25,7 +25,7 @@ class TestEq(RHTestCase):
         del uac_json["collectionExerciseId"]
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(uac_json, self.uac_json['address'], self.app )
+            EqPayloadConstructor(uac_json, self.uac_json['address'], self.app, None)
         self.assertIn(f'No collection id in supplied case JSON', ex.exception.message)
 
     def test_create_eq_constructor_missing_questionnaire_id(self):
@@ -33,7 +33,7 @@ class TestEq(RHTestCase):
         del uac_json["questionnaireId"]
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(uac_json, self.uac_json['address'], self.app)
+            EqPayloadConstructor(uac_json, self.uac_json['address'], self.app, None)
             self.assertIn(f'No questionnaireId in supplied case JSON', ex.exception.message)
 
     def test_create_eq_constructor_missing_case_type(self):
@@ -41,7 +41,7 @@ class TestEq(RHTestCase):
         del uac_json["caseType"]
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(uac_json, self.uac_json['address'], self.app)
+            EqPayloadConstructor(uac_json, self.uac_json['address'], self.app, None)
             self.assertIn(f'No case type in supplied case JSON', ex.exception.message)
 
     def test_create_eq_constructor_missing_uprn(self):
@@ -49,12 +49,11 @@ class TestEq(RHTestCase):
         del uac_json["address"]["uprn"]
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(uac_json, self.uac_json['address'], self.app)
+            EqPayloadConstructor(uac_json, self.uac_json['address'], self.app, None)
             self.assertIn(f'Could not retrieve address uprn from case JSON', ex.exception.message)
 
     @unittest_run_loop
     async def test_build(self):
-        self.maxDiff = None  # for full payload comparison when running this test
         with mock.patch('app.eq.uuid4') as mocked_uuid4, mock.patch('app.eq.time.time') as mocked_time:
             # NB: has to be mocked after setup but before import
             mocked_time.return_value = self.eq_payload['iat']
@@ -62,12 +61,31 @@ class TestEq(RHTestCase):
 
             with self.assertLogs('app.eq', 'DEBUG') as cm:
                 payload = await EqPayloadConstructor(
-                    self.uac_json, self.uac_json['address'], self.app).build()
+                    self.uac_json, self.uac_json['address'], self.app, None).build()
             self.assertLogLine(cm, 'Creating payload for JWT', case_id=self.case_id, tx_id=self.jti)
 
         mocked_uuid4.assert_called()
         mocked_time.assert_called()
         self.assertEqual(payload, self.eq_payload)
+
+    @unittest_run_loop
+    async def test_build_assisted_digital(self):
+        eq_payload = self.eq_payload.copy()
+        eq_payload['channel'] = 'ad'
+        eq_payload['user_id'] = '1000007'
+        with mock.patch('app.eq.uuid4') as mocked_uuid4, mock.patch('app.eq.time.time') as mocked_time:
+            # NB: has to be mocked after setup but before import
+            mocked_time.return_value = self.eq_payload['iat']
+            mocked_uuid4.return_value = self.jti
+
+            with self.assertLogs('app.eq', 'DEBUG') as cm:
+                payload = await EqPayloadConstructor(
+                    self.uac_json, self.uac_json['address'], self.app, eq_payload['user_id']).build()
+            self.assertLogLine(cm, 'Creating payload for JWT', case_id=self.case_id, tx_id=self.jti)
+
+        mocked_uuid4.assert_called()
+        mocked_time.assert_called()
+        self.assertEqual(payload, eq_payload)
 
     @unittest_run_loop
     async def test_build_raises_InvalidEqPayLoad_missing_attributes(self):
@@ -76,7 +94,7 @@ class TestEq(RHTestCase):
 
         with self.assertRaises(InvalidEqPayLoad) as ex:
             await eq.EqPayloadConstructor(
-                self.uac_json, None, self.app).build()
+                self.uac_json, None, self.app, None).build()
         self.assertIn('Attributes is empty', ex.exception.message)
 
     def test_build_display_address(self):


### PR DESCRIPTION
# Motivation and Context
Where RH has been launched with assistance at an Assisted Digital location the URL query string will carry an 'adlocation' parameter.  The EQ request payload JSON channel and user_id elements and Survey Launched request POST should be set according to this parameter as [documented](https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=CATD&title=Census+Assisted+Digital+solution).

# What has changed
As per the [documented design](https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=CATD&title=Census+Assisted+Digital+solution) changes have been made for Assisted Digital requirements:

- In handlers.py the RH /start/ GET handler stores the 'adlocation' query parameter into the session.
- In handlers.py the saved 'adlocation' query parameter is sent in the POST body request for the Survey Launched event. 
- In eq.py the 'adlocation' saved parameter is used to set the channel and user_id payload elements.

Note: if the session times out the application will lose the saved 'adlocation' query parameter and not handle the request as an Assisted Digital response.

# How to test?
Unit tests have been written and submitted as part of this pull request. Manually you need to look at the Survey Launched event message sent to RabbitMQ and EQ payload sent when the client is redirected to the questionnaire.