### PR TITLE
EQ Language Code change to 'eo' and period_id change to '2019'

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -112,7 +112,7 @@ class EqPayloadConstructor(object):
             "user_id": self._user_id,
             "questionnaire_id": self._questionnaire_id,
             "eq_id": "census",  # for 19.9 hardcoded as will not be needed for new payload but still needed for original
-            "period_id": "1",  # for 19.9 hardcoded as will not be needed for new payload but still needed for original
+            "period_id": "2019",  # for 19.9 hardcoded as will not be needed for new payload but still needed for original
             "form_type": "individual_gb_eng",  # for 19.9 hardcoded as will not be needed for new payload but still needed for original
             "survey": "CENSUS"  # hardcoded for census
         }

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -993,7 +993,7 @@ class StartSelectLanguageEN(Start):
             attributes['language'] = 'ga'
 
         elif language_option == 'ulster-scotch':
-            attributes['language'] = 'en_US'
+            attributes['language'] = 'eo'
 
         elif language_option == 'english':
             attributes['language'] = 'en'
@@ -1053,7 +1053,7 @@ class StartSelectLanguageCY(Start):
             attributes['language'] = 'ga'
 
         elif language_option == 'ulster-scotch':
-            attributes['language'] = 'en_US'
+            attributes['language'] = 'eo'
 
         elif language_option == 'english':
             attributes['language'] = 'en'
@@ -1113,7 +1113,7 @@ class StartSelectLanguageNI(Start):
             attributes['language'] = 'ga'
 
         elif language_option == 'ulster-scotch':
-            attributes['language'] = 'en_US'
+            attributes['language'] = 'eo'
 
         elif language_option == 'english':
             attributes['language'] = 'en'

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -259,7 +259,7 @@ class RHTestCase(AioHTTPTestCase):
         self.jti = str(uuid.uuid4())
         self.uac_code = ''.join([str(n) for n in range(13)])
         self.uac1, self.uac2, self.uac3, self.uac4 = self.uac_code[:4], self.uac_code[4:8], self.uac_code[8:12], self.uac_code[12:]
-        self.period_id = "1"
+        self.period_id = "2019"
         self.uac = self.uac_json['uac']
         self.uprn = self.uac_json['address']['uprn']
         self.response_id = self.uac_json['questionnaireId']

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -318,7 +318,7 @@ class TestHandlers(RHTestCase):
             mocked.post(self.rhsvc_url_surveylaunched)
             eq_payload = self.eq_payload.copy()
             eq_payload['region_code'] = 'GB-NIR'
-            eq_payload['language_code'] = 'en_US'
+            eq_payload['language_code'] = 'eo'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_en}"
             eq_payload['account_service_log_out_url'] = \
@@ -365,7 +365,7 @@ class TestHandlers(RHTestCase):
             mocked.post(self.rhsvc_url_surveylaunched)
             eq_payload = self.eq_payload.copy()
             eq_payload['region_code'] = 'GB-NIR'
-            eq_payload['language_code'] = 'en_US'
+            eq_payload['language_code'] = 'eo'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_cy}"
             eq_payload['account_service_log_out_url'] = \
@@ -412,7 +412,7 @@ class TestHandlers(RHTestCase):
             mocked.post(self.rhsvc_url_surveylaunched)
             eq_payload = self.eq_payload.copy()
             eq_payload['region_code'] = 'GB-NIR'
-            eq_payload['language_code'] = 'en_US'
+            eq_payload['language_code'] = 'eo'
             eq_payload['account_service_url'] = \
                 f"{self.app['ACCOUNT_SERVICE_URL']}{self.app['URL_PATH_PREFIX']}{self.account_service_url_ni}"
             eq_payload['account_service_log_out_url'] = \


### PR DESCRIPTION
Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Updates to EQ payload - CR512

# What has changed
EQ language_code for en_US to eo
EQ period_id to 2019

# How to test?
Unit tests updated

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):