### PR TITLE
Modified region code test to only match first character

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -67,7 +67,7 @@ class EqPayloadConstructor(object):
             raise InvalidEqPayLoad(f"Could not retrieve address uprn from case JSON ")
 
         try:
-            self._region = case["region"]
+            self._region = case["region"][0]
         except KeyError:
             raise InvalidEqPayLoad(f"Could not retrieve region from case JSON ")
 

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -446,7 +446,7 @@ class AddressConfirmationEN(Start):
             return attributes
 
         if address_confirmation == 'Yes':
-            if case['region'] == 'N':
+            if case['region'][0] == 'N':
                 raise HTTPFound(self._request.app.router['StartLanguageOptionsEN:get'].url_for())
             else:
                 attributes['language'] = 'en'
@@ -508,7 +508,7 @@ class AddressConfirmationCY(Start):
             return attributes
 
         if address_confirmation == 'Yes':
-            if case['region'] == 'N':
+            if case['region'][0] == 'N':
                 raise HTTPFound(self._request.app.router['StartLanguageOptionsCY:get'].url_for())
             else:
                 attributes['language'] = 'cy'
@@ -570,7 +570,7 @@ class AddressConfirmationNI(Start):
             return attributes
 
         if address_confirmation == 'Yes':
-            if case['region'] == 'N':
+            if case['region'][0] == 'N':
                 raise HTTPFound(self._request.app.router['StartLanguageOptionsNI:get'].url_for())
             else:
                 attributes['language'] = 'en'
@@ -637,7 +637,7 @@ class AddressEditEN(Start):
             logger.error("Error raising address modification call", client_ip=self._client_ip)
             raise ex
 
-        if case['region'] == 'N':
+        if case['region'][0] == 'N':
             raise HTTPFound(self._request.app.router['StartLanguageOptionsNI:get'].url_for())
         else:
             attributes['language'] = 'en'
@@ -695,7 +695,7 @@ class AddressEditCY(Start):
             logger.error("Error raising address modification call", client_ip=self._client_ip)
             raise ex
 
-        if case['region'] == 'N':
+        if case['region'][0] == 'N':
             raise HTTPFound(self._request.app.router['StartLanguageOptionsCY:get'].url_for())
         else:
             attributes['language'] = 'cy'
@@ -753,7 +753,7 @@ class AddressEditNI(Start):
             logger.error("Error raising address modification call", client_ip=self._client_ip)
             raise ex
 
-        if case['region'] == 'N':
+        if case['region'][0] == 'N':
             raise HTTPFound(self._request.app.router['StartLanguageOptionsNI:get'].url_for())
         else:
             attributes['language'] = 'en'


### PR DESCRIPTION
Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
case['region'] in merged environments is not a single character, so match failing

# What has changed
Updated match to only check first character of case['region']

# How to test?
Unit tests as before

# Links
None

# Screenshots (if appropriate):