### PR TITLE
Corrected the message on the endpoint hit logging

### DIFF
--- a/app/handlers.py
+++ b/app/handlers.py
@@ -38,7 +38,10 @@ routes = RouteTableDef()
 @routes.view('/info', use_prefix=False)
 class Info:
     async def get(self, request):
-        logger.info('entered endpoint',
+        # View::log_entry inlined here, because there's no overarcing View class
+        method = request.method
+        endpoint = 'info'
+        logger.info(f"received {method} on endpoint '{endpoint}'",
                     method=request.method,
                     path=request.path)
         info = {
@@ -146,6 +149,12 @@ class View:
                     self._request.app['RHSVC_AUTH'], launch_json,
                     self._handle_response, None))
 
+    def log_entry(self, request, endpoint):
+        method = request.method
+        logger.info(f"received {method} on endpoint '{endpoint}'",
+                    method=request.method,
+                    path=request.path)
+
 
 class Start(View):
     def __init__(self):
@@ -239,9 +248,7 @@ class IndexEN(Start):
         :param request:
         :return:
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start')
         self._request = request
         query_string = request.query
         session = await get_session(request)
@@ -274,9 +281,7 @@ class IndexEN(Start):
         :param request:
         :return: address confirmation view
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start')
         self._request = request
         data = await self._request.post()
 
@@ -338,9 +343,7 @@ class IndexCY(Start):
         :param request:
         :return:
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start')
         self._request = request
         query_string = request.query
         session = await get_session(request)
@@ -373,9 +376,7 @@ class IndexCY(Start):
         :param request:
         :return: address confirmation view
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start')
         self._request = request
         data = await self._request.post()
 
@@ -439,9 +440,7 @@ class IndexNI(Start):
         :param request:
         :return:
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start')
         self._request = request
         query_string = request.query
         session = await get_session(request)
@@ -473,9 +472,7 @@ class IndexNI(Start):
         :param request:
         :return: address confirmation view
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start')
         self._request = request
         data = await self._request.post()
 
@@ -535,9 +532,7 @@ class AddressConfirmationEN(Start):
         """
         Address Confirmation get.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/address-confirmation')
         await check_permission(request)
         self._request = request
 
@@ -559,9 +554,7 @@ class AddressConfirmationEN(Start):
         """
         Address Confirmation flow. If correct address will build EQ payload and send to EQ.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/address-confirmation')
         await check_permission(request)
         self._request = request
         data = await request.post()
@@ -613,9 +606,7 @@ class AddressConfirmationCY(Start):
         """
         Address Confirmation get.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/address-confirmation')
         await check_permission(request)
         self._request = request
 
@@ -637,9 +628,7 @@ class AddressConfirmationCY(Start):
         """
         Address Confirmation flow. If correct address will build EQ payload and send to EQ.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/address-confirmation')
         await check_permission(request)
         self._request = request
         data = await request.post()
@@ -692,9 +681,7 @@ class AddressConfirmationNI(Start):
         """
         Address Confirmation get.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/address-confirmation')
         await check_permission(request)
         self._request = request
 
@@ -716,9 +703,7 @@ class AddressConfirmationNI(Start):
         """
         Address Confirmation flow. If correct address will build EQ payload and send to EQ.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/address-confirmation')
         await check_permission(request)
         self._request = request
         data = await request.post()
@@ -771,9 +756,7 @@ class AddressEditEN(Start):
         """
         Address Edit get.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/address-edit')
         await check_permission(request)
         self._request = request
 
@@ -795,9 +778,7 @@ class AddressEditEN(Start):
         """
         Address Edit flow. Edited address details.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/address-edit')
         await check_permission(request)
         data = await request.post()
         self._request = request
@@ -850,9 +831,7 @@ class AddressEditCY(Start):
         """
         Address Edit get.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/address-edit')
         await check_permission(request)
         self._request = request
 
@@ -874,9 +853,7 @@ class AddressEditCY(Start):
         """
         Address Edit flow. Edited address details.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/address-edit')
         await check_permission(request)
         data = await request.post()
         self._request = request
@@ -929,9 +906,7 @@ class AddressEditNI(Start):
         """
         Address Edit get.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/address-edit')
         await check_permission(request)
         self._request = request
 
@@ -953,9 +928,7 @@ class AddressEditNI(Start):
         """
         Address Edit flow. Edited address details.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/address-edit')
         await check_permission(request)
         data = await request.post()
         self._request = request
@@ -1008,9 +981,7 @@ class StartLanguageOptionsEN(Start):
         """
         Address Confirmation get.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/language-options')
         await check_permission(request)
         self._request = request
 
@@ -1030,9 +1001,7 @@ class StartLanguageOptionsEN(Start):
 
     @aiohttp_jinja2.template('start-ni-language-options.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/language-options')
         await check_permission(request)
         self._request = request
         data = await request.post()
@@ -1080,9 +1049,7 @@ class StartLanguageOptionsCY(Start):
         """
         Address Confirmation get.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/language-options')
         await check_permission(request)
         self._request = request
 
@@ -1102,9 +1069,7 @@ class StartLanguageOptionsCY(Start):
 
     @aiohttp_jinja2.template('start-ni-language-options.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/language-options')
         await check_permission(request)
         self._request = request
         data = await request.post()
@@ -1152,9 +1117,7 @@ class StartLanguageOptionsNI(Start):
         """
         Address Confirmation get.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/language-options')
         await check_permission(request)
         self._request = request
 
@@ -1174,9 +1137,7 @@ class StartLanguageOptionsNI(Start):
 
     @aiohttp_jinja2.template('start-ni-language-options.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/language-options')
         await check_permission(request)
         self._request = request
         data = await request.post()
@@ -1224,9 +1185,7 @@ class StartSelectLanguageEN(Start):
         """
         Address Confirmation get.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/select-language')
         await check_permission(request)
         self._request = request
 
@@ -1245,9 +1204,7 @@ class StartSelectLanguageEN(Start):
 
     @aiohttp_jinja2.template('start-ni-select-language.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/select-language')
         await check_permission(request)
         self._request = request
         data = await request.post()
@@ -1297,9 +1254,7 @@ class StartSelectLanguageCY(Start):
         """
         Address Confirmation get.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/select-language')
         await check_permission(request)
         self._request = request
 
@@ -1318,9 +1273,7 @@ class StartSelectLanguageCY(Start):
 
     @aiohttp_jinja2.template('start-ni-select-language.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/select-language')
         await check_permission(request)
         self._request = request
         data = await request.post()
@@ -1370,9 +1323,7 @@ class StartSelectLanguageNI(Start):
         """
         Address Confirmation get.
         """
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/select-language')
         await check_permission(request)
         self._request = request
 
@@ -1391,9 +1342,7 @@ class StartSelectLanguageNI(Start):
 
     @aiohttp_jinja2.template('start-ni-select-language.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/select-language')
         await check_permission(request)
         self._request = request
         data = await request.post()
@@ -1440,9 +1389,7 @@ class StartSelectLanguageNI(Start):
 class UACTimeout(View):
     @aiohttp_jinja2.template('timeout.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/timeout')
         return {}
 
 
@@ -1450,9 +1397,7 @@ class UACTimeout(View):
 class SaveAndExitEN(View):
     @aiohttp_jinja2.template('save-and-exit.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/save-and-exit')
         self._request = request
         await forget(request)
         return {
@@ -1466,9 +1411,7 @@ class SaveAndExitEN(View):
 class SaveAndExitCY(View):
     @aiohttp_jinja2.template('save-and-exit.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/save-and-exit')
         self._request = request
         await forget(request)
         return {
@@ -1483,9 +1426,7 @@ class SaveAndExitCY(View):
 class SaveAndExitNI(View):
     @aiohttp_jinja2.template('save-and-exit.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/save-and-exit')
         self._request = request
         await forget(request)
         return {
@@ -1577,9 +1518,7 @@ class WebChat(View):
 class WebChatWindowEN(WebChat):
     @aiohttp_jinja2.template('webchat-window.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'webchat/chat')
         return {
             'display_region': 'en',
             'domain_url_en': self._domain_url_en,
@@ -1592,9 +1531,7 @@ class WebChatWindowEN(WebChat):
 class WebChatWindowCY(WebChat):
     @aiohttp_jinja2.template('webchat-window.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'webchat/chat')
         return {
             'display_region': 'cy',
             'locale': 'cy',
@@ -1608,9 +1545,7 @@ class WebChatWindowCY(WebChat):
 class WebChatWindowNI(WebChat):
     @aiohttp_jinja2.template('webchat-window.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'webchat/chat')
         return {
             'display_region': 'ni',
             'domain_url_en': self._domain_url_en,
@@ -1623,9 +1558,7 @@ class WebChatWindowNI(WebChat):
 class WebChatEN(WebChat):
     @aiohttp_jinja2.template('webchat-form.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'webchat')
         self._request = request
         logger.info('date/time check', client_ip=self._client_ip)
         if WebChat.check_open():
@@ -1653,9 +1586,7 @@ class WebChatEN(WebChat):
 
     @aiohttp_jinja2.template('webchat-form.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'webchat')
         data = await request.post()
         self._request = request
 
@@ -1710,9 +1641,7 @@ class WebChatEN(WebChat):
 class WebChatCY(WebChat):
     @aiohttp_jinja2.template('webchat-form.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'webchat')
         self._request = request
         logger.info('date/time check', client_ip=self._client_ip)
         if WebChat.check_open():
@@ -1742,9 +1671,7 @@ class WebChatCY(WebChat):
 
     @aiohttp_jinja2.template('webchat-form.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'webchat')
         data = await request.post()
         self._request = request
 
@@ -1802,9 +1729,7 @@ class WebChatCY(WebChat):
 class WebChatNI(WebChat):
     @aiohttp_jinja2.template('webchat-form.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'webchat')
         self._request = request
         logger.info('date/time check', client_ip=self._client_ip)
         if WebChat.check_open():
@@ -1832,9 +1757,7 @@ class WebChatNI(WebChat):
 
     @aiohttp_jinja2.template('webchat-form.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'webchat')
         data = await request.post()
         self._request = request
 
@@ -1954,10 +1877,6 @@ class RequestCodeCommon(View):
 
     async def get_postcode(self, request, data, fulfillment_type,
                            display_region, locale):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
-
         if RequestCodeCommon.postcode_validation_pattern.fullmatch(
                 data['request-postcode'].upper()):
 
@@ -1990,10 +1909,6 @@ class RequestCodeCommon(View):
                                          ':get'].url_for())
 
     async def post_enter_mobile(self, attributes, data, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
-
         if RequestCodeCommon.mobile_validation_pattern.fullmatch(
                 data['request-mobile-number']):
 
@@ -2075,9 +1990,7 @@ class RequestCodeCommon(View):
 class RequestCodeHouseholdEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-household.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code')
         self._request = request
         return {
             'display_region': 'en',
@@ -2091,9 +2004,7 @@ class RequestCodeHouseholdEN(RequestCodeCommon):
 class RequestCodeHouseholdCY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-household.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code')
         self._request = request
         return {
             'display_region': 'cy',
@@ -2108,9 +2019,7 @@ class RequestCodeHouseholdCY(RequestCodeCommon):
 class RequestCodeHouseholdNI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-household.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code')
         self._request = request
         return {
             'display_region': 'ni',
@@ -2124,9 +2033,7 @@ class RequestCodeHouseholdNI(RequestCodeCommon):
 class RequestCodeEnterAddressHHEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-enter-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/enter-address')
         self._request = request
         return {
             'display_region': 'en',
@@ -2137,9 +2044,7 @@ class RequestCodeEnterAddressHHEN(RequestCodeCommon):
 
     @aiohttp_jinja2.template('request-code-enter-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/enter-address')
         self._request = request
         data = await self._request.post()
         await RequestCodeCommon.get_postcode(self, request, data, 'HH', 'EN',
@@ -2150,9 +2055,7 @@ class RequestCodeEnterAddressHHEN(RequestCodeCommon):
 class RequestCodeEnterAddressHHCY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-enter-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/enter-address')
         self._request = request
         return {
             'display_region': 'cy',
@@ -2164,9 +2067,7 @@ class RequestCodeEnterAddressHHCY(RequestCodeCommon):
 
     @aiohttp_jinja2.template('request-code-enter-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/enter-address')
         self._request = request
         data = await self._request.post()
         await RequestCodeCommon.get_postcode(self, request, data, 'HH', 'CY',
@@ -2177,9 +2078,7 @@ class RequestCodeEnterAddressHHCY(RequestCodeCommon):
 class RequestCodeEnterAddressHHNI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-enter-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/enter-address')
         self._request = request
         return {
             'display_region': 'ni',
@@ -2190,9 +2089,7 @@ class RequestCodeEnterAddressHHNI(RequestCodeCommon):
 
     @aiohttp_jinja2.template('request-code-enter-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/enter-address')
         self._request = request
         data = await self._request.post()
         await RequestCodeCommon.get_postcode(self, request, data, 'HH', 'NI',
@@ -2203,9 +2100,7 @@ class RequestCodeEnterAddressHHNI(RequestCodeCommon):
 class RequestCodeSelectAddressHHEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-select-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/select-address')
         attributes = await self.get_check_attributes(request, 'HH', 'EN')
         address_content = await self.get_postcode_return(
             attributes['postcode'], attributes['fulfillment_type'],
@@ -2215,9 +2110,7 @@ class RequestCodeSelectAddressHHEN(RequestCodeCommon):
 
     @aiohttp_jinja2.template('request-code-select-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/select-address')
         attributes = await self.get_check_attributes(request, 'HH', 'EN')
         data = await request.post()
 
@@ -2246,9 +2139,7 @@ class RequestCodeSelectAddressHHEN(RequestCodeCommon):
 class RequestCodeSelectAddressHHCY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-select-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/select-address')
         attributes = await self.get_check_attributes(request, 'HH', 'CY')
         address_content = await self.get_postcode_return(
             attributes['postcode'], attributes['fulfillment_type'],
@@ -2258,9 +2149,7 @@ class RequestCodeSelectAddressHHCY(RequestCodeCommon):
 
     @aiohttp_jinja2.template('request-code-select-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/select-address')
         attributes = await self.get_check_attributes(request, 'HH', 'CY')
         data = await request.post()
 
@@ -2289,9 +2178,7 @@ class RequestCodeSelectAddressHHCY(RequestCodeCommon):
 class RequestCodeSelectAddressHHNI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-select-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/select-address')
         attributes = await self.get_check_attributes(request, 'HH', 'NI')
         address_content = await self.get_postcode_return(
             attributes['postcode'], attributes['fulfillment_type'],
@@ -2301,9 +2188,7 @@ class RequestCodeSelectAddressHHNI(RequestCodeCommon):
 
     @aiohttp_jinja2.template('request-code-select-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/select-address')
         attributes = await self.get_check_attributes(request, 'HH', 'NI')
         data = await request.post()
 
@@ -2332,18 +2217,14 @@ class RequestCodeSelectAddressHHNI(RequestCodeCommon):
 class RequestCodeConfirmAddressHHEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-confirm-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/confirm-address')
         attributes = await self.get_check_attributes(request, 'HH', 'EN')
         attributes['page_title'] = 'Is this address correct?'
         return attributes
 
     @aiohttp_jinja2.template('request-code-confirm-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/confirm-address')
         attributes = await self.get_check_attributes(request, 'HH', 'EN')
         attributes['page_title'] = 'Is this address correct?'
         data = await request.post()
@@ -2397,18 +2278,14 @@ class RequestCodeConfirmAddressHHEN(RequestCodeCommon):
 class RequestCodeConfirmAddressHHCY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-confirm-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/confirm-address')
         attributes = await self.get_check_attributes(request, 'HH', 'CY')
         attributes['page_title'] = "Ydy'r cyfeiriad hwn yn gywir?"
         return attributes
 
     @aiohttp_jinja2.template('request-code-confirm-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/confirm-address')
         attributes = await self.get_check_attributes(request, 'HH', 'CY')
         attributes['page_title'] = "Ydy'r cyfeiriad hwn yn gywir?"
         data = await request.post()
@@ -2462,18 +2339,14 @@ class RequestCodeConfirmAddressHHCY(RequestCodeCommon):
 class RequestCodeConfirmAddressHHNI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-confirm-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/confirm-address')
         attributes = await self.get_check_attributes(request, 'HH', 'NI')
         attributes['page_title'] = 'Is this address correct?'
         return attributes
 
     @aiohttp_jinja2.template('request-code-confirm-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/confirm-address')
         attributes = await self.get_check_attributes(request, 'HH', 'NI')
         attributes['page_title'] = 'Is this address correct?'
         data = await request.post()
@@ -2526,9 +2399,7 @@ class RequestCodeConfirmAddressHHNI(RequestCodeCommon):
 class RequestCodeNotRequiredHHEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-not-required.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/not-required')
         attributes = await self.get_check_attributes(request, 'HH', 'EN')
         attributes[
             'page_title'] = 'Your address is not part of the 2019 rehearsal'
@@ -2539,9 +2410,7 @@ class RequestCodeNotRequiredHHEN(RequestCodeCommon):
 class RequestCodeNotRequiredHHCY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-not-required.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/not-required')
         attributes = await self.get_check_attributes(request, 'HH', 'CY')
         attributes[
             'page_title'] = 'Nid yw eich cyfeiriad yn rhan o ymarfer 2019'
@@ -2552,9 +2421,7 @@ class RequestCodeNotRequiredHHCY(RequestCodeCommon):
 class RequestCodeNotRequiredHHNI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-not-required.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/not-required')
         attributes = await self.get_check_attributes(request, 'HH', 'NI')
         attributes[
             'page_title'] = 'Your address is not part of the 2019 rehearsal'
@@ -2565,18 +2432,14 @@ class RequestCodeNotRequiredHHNI(RequestCodeCommon):
 class RequestCodeEnterMobileHHEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-enter-mobile.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/enter-mobile')
         attributes = await self.get_check_attributes(request, 'HH', 'EN')
         attributes['page_title'] = 'What is your mobile phone number?'
         return attributes
 
     @aiohttp_jinja2.template('request-code-enter-mobile.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/enter-mobile')
         attributes = await self.get_check_attributes(request, 'HH', 'EN')
         attributes['page_title'] = 'What is your mobile phone number?'
         data = await request.post()
@@ -2588,18 +2451,14 @@ class RequestCodeEnterMobileHHEN(RequestCodeCommon):
 class RequestCodeEnterMobileHHCY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-enter-mobile.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/enter-mobile')
         attributes = await self.get_check_attributes(request, 'HH', 'CY')
         attributes['page_title'] = 'Beth yw eich rhif ffôn symudol?'
         return attributes
 
     @aiohttp_jinja2.template('request-code-enter-mobile.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/enter-mobile')
         attributes = await self.get_check_attributes(request, 'HH', 'CY')
         attributes['page_title'] = 'Beth yw eich rhif ffôn symudol?'
         data = await request.post()
@@ -2611,18 +2470,14 @@ class RequestCodeEnterMobileHHCY(RequestCodeCommon):
 class RequestCodeEnterMobileHHNI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-enter-mobile.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/enter-mobile')
         attributes = await self.get_check_attributes(request, 'HH', 'NI')
         attributes['page_title'] = 'What is your mobile phone number?'
         return attributes
 
     @aiohttp_jinja2.template('request-code-enter-mobile.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/enter-mobile')
         attributes = await self.get_check_attributes(request, 'HH', 'NI')
         attributes['page_title'] = 'What is your mobile phone number?'
         data = await request.post()
@@ -2634,18 +2489,14 @@ class RequestCodeEnterMobileHHNI(RequestCodeCommon):
 class RequestCodeConfirmMobileHHEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-confirm-mobile.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/confirm-mobile')
         attributes = await self.get_check_attributes(request, 'HH', 'EN')
         attributes['page_title'] = 'Is this mobile phone number correct?'
         return attributes
 
     @aiohttp_jinja2.template('request-code-confirm-mobile.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/confirm-mobile')
         attributes = await self.get_check_attributes(request, 'HH', 'EN')
         attributes['page_title'] = 'Is this mobile phone number correct?'
         data = await request.post()
@@ -2698,18 +2549,14 @@ class RequestCodeConfirmMobileHHEN(RequestCodeCommon):
 class RequestCodeConfirmMobileHHCY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-confirm-mobile.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/confirm-mobile')
         attributes = await self.get_check_attributes(request, 'HH', 'CY')
         attributes['page_title'] = "Ydy'r rhif ffôn symudol hwn yn gywir?"
         return attributes
 
     @aiohttp_jinja2.template('request-code-confirm-mobile.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/confirm-mobile')
         attributes = await self.get_check_attributes(request, 'HH', 'CY')
         attributes['page_title'] = "Ydy'r rhif ffôn symudol hwn yn gywir?"
         data = await request.post()
@@ -2763,18 +2610,14 @@ class RequestCodeConfirmMobileHHCY(RequestCodeCommon):
 class RequestCodeConfirmMobileHHNI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-confirm-mobile.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/confirm-mobile')
         attributes = await self.get_check_attributes(request, 'HH', 'NI')
         attributes['page_title'] = 'Is this mobile phone number correct?'
         return attributes
 
     @aiohttp_jinja2.template('request-code-confirm-mobile.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/confirm-mobile')
         attributes = await self.get_check_attributes(request, 'HH', 'NI')
         attributes['page_title'] = 'Is this mobile phone number correct?'
         data = await request.post()
@@ -2828,9 +2671,7 @@ class RequestCodeConfirmMobileHHNI(RequestCodeCommon):
 class RequestCodeCodeSentHHEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-code-sent.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/code-sent')
         attributes = await self.get_check_attributes(request, 'HH', 'EN')
         attributes['page_title'] = 'We have sent an access code'
         return attributes
@@ -2840,9 +2681,7 @@ class RequestCodeCodeSentHHEN(RequestCodeCommon):
 class RequestCodeCodeSentHHCY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-code-sent.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/code-sent')
         attributes = await self.get_check_attributes(request, 'HH', 'CY')
         attributes['page_title'] = 'Rydym ni wedi anfon cod mynediad'
         return attributes
@@ -2852,9 +2691,7 @@ class RequestCodeCodeSentHHCY(RequestCodeCommon):
 class RequestCodeCodeSentHHNI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-code-sent.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/code-sent')
         attributes = await self.get_check_attributes(request, 'HH', 'NI')
         attributes['page_title'] = 'We have sent an access code'
         return attributes
@@ -2864,9 +2701,7 @@ class RequestCodeCodeSentHHNI(RequestCodeCommon):
 class RequestCodeTimeoutHHEN(RequestCodeCommon):
     @aiohttp_jinja2.template('timeout.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/timeout')
         self._request = request
         return {
             'fulfillment_type': 'HH',
@@ -2881,33 +2716,23 @@ class RequestCodeTimeoutHHEN(RequestCodeCommon):
 class RequestCodeTimeoutHHCY(RequestCodeCommon):
     @aiohttp_jinja2.template('timeout.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/timeout')
         self._request = request
         return {
-            'fulfillment_type':
-            'HH',
-            'display_region':
-            'cy',
-            'locale':
-            'cy',
-            'domain_url_en':
-            self._domain_url_en,
-            'domain_url_cy':
-            self._domain_url_cy,
-            'page_title':
-            'Mae eich sesiwn wedi cyrraedd y terfyn amser oherwydd anweithgarwch'
-        }
+            'fulfillment_type': 'HH',
+            'display_region': 'cy',
+            'locale': 'cy',
+            'domain_url_en': self._domain_url_en,
+            'domain_url_cy': self._domain_url_cy,
+            'page_title': 'Mae eich sesiwn wedi cyrraedd y terfyn amser oherwydd anweithgarwch',
+        } # yapf: disable
 
 
 @routes.view('/ni/request-access-code/timeout')
 class RequestCodeTimeoutHHNI(RequestCodeCommon):
     @aiohttp_jinja2.template('timeout.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-access-code/timeout')
         self._request = request
         return {
             'fulfillment_type': 'HH',
@@ -2922,9 +2747,7 @@ class RequestCodeTimeoutHHNI(RequestCodeCommon):
 class RequestCodeIndividualEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-individual.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code')
         self._request = request
         return {
             'display_region': 'en',
@@ -2938,9 +2761,7 @@ class RequestCodeIndividualEN(RequestCodeCommon):
 class RequestCodeIndividualCY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-individual.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code')
         self._request = request
         return {
             'display_region': 'cy',
@@ -2955,9 +2776,7 @@ class RequestCodeIndividualCY(RequestCodeCommon):
 class RequestCodeIndividualNI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-individual.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code')
         self._request = request
         return {
             'display_region': 'ni',
@@ -2971,9 +2790,7 @@ class RequestCodeIndividualNI(RequestCodeCommon):
 class RequestCodeEnterAddressHIEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-enter-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/enter-address')
         self._request = request
         return {
             'fulfillment_type': 'HI',
@@ -2985,9 +2802,7 @@ class RequestCodeEnterAddressHIEN(RequestCodeCommon):
 
     @aiohttp_jinja2.template('request-code-enter-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/enter-address')
         self._request = request
         data = await self._request.post()
         await RequestCodeCommon.get_postcode(self, request, data, 'HI', 'EN',
@@ -2998,9 +2813,7 @@ class RequestCodeEnterAddressHIEN(RequestCodeCommon):
 class RequestCodeEnterAddressHICY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-enter-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/enter-address')
         self._request = request
         return {
             'fulfillment_type': 'HI',
@@ -3013,9 +2826,7 @@ class RequestCodeEnterAddressHICY(RequestCodeCommon):
 
     @aiohttp_jinja2.template('request-code-enter-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/enter-address')
         self._request = request
         data = await self._request.post()
         await RequestCodeCommon.get_postcode(self, request, data, 'HI', 'CY',
@@ -3026,9 +2837,7 @@ class RequestCodeEnterAddressHICY(RequestCodeCommon):
 class RequestCodeEnterAddressHINI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-enter-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/enter-address')
         self._request = request
         return {
             'fulfillment_type': 'HI',
@@ -3040,9 +2849,7 @@ class RequestCodeEnterAddressHINI(RequestCodeCommon):
 
     @aiohttp_jinja2.template('request-code-enter-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/enter-address')
         self._request = request
         data = await self._request.post()
         await RequestCodeCommon.get_postcode(self, request, data, 'HI', 'NI',
@@ -3053,9 +2860,7 @@ class RequestCodeEnterAddressHINI(RequestCodeCommon):
 class RequestCodeSelectAddressHIEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-select-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/select-address')
         attributes = await self.get_check_attributes(request, 'HI', 'EN')
         address_content = await self.get_postcode_return(
             attributes['postcode'], attributes['fulfillment_type'],
@@ -3065,9 +2870,7 @@ class RequestCodeSelectAddressHIEN(RequestCodeCommon):
 
     @aiohttp_jinja2.template('request-code-select-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/select-address')
         attributes = await self.get_check_attributes(request, 'HI', 'EN')
         data = await request.post()
 
@@ -3096,9 +2899,7 @@ class RequestCodeSelectAddressHIEN(RequestCodeCommon):
 class RequestCodeSelectAddressHICY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-select-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/select-address')
         attributes = await self.get_check_attributes(request, 'HI', 'CY')
         address_content = await self.get_postcode_return(
             attributes['postcode'], attributes['fulfillment_type'],
@@ -3108,9 +2909,7 @@ class RequestCodeSelectAddressHICY(RequestCodeCommon):
 
     @aiohttp_jinja2.template('request-code-select-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/select-address')
         attributes = await self.get_check_attributes(request, 'HI', 'CY')
         data = await request.post()
 
@@ -3139,9 +2938,7 @@ class RequestCodeSelectAddressHICY(RequestCodeCommon):
 class RequestCodeSelectAddressHINI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-select-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/select-address')
         attributes = await self.get_check_attributes(request, 'HI', 'NI')
         address_content = await self.get_postcode_return(
             attributes['postcode'], attributes['fulfillment_type'],
@@ -3151,9 +2948,7 @@ class RequestCodeSelectAddressHINI(RequestCodeCommon):
 
     @aiohttp_jinja2.template('request-code-select-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/select-address')
         attributes = await self.get_check_attributes(request, 'HI', 'NI')
         data = await request.post()
 
@@ -3182,18 +2977,14 @@ class RequestCodeSelectAddressHINI(RequestCodeCommon):
 class RequestCodeConfirmAddressHIEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-confirm-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/confirm-address')
         attributes = await self.get_check_attributes(request, 'HI', 'EN')
         attributes['page_title'] = 'Is this address correct?'
         return attributes
 
     @aiohttp_jinja2.template('request-code-confirm-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/confirm-address')
         attributes = await self.get_check_attributes(request, 'HI', 'EN')
         attributes['page_title'] = 'Is this address correct?'
         data = await request.post()
@@ -3246,18 +3037,14 @@ class RequestCodeConfirmAddressHIEN(RequestCodeCommon):
 class RequestCodeConfirmAddressHICY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-confirm-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/confirm-address')
         attributes = await self.get_check_attributes(request, 'HI', 'CY')
         attributes['page_title'] = "Ydy'r cyfeiriad hwn yn gywir?"
         return attributes
 
     @aiohttp_jinja2.template('request-code-confirm-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/confirm-address')
         attributes = await self.get_check_attributes(request, 'HI', 'CY')
         attributes['page_title'] = "Ydy'r cyfeiriad hwn yn gywir?"
         data = await request.post()
@@ -3310,18 +3097,14 @@ class RequestCodeConfirmAddressHICY(RequestCodeCommon):
 class RequestCodeConfirmAddressHINI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-confirm-address.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/confirm-address')
         attributes = await self.get_check_attributes(request, 'HI', 'NI')
         attributes['page_title'] = 'Is this address correct?'
         return attributes
 
     @aiohttp_jinja2.template('request-code-confirm-address.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/confirm-address')
         attributes = await self.get_check_attributes(request, 'HI', 'NI')
         attributes['page_title'] = 'Is this address correct?'
         data = await request.post()
@@ -3374,9 +3157,7 @@ class RequestCodeConfirmAddressHINI(RequestCodeCommon):
 class RequestCodeNotRequiredHIEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-not-required.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/not-required')
         attributes = await self.get_check_attributes(request, 'HI', 'EN')
         attributes[
             'page_title'] = 'Your address is not part of the 2019 rehearsal'
@@ -3387,9 +3168,7 @@ class RequestCodeNotRequiredHIEN(RequestCodeCommon):
 class RequestCodeNotRequiredHICY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-not-required.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/not-required')
         attributes = await self.get_check_attributes(request, 'HI', 'CY')
         attributes[
             'page_title'] = 'Nid yw eich cyfeiriad yn rhan o ymarfer 2019'
@@ -3400,9 +3179,7 @@ class RequestCodeNotRequiredHICY(RequestCodeCommon):
 class RequestCodeNotRequiredHINI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-not-required.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/not-required')
         attributes = await self.get_check_attributes(request, 'HI', 'NI')
         attributes[
             'page_title'] = 'Your address is not part of the 2019 rehearsal'
@@ -3413,18 +3190,14 @@ class RequestCodeNotRequiredHINI(RequestCodeCommon):
 class RequestCodeEnterMobileHIEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-enter-mobile.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/enter-mobile')
         attributes = await self.get_check_attributes(request, 'HI', 'EN')
         attributes['page_title'] = 'What is your mobile phone number?'
         return attributes
 
     @aiohttp_jinja2.template('request-code-enter-mobile.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/enter-mobile')
         attributes = await self.get_check_attributes(request, 'HI', 'EN')
         attributes['page_title'] = 'What is your mobile phone number?'
         data = await request.post()
@@ -3436,18 +3209,14 @@ class RequestCodeEnterMobileHIEN(RequestCodeCommon):
 class RequestCodeEnterMobileHICY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-enter-mobile.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/enter-mobile')
         attributes = await self.get_check_attributes(request, 'HI', 'CY')
         attributes['page_title'] = 'Beth yw eich rhif ffôn symudol?'
         return attributes
 
     @aiohttp_jinja2.template('request-code-enter-mobile.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/enter-mobile')
         attributes = await self.get_check_attributes(request, 'HI', 'CY')
         attributes['page_title'] = 'Beth yw eich rhif ffôn symudol?'
         data = await request.post()
@@ -3459,18 +3228,14 @@ class RequestCodeEnterMobileHICY(RequestCodeCommon):
 class RequestCodeEnterMobileHINI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-enter-mobile.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/enter-mobile')
         attributes = await self.get_check_attributes(request, 'HI', 'NI')
         attributes['page_title'] = 'What is your mobile phone number?'
         return attributes
 
     @aiohttp_jinja2.template('request-code-enter-mobile.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/enter-mobile')
         attributes = await self.get_check_attributes(request, 'HI', 'NI')
         attributes['page_title'] = 'What is your mobile phone number?'
         data = await request.post()
@@ -3482,18 +3247,14 @@ class RequestCodeEnterMobileHINI(RequestCodeCommon):
 class RequestCodeConfirmMobileHIEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-confirm-mobile.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/confirm-mobile')
         attributes = await self.get_check_attributes(request, 'HI', 'EN')
         attributes['page_title'] = 'Is this mobile phone number correct?'
         return attributes
 
     @aiohttp_jinja2.template('request-code-confirm-mobile.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/confirm-mobile')
         attributes = await self.get_check_attributes(request, 'HI', 'EN')
         attributes['page_title'] = 'Is this mobile phone number correct?'
         data = await request.post()
@@ -3547,18 +3308,14 @@ class RequestCodeConfirmMobileHIEN(RequestCodeCommon):
 class RequestCodeConfirmMobileHICY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-confirm-mobile.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/confirm-mobile')
         attributes = await self.get_check_attributes(request, 'HI', 'CY')
         attributes['page_title'] = "Ydy'r rhif ffôn symudol hwn yn gywir?"
         return attributes
 
     @aiohttp_jinja2.template('request-code-confirm-mobile.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/confirm-mobile')
         attributes = await self.get_check_attributes(request, 'HI', 'CY')
         attributes['page_title'] = "Ydy'r rhif ffôn symudol hwn yn gywir?"
         data = await request.post()
@@ -3612,18 +3369,14 @@ class RequestCodeConfirmMobileHICY(RequestCodeCommon):
 class RequestCodeConfirmMobileHINI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-confirm-mobile.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/confirm-mobile')
         attributes = await self.get_check_attributes(request, 'HI', 'NI')
         attributes['page_title'] = 'Is this mobile phone number correct?'
         return attributes
 
     @aiohttp_jinja2.template('request-code-confirm-mobile.html')
     async def post(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/confirm-mobile')
         attributes = await self.get_check_attributes(request, 'HI', 'NI')
         attributes['page_title'] = 'Is this mobile phone number correct?'
         data = await request.post()
@@ -3677,9 +3430,7 @@ class RequestCodeConfirmMobileHINI(RequestCodeCommon):
 class RequestCodeCodeSentHIEN(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-code-sent.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/code-sent')
         attributes = await self.get_check_attributes(request, 'HI', 'EN')
         attributes['page_title'] = 'We have sent an access code'
         return attributes
@@ -3689,9 +3440,7 @@ class RequestCodeCodeSentHIEN(RequestCodeCommon):
 class RequestCodeCodeSentHICY(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-code-sent.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/code-sent')
         attributes = await self.get_check_attributes(request, 'HI', 'CY')
         attributes['page_title'] = 'Rydym ni wedi anfon cod mynediad'
         return attributes
@@ -3701,9 +3450,7 @@ class RequestCodeCodeSentHICY(RequestCodeCommon):
 class RequestCodeCodeSentHINI(RequestCodeCommon):
     @aiohttp_jinja2.template('request-code-code-sent.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/code-sent')
         attributes = await self.get_check_attributes(request, 'HI', 'NI')
         attributes['page_title'] = 'We have sent an access code'
         return attributes
@@ -3713,9 +3460,7 @@ class RequestCodeCodeSentHINI(RequestCodeCommon):
 class RequestCodeTimeoutHIEN(RequestCodeCommon):
     @aiohttp_jinja2.template('timeout.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/timeout')
         self._request = request
         return {
             'fulfillment_type': 'HI',
@@ -3730,33 +3475,23 @@ class RequestCodeTimeoutHIEN(RequestCodeCommon):
 class RequestCodeTimeoutHICY(RequestCodeCommon):
     @aiohttp_jinja2.template('timeout.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/timeout')
         self._request = request
         return {
-            'fulfillment_type':
-            'HI',
-            'display_region':
-            'cy',
-            'locale':
-            'cy',
-            'domain_url_en':
-            self._domain_url_en,
-            'domain_url_cy':
-            self._domain_url_cy,
-            'page_title':
-            'Mae eich sesiwn wedi cyrraedd y terfyn amser oherwydd anweithgarwch'
-        }
+            'fulfillment_type': 'HI',
+            'display_region': 'cy',
+            'locale': 'cy',
+            'domain_url_en': self._domain_url_en,
+            'domain_url_cy': self._domain_url_cy,
+            'page_title': 'Mae eich sesiwn wedi cyrraedd y terfyn amser oherwydd anweithgarwch',
+        } # yapf: disable
 
 
 @routes.view('/ni/request-individual-code/timeout')
 class RequestCodeTimeoutHINI(RequestCodeCommon):
     @aiohttp_jinja2.template('timeout.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'request-individual-code/timeout')
         self._request = request
         return {
             'fulfillment_type': 'HI',
@@ -3771,9 +3506,7 @@ class RequestCodeTimeoutHINI(RequestCodeCommon):
 class AccessibilityEN(RequestCodeCommon):
     @aiohttp_jinja2.template('accessibility.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/accessibility')
         self._request = request
         return {
             'display_region': 'en',
@@ -3787,9 +3520,7 @@ class AccessibilityEN(RequestCodeCommon):
 class AccessibilityCY(RequestCodeCommon):
     @aiohttp_jinja2.template('accessibility.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/accessibility')
         self._request = request
         return {
             'display_region': 'cy',
@@ -3804,9 +3535,7 @@ class AccessibilityCY(RequestCodeCommon):
 class AccessibilityNI(RequestCodeCommon):
     @aiohttp_jinja2.template('accessibility.html')
     async def get(self, request):
-        logger.info('entered endpoint',
-                    method=request.method,
-                    path=request.path)
+        self.log_entry(request, 'start/accessibility')
         self._request = request
         return {
             'display_region': 'ni',


### PR DESCRIPTION
# Motivation and Context
Messages logged while hitting endpoints now use a custom endpoint name that is language-agnostic. They now store this endpoint and the method in the `event` of the JSON.

# What has changed
Minor refactor of two dictionaries.
Every endpoint now uses a refactored function call, except `/info`.
All endpoints now have a language-agnostic name.

# How to test?
Unit tests run. Visual inspection of logs when endpoints are hit was performed.

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-531