### PR TITLE
CR484

### DIFF
--- a/app/templates/start-ni-language-options.html
+++ b/app/templates/start-ni-language-options.html
@@ -80,7 +80,7 @@
         })
     }}
 
-    <p class="u-mt-l"><a href="/help/i-want-something/" onclick="window.open(this.href,'targetWindow','location=no,status=no,scrollbars=yes,resizable=yes'); return false;">Help in other languages</a>:<br>
-        including Polish (Jezvk polski), Lithuanian (Lietuvių), Cantonese (廣東話) and Manderin (普通話)</p>
+    <p class="u-mt-l"><a href="/ni/help/languages-and-accessibility/language-support/" onclick="window.open(this.href,'targetWindow','location=no,status=no,scrollbars=yes,resizable=yes'); return false;">Help in other languages</a>:<br>
+        including Polish (Jezvk polski), Lithuanian (Lietuvių), Cantonese (廣東話) and Mandarin (普通話)</p>
 
 {% endblock %}

--- a/app/templates/start-ni-select-language.html
+++ b/app/templates/start-ni-select-language.html
@@ -92,4 +92,7 @@
         })
     }}
 
+    <p class="u-mt-l"><a href="/ni/help/languages-and-accessibility/language-support/" onclick="window.open(this.href,'targetWindow','location=no,status=no,scrollbars=yes,resizable=yes'); return false;">Help in other languages</a>:<br>
+        including Polish (Jezvk polski), Lithuanian (Lietuvių), Cantonese (廣東話) and Mandarin (普通話)</p>
+
 {% endblock %}


### PR DESCRIPTION
Added 'Help in other languages' text to both pages, fixed url

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Adds language options to both NI question pages, and updates link to help site

# What has changed
Two template files for the NI language questions

# How to test?
Trigger questions

# Links

# Screenshots (if appropriate):