### PR TITLE
CR491 Reversion

### DIFF
--- a/app/templates/base-cy.html
+++ b/app/templates/base-cy.html
@@ -84,13 +84,3 @@
     <!-- End Google Analytics -->
 
 {% endblock %}
-
-{% block preHeader %}
-    {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
-    {{
-        onsCookiesBanner({
-            "html": 'CENSUS.GOV.UK uses cookies to make the site simpler.',
-            "secondaryButtonUrl": '/cwcis'
-        })
-    }}
-{% endblock %}

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -69,13 +69,3 @@
     <!-- End Google Analytics -->
 
 {% endblock %}
-
-{% block preHeader %}
-    {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
-    {{
-        onsCookiesBanner({
-            "html": 'CENSUS.GOV.UK uses cookies to make the site simpler.',
-            "secondaryButtonUrl": '/cookies'
-        })
-    }}
-{% endblock %}

--- a/app/templates/base-ni.html
+++ b/app/templates/base-ni.html
@@ -71,13 +71,3 @@
     <!-- End Google Analytics -->
 
 {% endblock %}
-
-{% block preHeader %}
-    {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
-    {{
-        onsCookiesBanner({
-            "html": 'CENSUS.GOV.UK uses cookies to make the site simpler.',
-            "secondaryButtonUrl": '/ni/cookies'
-        })
-    }}
-{% endblock %}

--- a/app/templates/base-start-cy.html
+++ b/app/templates/base-start-cy.html
@@ -95,13 +95,3 @@
     <!-- End Google Analytics -->
 
 {% endblock %}
-
-{% block preHeader %}
-    {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
-    {{
-        onsCookiesBanner({
-            "html": 'CENSUS.GOV.UK uses cookies to make the site simpler.',
-            "secondaryButtonUrl": '/cwcis'
-        })
-    }}
-{% endblock %}

--- a/app/templates/base-start-en.html
+++ b/app/templates/base-start-en.html
@@ -94,13 +94,3 @@
     <!-- End Google Analytics -->
 
 {% endblock %}
-
-{% block preHeader %}
-    {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
-    {{
-        onsCookiesBanner({
-            "html": 'CENSUS.GOV.UK uses cookies to make the site simpler.',
-            "secondaryButtonUrl": '/cookies'
-        })
-    }}
-{% endblock %}

--- a/app/templates/base-start-ni.html
+++ b/app/templates/base-start-ni.html
@@ -72,13 +72,3 @@
     <!-- End Google Analytics -->
 
 {% endblock %}
-
-{% block preHeader %}
-    {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
-    {{
-        onsCookiesBanner({
-            "html": 'CENSUS.GOV.UK uses cookies to make the site simpler.',
-            "secondaryButtonUrl": '/ni/cookies'
-        })
-    }}
-{% endblock %}

--- a/scripts/load_templates.sh
+++ b/scripts/load_templates.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "${DIR}"/.. || exit
 
-DESIGN_SYSTEM_VERSION="13.5.0"
+DESIGN_SYSTEM_VERSION="13.4.5"
 
 TEMP_DIR=$(mktemp -d)
 


### PR DESCRIPTION
Revert cookie banner changes due to conflict

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Cookie Banner prevents UAC validation - reverting changes

# What has changed
Previous code removed

# How to test?

# Links


# Screenshots (if appropriate):