### PR TITLE
CR-494 Hash of UAC requested from RH service.

### DIFF
--- a/app/handlers.py
+++ b/app/handlers.py
@@ -23,7 +23,7 @@ from .exceptions import InactiveCaseError
 from .eq import EqPayloadConstructor
 from .flash import flash
 from .exceptions import InvalidEqPayLoad
-from .security import remember, check_permission, forget
+from .security import remember, check_permission, forget, get_sha256_hash
 from collections import namedtuple
 
 logger = wrap_logger(logging.getLogger("respondent-home"))
@@ -114,16 +114,16 @@ class View:
 class Start(View):
 
     def __init__(self):
-        self._uac = None
+        self._uac_hash = None
         self._sample_unit_id = None
         super().__init__()
 
     @property
     def _rhsvc_url(self):
-        return f"{self._request.app['RHSVC_URL']}/uacs/{self._uac}"
+        return f"{self._request.app['RHSVC_URL']}/uacs/{self._uac_hash}"
 
     @staticmethod
-    def join_uac(data, expected_length=16):
+    def uac_hash(data, expected_length=16):
         if data.get('uac'):
             combined = data.get('uac').lower().replace(" ", "")
         else:
@@ -133,7 +133,8 @@ class Start(View):
 
         if (len(combined) < expected_length) or not (uac_validation_pattern.fullmatch(combined)):
             raise TypeError
-        return combined
+
+        return get_sha256_hash(combined)
 
     @staticmethod
     def validate_case(case_json):
@@ -143,7 +144,7 @@ class Start(View):
             raise InvalidEqPayLoad("CaseStatus is not OK")
 
     async def get_uac_details(self):
-        logger.debug(f"Making GET request to {self._rhsvc_url}", client_ip=self._client_ip)
+        logger.info("Making GET request for UAC", uac_hash=self._uac_hash, client_ip=self._client_ip)
         return await self._make_request(
             Request("GET", self._rhsvc_url, self._request.app["RHSVC_AUTH"], None, self._handle_response, "json"))
 
@@ -221,7 +222,7 @@ class IndexEN(Start):
         data = await self._request.post()
 
         try:
-            self._uac = self.join_uac(data)
+            self._uac_hash = self.uac_hash(data)
         except TypeError:
             logger.warn("Attempt to use a malformed access code", client_ip=self._client_ip)
             flash(self._request, BAD_CODE_MSG)
@@ -293,7 +294,7 @@ class IndexCY(Start):
         data = await self._request.post()
 
         try:
-            self._uac = self.join_uac(data)
+            self._uac_hash = self.uac_hash(data)
         except TypeError:
             logger.warn("Attempt to use a malformed access code", client_ip=self._client_ip)
             flash(self._request, BAD_CODE_MSG_CY)
@@ -366,7 +367,7 @@ class IndexNI(Start):
         data = await self._request.post()
 
         try:
-            self._uac = self.join_uac(data)
+            self._uac_hash = self.uac_hash(data)
         except TypeError:
             logger.warn("Attempt to use a malformed access code", client_ip=self._client_ip)
             flash(self._request, BAD_CODE_MSG)

--- a/app/security.py
+++ b/app/security.py
@@ -1,6 +1,7 @@
 import random
 import string
 import logging
+import hashlib
 
 from structlog import wrap_logger
 from aiohttp import web
@@ -99,3 +100,7 @@ async def remember(identity, request):
     session = await get_session(request)
     session[SESSION_KEY] = identity
     logger.info("Identity remembered", client_ip=request.headers.get("X-Forwarded-For"), identity=identity)
+
+
+def get_sha256_hash(uac: str):
+    return hashlib.sha256(uac.encode()).hexdigest()

--- a/tests/test_data/rhsvc/uac-cy.json
+++ b/tests/test_data/rhsvc/uac-cy.json
@@ -1,5 +1,5 @@
 {
-	"uac": "0123456789101112",
+	"uacHash": "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4",
 	"active": "True",
 	"caseStatus": "OK",
 	"questionnaireId": "11100000009",

--- a/tests/test_data/rhsvc/uac-ni.json
+++ b/tests/test_data/rhsvc/uac-ni.json
@@ -1,5 +1,5 @@
 {
-	"uac": "0123456789101112",
+	"uacHash": "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4",
 	"active": "True",
 	"caseStatus": "OK",
 	"questionnaireId": "11100000009",

--- a/tests/test_data/rhsvc/uac.json
+++ b/tests/test_data/rhsvc/uac.json
@@ -1,5 +1,5 @@
 {
-	"uac": "0123456789101112",
+	"uacHash": "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4",
 	"active": "True",
 	"caseStatus": "OK",
 	"questionnaireId": "11100000009",

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -260,7 +260,8 @@ class RHTestCase(AioHTTPTestCase):
         self.uac_code = ''.join([str(n) for n in range(13)])
         self.uac1, self.uac2, self.uac3, self.uac4 = self.uac_code[:4], self.uac_code[4:8], self.uac_code[8:12], self.uac_code[12:]
         self.period_id = "2019"
-        self.uac = self.uac_json['uac']
+        self.uac = 'w4nwwpphjjptp7fn'
+        self.uacHash = self.uac_json['uacHash']
         self.uprn = self.uac_json['address']['uprn']
         self.response_id = self.uac_json['questionnaireId']
         self.questionnaire_id = self.uac_json['questionnaireId']
@@ -342,7 +343,7 @@ class RHTestCase(AioHTTPTestCase):
         }
 
         self.rhsvc_url = (
-            f"{self.app['RHSVC_URL']}/uacs/{self.uac}"
+            f"{self.app['RHSVC_URL']}/uacs/{self.uacHash}"
         )
 
         self.rhsvc_url_surveylaunched = (

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -2224,35 +2224,35 @@ class TestHandlers(RHTestCase):
             self.assertIn(self.nisra_logo, contents)
             self.assertIn('Bank Holidays', contents)
 
-    def test_join_uac_en(self):
+    def test_uac_hash_en(self):
         # Given some post data
-        post_data = {'uac': '1234567890121314', 'action[save_continue]': ''}
+        post_data = {'uac': 'w4nw wpph jjpt p7fn', 'action[save_continue]': ''}
 
         # When join_uac is called
-        result = IndexEN.join_uac(post_data)
+        result = IndexEN.uac_hash(post_data)
 
         # Then a single string built from the uac values is returned
-        self.assertEqual(result, post_data['uac'])
+        self.assertEqual(result, '8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4')
 
     def test_join_uac_cy(self):
         # Given some post data
-        post_data = {'uac': '1234567890121314', 'action[save_continue]': ''}
+        post_data = {'uac': 'w4nw wpph jjpt p7fn', 'action[save_continue]': ''}
 
         # When join_uac is called
-        result = IndexCY.join_uac(post_data)
+        result = IndexCY.uac_hash(post_data)
 
         # Then a single string built from the uac values is returned
-        self.assertEqual(result, post_data['uac'])
+        self.assertEqual(result, '8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4')
 
     def test_join_uac_ni(self):
         # Given some post data
-        post_data = {'uac': '1234567890121314', 'action[save_continue]': ''}
+        post_data = {'uac': 'w4nw wpph jjpt p7fn', 'action[save_continue]': ''}
 
         # When join_uac is called
-        result = IndexNI.join_uac(post_data)
+        result = IndexNI.uac_hash(post_data)
 
         # Then a single string built from the uac values is returned
-        self.assertEqual(result, post_data['uac'])
+        self.assertEqual(result, '8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4')
 
     def test_join_uac_missing_en(self):
         # Given some missing post data
@@ -2260,7 +2260,7 @@ class TestHandlers(RHTestCase):
 
         # When join_uac is called
         with self.assertRaises(TypeError):
-            IndexEN.join_uac(post_data)
+            IndexEN.uac_hash(post_data)
         # Then a TypeError is raised
 
     def test_join_uac_missing_cy(self):
@@ -2269,7 +2269,7 @@ class TestHandlers(RHTestCase):
 
         # When join_uac is called
         with self.assertRaises(TypeError):
-            IndexCY.join_uac(post_data)
+            IndexCY.uac_hash(post_data)
         # Then a TypeError is raised
 
     def test_join_uac_missing_ni(self):
@@ -2278,7 +2278,7 @@ class TestHandlers(RHTestCase):
 
         # When join_uac is called
         with self.assertRaises(TypeError):
-            IndexNI.join_uac(post_data)
+            IndexNI.uac_hash(post_data)
         # Then a TypeError is raised
 
     def test_join_uac_some_missing_en(self):
@@ -2287,7 +2287,7 @@ class TestHandlers(RHTestCase):
 
         # When join_uac is called
         with self.assertRaises(TypeError):
-            IndexEN.join_uac(post_data)
+            IndexEN.uac_hash(post_data)
         # Then a TypeError is raised
 
     def test_join_uac_some_missing_cy(self):
@@ -2296,7 +2296,7 @@ class TestHandlers(RHTestCase):
 
         # When join_uac is called
         with self.assertRaises(TypeError):
-            IndexCY.join_uac(post_data)
+            IndexCY.uac_hash(post_data)
         # Then a TypeError is raised
 
     def test_join_uac_some_missing_ni(self):
@@ -2305,7 +2305,7 @@ class TestHandlers(RHTestCase):
 
         # When join_uac is called
         with self.assertRaises(TypeError):
-            IndexNI.join_uac(post_data)
+            IndexNI.uac_hash(post_data)
         # Then a TypeError is raised
 
     def test_validate_case_en(self):


### PR DESCRIPTION
# Motivation and Context
At present the request to RH Service to get details for a UAC uses the UAC as entered by the client with the URL /uacs/{uac}. The RH service hashes the UAC and looks for the UAC details in its repository using the hash. It has been decided to change this behaviour such that the RH UI itself hashes the UAC and makes the request to RH service with the hashed UAC - /uac/{uacHash}.

# What has changed
Minimum changes undertaken to implement required functionality. The join_uac function whose name is a misnomer since the UI was changed from entering the UAC as separate groups, has been renamed uac_hash and returns a hash of the UAC for use in the URL to RH service. I resisted making any unnecessary changes to tidy up the method.

# How to test?
Unit tests changed as required to reflect use of UAC hash. Running the application as normal entering a UAC will work as before.

Note, must be released with [related RH service PR](https://github.com/ONSdigital/census-rh-service/pull/40)