### PR TITLE
CR491

### DIFF
--- a/app/templates/base-cy.html
+++ b/app/templates/base-cy.html
@@ -84,3 +84,13 @@
     <!-- End Google Analytics -->
 
 {% endblock %}
+
+{% block preHeader %}
+    {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
+    {{
+        onsCookiesBanner({
+            "html": 'CENSUS.GOV.UK uses cookies to make the site simpler.',
+            "secondaryButtonUrl": '/cwcis'
+        })
+    }}
+{% endblock %}

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -69,3 +69,13 @@
     <!-- End Google Analytics -->
 
 {% endblock %}
+
+{% block preHeader %}
+    {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
+    {{
+        onsCookiesBanner({
+            "html": 'CENSUS.GOV.UK uses cookies to make the site simpler.',
+            "secondaryButtonUrl": '/cookies'
+        })
+    }}
+{% endblock %}

--- a/app/templates/base-ni.html
+++ b/app/templates/base-ni.html
@@ -71,3 +71,13 @@
     <!-- End Google Analytics -->
 
 {% endblock %}
+
+{% block preHeader %}
+    {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
+    {{
+        onsCookiesBanner({
+            "html": 'CENSUS.GOV.UK uses cookies to make the site simpler.',
+            "secondaryButtonUrl": '/ni/cookies'
+        })
+    }}
+{% endblock %}

--- a/app/templates/base-start-cy.html
+++ b/app/templates/base-start-cy.html
@@ -95,3 +95,13 @@
     <!-- End Google Analytics -->
 
 {% endblock %}
+
+{% block preHeader %}
+    {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
+    {{
+        onsCookiesBanner({
+            "html": 'CENSUS.GOV.UK uses cookies to make the site simpler.',
+            "secondaryButtonUrl": '/cwcis'
+        })
+    }}
+{% endblock %}

--- a/app/templates/base-start-en.html
+++ b/app/templates/base-start-en.html
@@ -94,3 +94,13 @@
     <!-- End Google Analytics -->
 
 {% endblock %}
+
+{% block preHeader %}
+    {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
+    {{
+        onsCookiesBanner({
+            "html": 'CENSUS.GOV.UK uses cookies to make the site simpler.',
+            "secondaryButtonUrl": '/cookies'
+        })
+    }}
+{% endblock %}

--- a/app/templates/base-start-ni.html
+++ b/app/templates/base-start-ni.html
@@ -72,3 +72,13 @@
     <!-- End Google Analytics -->
 
 {% endblock %}
+
+{% block preHeader %}
+    {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
+    {{
+        onsCookiesBanner({
+            "html": 'CENSUS.GOV.UK uses cookies to make the site simpler.',
+            "secondaryButtonUrl": '/ni/cookies'
+        })
+    }}
+{% endblock %}

--- a/scripts/load_templates.sh
+++ b/scripts/load_templates.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "${DIR}"/.. || exit
 
-DESIGN_SYSTEM_VERSION="13.4.5"
+DESIGN_SYSTEM_VERSION="13.5.0"
 
 TEMP_DIR=$(mktemp -d)
 


### PR DESCRIPTION
Add cookie banner to all 6 main base templates (webchat not required)
Welsh translation will be added later

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Implement new cookie banner

# What has changed
Updates to base templates to include the cookie banner from the design pattern
Update design pattern to 13.5.0

# How to test?
Cookie banner should appear everywhere (except webchat) until accepted, then not appear until cookies cleared

# Links
None

# Screenshots (if appropriate):