### PR TITLE
CR487

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -30,12 +30,16 @@ class EqPayloadConstructor(object):
 
         if self._sample_attributes['display_region'] == 'ni':
             save_and_exit_url = '/ni/start/save-and-exit'
+            start_url = '/ni/start/'
         elif self._sample_attributes['display_region'] == 'cy':
             save_and_exit_url = '/dechrau/save-and-exit'
+            start_url = '/dechrau/'
         else:
             save_and_exit_url = '/start/save-and-exit'
+            start_url = '/start/'
 
-        self._account_service_url = f'{app["ACCOUNT_SERVICE_URL"]}{app["URL_PATH_PREFIX"]}{save_and_exit_url}'
+        self._account_service_url = f'{app["ACCOUNT_SERVICE_URL"]}{app["URL_PATH_PREFIX"]}{start_url}'
+        self._account_service_log_out_url = f'{app["ACCOUNT_SERVICE_URL"]}{app["URL_PATH_PREFIX"]}{save_and_exit_url}'
 
         if adlocation:
             self._channel = 'ad'
@@ -99,7 +103,8 @@ class EqPayloadConstructor(object):
             "language_code": self._language_code,
             "display_address": self.build_display_address(self._sample_attributes),
             "response_id": self._response_id,
-            "account_service_url": self._account_service_url,  # required for save/continue
+            "account_service_url": self._account_service_url,
+            "account_service_log_out_url": self._account_service_log_out_url,  # required for save/continue
             "channel": self._channel,
             "user_id": self._user_id,
             "questionnaire_id": self._questionnaire_id,

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -311,7 +311,8 @@ class RHTestCase(AioHTTPTestCase):
             "language_code": 'en',
             "display_address": f"{self.uac_json['address']['addressLine1']}, {self.uac_json['address']['addressLine2']}",
             "response_id": self.response_id,
-            "account_service_url": f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}/start/save-and-exit",
+            "account_service_url": f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}/start/",
+            "account_service_log_out_url": f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}/start/save-and-exit",
             "channel": self.channel,
             "user_id": "",
             "questionnaire_id": self.questionnaire_id,
@@ -321,9 +322,12 @@ class RHTestCase(AioHTTPTestCase):
             "survey": self.survey
         }
 
-        self.account_service_url_en = '/start/save-and-exit'
-        self.account_service_url_cy = '/dechrau/save-and-exit'
-        self.account_service_url_ni = '/ni/start/save-and-exit'
+        self.account_service_url_en = '/start/'
+        self.account_service_url_cy = '/dechrau/'
+        self.account_service_url_ni = '/ni/start/'
+        self.account_service_log_out_url_en = '/start/save-and-exit'
+        self.account_service_log_out_url_cy = '/dechrau/save-and-exit'
+        self.account_service_log_out_url_ni = '/ni/start/save-and-exit'
 
         self.survey_launched_json = {
             "questionnaireId": self.questionnaire_id,

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -59,6 +59,8 @@ class TestEq(RHTestCase):
         eq_payload['language_code'] = 'en'
         eq_payload['account_service_url'] = \
             f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_en}"
+        eq_payload['account_service_log_out_url'] = \
+            f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_en}"
         self.maxDiff = None  # for full payload comparison when running this test
         with mock.patch('app.eq.uuid4') as mocked_uuid4, mock.patch('app.eq.time.time') as mocked_time:
             # NB: has to be mocked after setup but before import
@@ -81,6 +83,8 @@ class TestEq(RHTestCase):
         eq_payload['language_code'] = 'cy'
         eq_payload['account_service_url'] = \
             f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_cy}"
+        eq_payload['account_service_log_out_url'] = \
+            f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_cy}"
         self.maxDiff = None  # for full payload comparison when running this test
         with mock.patch('app.eq.uuid4') as mocked_uuid4, mock.patch('app.eq.time.time') as mocked_time:
             # NB: has to be mocked after setup but before import
@@ -103,6 +107,8 @@ class TestEq(RHTestCase):
         eq_payload['language_code'] = 'ul'
         eq_payload['account_service_url'] = \
             f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_ni}"
+        eq_payload['account_service_log_out_url'] = \
+            f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_ni}"
         self.maxDiff = None  # for full payload comparison when running this test
         with mock.patch('app.eq.uuid4') as mocked_uuid4, mock.patch('app.eq.time.time') as mocked_time:
             # NB: has to be mocked after setup but before import
@@ -127,6 +133,8 @@ class TestEq(RHTestCase):
         eq_payload['language_code'] = 'en'
         eq_payload['account_service_url'] = \
             f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_en}"
+        eq_payload['account_service_log_out_url'] = \
+            f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_en}"
         with mock.patch('app.eq.uuid4') as mocked_uuid4, mock.patch('app.eq.time.time') as mocked_time:
             # NB: has to be mocked after setup but before import
             mocked_time.return_value = self.eq_payload['iat']
@@ -150,6 +158,8 @@ class TestEq(RHTestCase):
         eq_payload['language_code'] = 'cy'
         eq_payload['account_service_url'] = \
             f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_cy}"
+        eq_payload['account_service_log_out_url'] = \
+            f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_cy}"
         with mock.patch('app.eq.uuid4') as mocked_uuid4, mock.patch('app.eq.time.time') as mocked_time:
             # NB: has to be mocked after setup but before import
             mocked_time.return_value = self.eq_payload['iat']
@@ -173,6 +183,8 @@ class TestEq(RHTestCase):
         eq_payload['language_code'] = 'ul'
         eq_payload['account_service_url'] = \
             f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_ni}"
+        eq_payload['account_service_log_out_url'] = \
+            f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_ni}"
         with mock.patch('app.eq.uuid4') as mocked_uuid4, mock.patch('app.eq.time.time') as mocked_time:
             # NB: has to be mocked after setup but before import
             mocked_time.return_value = self.eq_payload['iat']

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -93,6 +93,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'en'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_en}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_en}"
 
             response = await self.client.request("POST", self.post_index_en, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -126,6 +128,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'cy'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_cy}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_cy}"
 
             response = await self.client.request("POST", self.post_index_cy, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -159,6 +163,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'en'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_ni}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_ni}"
 
             response = await self.client.request("POST", self.post_index_ni, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -192,6 +198,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'en'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_en}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_en}"
 
             response = await self.client.request("POST", self.post_index_en, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -231,6 +239,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'en'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_cy}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_cy}"
 
             response = await self.client.request("POST", self.post_index_cy, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -270,6 +280,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'en'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_ni}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_ni}"
 
             response = await self.client.request("POST", self.post_index_ni, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -309,6 +321,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'ul'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_en}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_en}"
 
             response = await self.client.request("POST", self.post_index_en, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -354,6 +368,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'ul'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_cy}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_cy}"
 
             response = await self.client.request("POST", self.post_index_cy, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -399,6 +415,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'ul'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_ni}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_ni}"
 
             response = await self.client.request("POST", self.post_index_ni, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -444,6 +462,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'ga'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_en}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_en}"
 
             response = await self.client.request("POST", self.post_index_en, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -489,6 +509,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'ga'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_cy}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_cy}"
 
             response = await self.client.request("POST", self.post_index_cy, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -534,6 +556,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'ga'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_ni}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_ni}"
 
             response = await self.client.request("POST", self.post_index_ni, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -579,6 +603,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'en'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_en}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_en}"
 
             response = await self.client.request("POST", self.post_index_en, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -624,6 +650,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'en'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_cy}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_cy}"
 
             response = await self.client.request("POST", self.post_index_cy, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -669,6 +697,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'en'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_ni}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_ni}"
 
             response = await self.client.request("POST", self.post_index_ni, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -713,6 +743,8 @@ class TestHandlers(RHTestCase):
             eq_payload = self.eq_payload.copy()
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_en}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_en}"
 
             response = await self.client.request("POST", self.post_index_en, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -751,6 +783,8 @@ class TestHandlers(RHTestCase):
             eq_payload['language_code'] = 'cy'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_cy}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_cy}"
 
             response = await self.client.request("POST", self.post_index_cy, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)
@@ -787,6 +821,8 @@ class TestHandlers(RHTestCase):
             eq_payload = self.eq_payload.copy()
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_ni}"
+            eq_payload['account_service_log_out_url'] = \
+                f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_log_out_url_ni}"
 
             response = await self.client.request("POST", self.post_index_ni, allow_redirects=False, data=self.form_data)
             self.assertEqual(response.status, 302)


### PR DESCRIPTION
Added new account_service_log_out_url, changed value for account_service_url, all tests updated

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
account_service_url not as expected by EQ - this resolves issue

# What has changed
account_service_url changed to point to RH root
account_service_log_out_url added to point to save and exit page in RH

# How to test?
Existing unit tests updated

# Links
None

# Screenshots (if appropriate):