### PR TITLE
Fix to webchat language value format

### DIFF
--- a/app/handlers.py
+++ b/app/handlers.py
@@ -1270,7 +1270,7 @@ class WebChatEN(WebChat):
                     'display_region': 'en'}
 
         context = {'screen_name': data.get('screen_name'),
-                   'language': 'english',
+                   'language': 'en',
                    'country': data.get('country'),
                    'query': data.get('query'),
                    'display_region': 'en',
@@ -1324,7 +1324,7 @@ class WebChatCY(WebChat):
                     'locale': 'cy'}
 
         context = {'screen_name': data.get('screen_name'),
-                   'language': 'welsh',
+                   'language': 'cy',
                    'country': data.get('country'),
                    'query': data.get('query'),
                    'display_region': 'cy',
@@ -1378,7 +1378,7 @@ class WebChatNI(WebChat):
                     'display_region': 'ni'}
 
         context = {'screen_name': data.get('screen_name'),
-                   'language': 'english',
+                   'language': 'en',
                    'country': data.get('country'),
                    'query': data.get('query'),
                    'display_region': 'ni',
@@ -2095,14 +2095,14 @@ class RequestCodeTimeoutHHEN(RequestCodeCommon):
         return {'fulfillment_type': 'HH', 'display_region': 'en'}
 
 
-@routes.view('/request-access-code/timeout')
+@routes.view('/cy/request-access-code/timeout')
 class RequestCodeTimeoutHHCY(RequestCodeCommon):
     @aiohttp_jinja2.template('timeout.html')
     async def get(self, _):
         return {'fulfillment_type': 'HH', 'display_region': 'cy', 'locale': 'cy'}
 
 
-@routes.view('/request-access-code/timeout')
+@routes.view('/ni/request-access-code/timeout')
 class RequestCodeTimeoutHHNI(RequestCodeCommon):
     @aiohttp_jinja2.template('timeout.html')
     async def get(self, _):

--- a/app/templates/timeout.html
+++ b/app/templates/timeout.html
@@ -1,18 +1,18 @@
 {% if display_region == "ni" %}
     {% extends "base-ni.html" %}
-    {% set request_individual_url = url('RequestCodeEnterAddressHHNI:get') %}
-    {% set request_household_url = url('RequestCodeEnterAddressHINI:get') %}
+    {% set request_individual_url = url('RequestCodeEnterAddressHINI:get') %}
+    {% set request_household_url = url('RequestCodeEnterAddressHHNI:get') %}
     {% set index_url = url('IndexNI:get') %}
 {% elif display_region == "cy" %}
     {% extends "base-cy.html" %}
-    {% set request_individual_url = url('RequestCodeEnterAddressHHCY:get') %}
-    {% set request_household_url = url('RequestCodeEnterAddressHICY:get') %}
-    {% set index_url = url('IndexNI:get') %}
+    {% set request_individual_url = url('RequestCodeEnterAddressHICY:get') %}
+    {% set request_household_url = url('RequestCodeEnterAddressHHCY:get') %}
+    {% set index_url = url('IndexCY:get') %}
 {% else %}
     {% extends "base-en.html" %}
-    {% set request_individual_url = url('RequestCodeEnterAddressHHEN:get') %}
-    {% set request_household_url = url('RequestCodeEnterAddressHIEN:get') %}
-    {% set index_url = url('IndexNI:get') %}
+    {% set request_individual_url = url('RequestCodeEnterAddressHIEN:get') %}
+    {% set request_household_url = url('RequestCodeEnterAddressHHEN:get') %}
+    {% set index_url = url('IndexEN:get') %}
 {% endif %}
 
 {% from "components/panel/_macro.njk" import onsPanel %}

--- a/app/templates/timeout.html
+++ b/app/templates/timeout.html
@@ -1,30 +1,18 @@
 {% if display_region == "ni" %}
     {% extends "base-ni.html" %}
-    {% if fulfillment_type == 'HH' %}
-        {% set next_message = 'You will need to <a href="{{ url('RequestCodeEnterAddressHHNI:get') }}">re-enter your postcode</a>' %}
-    {% elif  fulfillment_type == 'HI' %}
-        {% set next_message = 'You will need to <a href="{{ url('RequestCodeEnterAddressHINI:get') }}">re-enter your postcode</a>' %}
-    {% else %}
-        {% set next_message = 'You will need to <a href="{{ url('IndexNI:get') }}">re-enter your access code</a>' %}
-    {% endif %}
+    {% set request_individual_url = url('RequestCodeEnterAddressHHNI:get') %}
+    {% set request_household_url = url('RequestCodeEnterAddressHINI:get') %}
+    {% set index_url = url('IndexNI:get') %}
 {% elif display_region == "cy" %}
     {% extends "base-cy.html" %}
-    {% if fulfillment_type == 'HH' %}
-        {% set next_message = 'You will need to <a href="{{ url('RequestCodeEnterAddressHHCY:get') }}">re-enter your postcode</a>' %}
-    {% elif  fulfillment_type == 'HI' %}
-        {% set next_message = 'You will need to <a href="{{ url('RequestCodeEnterAddressHICY:get') }}">re-enter your postcode</a>' %}
-    {% else %}
-        {% set next_message = 'You will need to <a href="{{ url('IndexCY:get') }}">re-enter your access code</a>' %}
-    {% endif %}
+    {% set request_individual_url = url('RequestCodeEnterAddressHHCY:get') %}
+    {% set request_household_url = url('RequestCodeEnterAddressHICY:get') %}
+    {% set index_url = url('IndexNI:get') %}
 {% else %}
     {% extends "base-en.html" %}
-    {% if fulfillment_type == 'HH' %}
-        {% set next_message = 'You will need to <a href="{{ url('RequestCodeEnterAddressHHEN:get') }}">re-enter your postcode</a>' %}
-    {% elif  fulfillment_type == 'HI' %}
-        {% set next_message = 'You will need to <a href="{{ url('RequestCodeEnterAddressHIEN:get') }}">re-enter your postcode</a>' %}
-    {% else %}
-        {% set next_message = 'You will need to <a href="{{ url('IndexEN:get') }}">re-enter your access code</a>' %}
-    {% endif %}
+    {% set request_individual_url = url('RequestCodeEnterAddressHHEN:get') %}
+    {% set request_household_url = url('RequestCodeEnterAddressHIEN:get') %}
+    {% set index_url = url('IndexNI:get') %}
 {% endif %}
 
 {% from "components/panel/_macro.njk" import onsPanel %}
@@ -37,5 +25,11 @@
         <p>To protect your information we have timed you out.</p>
     {% endcall %}
 
-    <p>{{ next_message }}</p>
+        {% if fulfillment_type == 'HH' %}
+            <p>You will need to <a href="{{ request_household_url }}">re-enter your postcode</a></p>
+        {% elif  fulfillment_type == 'HI' %}
+            <p>You will need to <a href="{{ request_individual_url }}">re-enter your postcode</a></p>
+        {% else %}
+            <p>You will need to <a href="{{ index_url }}">re-enter your access code</a></p>
+        {% endif %}
 {% endblock %}


### PR DESCRIPTION
Fixed timeout call urls and template

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Language parameter for web chat not as Serco want
Timeout template not working correctly

# What has changed
Changed language values from words to code (english > en etc)
Reverted timeout html template to earlier version, fixed urls for /cy and /ni

# How to test?
View source for language code
Via url for timeout

# Links
/request-access-code/timeout
/cy/request-access-code/timeout
/ni/request-access-code/timeout
/request-individual-code/timeout
/cy/request-individual-code/timeout
/ni/request-individual-code/timeout

# Screenshots (if appropriate):