### PR TITLE
Complete replacement of instance variables with request local variables

### DIFF
--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -2858,7 +2858,7 @@ class TestHandlers(RHTestCase):
         post_data = {'uac': 'w4nw wpph jjpt p7fn', 'action[save_continue]': ''}
 
         # When join_uac is called
-        result = IndexEN.uac_hash(post_data)
+        result = IndexEN.uac_hash(post_data['uac'])
 
         # Then a single string built from the uac values is returned
         self.assertEqual(result, '8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4')
@@ -2868,7 +2868,7 @@ class TestHandlers(RHTestCase):
         post_data = {'uac': 'w4nw wpph jjpt p7fn', 'action[save_continue]': ''}
 
         # When join_uac is called
-        result = IndexCY.uac_hash(post_data)
+        result = IndexCY.uac_hash(post_data['uac'])
 
         # Then a single string built from the uac values is returned
         self.assertEqual(result, '8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4')
@@ -2878,7 +2878,7 @@ class TestHandlers(RHTestCase):
         post_data = {'uac': 'w4nw wpph jjpt p7fn', 'action[save_continue]': ''}
 
         # When join_uac is called
-        result = IndexNI.uac_hash(post_data)
+        result = IndexNI.uac_hash(post_data['uac'])
 
         # Then a single string built from the uac values is returned
         self.assertEqual(result, '8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4')
@@ -2889,7 +2889,7 @@ class TestHandlers(RHTestCase):
 
         # When join_uac is called
         with self.assertRaises(TypeError):
-            IndexEN.uac_hash(post_data)
+            IndexEN.uac_hash(post_data['uac'])
         # Then a TypeError is raised
 
     def test_join_uac_missing_cy(self):
@@ -2898,7 +2898,7 @@ class TestHandlers(RHTestCase):
 
         # When join_uac is called
         with self.assertRaises(TypeError):
-            IndexCY.uac_hash(post_data)
+            IndexCY.uac_hash(post_data['uac'])
         # Then a TypeError is raised
 
     def test_join_uac_missing_ni(self):
@@ -2907,7 +2907,7 @@ class TestHandlers(RHTestCase):
 
         # When join_uac is called
         with self.assertRaises(TypeError):
-            IndexNI.uac_hash(post_data)
+            IndexNI.uac_hash(post_data['uac'])
         # Then a TypeError is raised
 
     def test_join_uac_some_missing_en(self):
@@ -2916,7 +2916,7 @@ class TestHandlers(RHTestCase):
 
         # When join_uac is called
         with self.assertRaises(TypeError):
-            IndexEN.uac_hash(post_data)
+            IndexEN.uac_hash(post_data['uac'])
         # Then a TypeError is raised
 
     def test_join_uac_some_missing_cy(self):
@@ -2925,7 +2925,7 @@ class TestHandlers(RHTestCase):
 
         # When join_uac is called
         with self.assertRaises(TypeError):
-            IndexCY.uac_hash(post_data)
+            IndexCY.uac_hash(post_data['uac'])
         # Then a TypeError is raised
 
     def test_join_uac_some_missing_ni(self):
@@ -2934,7 +2934,7 @@ class TestHandlers(RHTestCase):
 
         # When join_uac is called
         with self.assertRaises(TypeError):
-            IndexNI.uac_hash(post_data)
+            IndexNI.uac_hash(post_data['uac'])
         # Then a TypeError is raised
 
     def test_validate_case_en(self):


### PR DESCRIPTION
# Motivation and Context
Solves potential high-load race-conditions and associated badness.

# What has changed
One variable `self._request` has been replaced with direct argument passing.
One variable `self._client_ip` has been moved into `request['client_ip']`
One variable `self._sample_unit_id` has been fully removed.
A refactor of `_make_request` has been performed, to use defaulted keyword arguments instead of named tuples.

# How to test?
Full manual test of all pages, focussing on ensuring that external requests through `_make_request` have not stopped working, and basic assurance that no pages violently error due to missing variables.

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-527

# Screenshots (if appropriate):