### PR TITLE
Updates to postcode and mobile number validations to cope with leadin…

### DIFF
--- a/app/handlers.py
+++ b/app/handlers.py
@@ -1891,13 +1891,15 @@ class RequestCodeCommon(View):
 
     async def get_postcode(self, request, data, fulfillment_type,
                            display_region, locale):
+        postcode_value = data['request-postcode'].upper().strip()
+        postcode_value = re.sub(' +', ' ', postcode_value)
         if RequestCodeCommon.postcode_validation_pattern.fullmatch(
-                data['request-postcode'].upper()):
+                postcode_value):
 
             logger.info('valid postcode', client_ip=request['client_ip'])
 
             attributes = {}
-            attributes['postcode'] = data['request-postcode'].upper()
+            attributes['postcode'] = postcode_value
             attributes['display_region'] = display_region.lower()
             attributes['locale'] = locale
             attributes['fulfillment_type'] = fulfillment_type
@@ -1923,10 +1925,14 @@ class RequestCodeCommon(View):
                                    ':get'].url_for())
 
     async def post_enter_mobile(self, request, attributes, data):
+        mobile_number = re.sub(' +', ' ', data['request-mobile-number'].strip())
         if RequestCodeCommon.mobile_validation_pattern.fullmatch(
-                data['request-mobile-number']):
+                mobile_number):
 
-            attributes['mobile_number'] = data['request-mobile-number']
+            logger.info('valid mobile number',
+                        client_ip=request['client_ip'])
+
+            attributes['mobile_number'] = mobile_number
             session = await get_session(request)
             session['attributes'] = attributes
 


### PR DESCRIPTION
…g/trailing/duplicate spaces

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Fix for CR546 and CR543, both caused by additional spaces in validations

# What has changed
CR543 - Spurious spaces in Postcodes - now strips leading and trailing spaces, and sets duplicates (within the postcode) to single spaces
CR546 - Spurious spaces in Mobile numbers - now strips leading and trailing spaces, and sets duplicates (within the mobile number) to single spaces

# How to test?
In UI use 'Request Access Hold' or 'Request Individual Code' journeys, and add unnecessary spaces in and around values for postcode and mobile number - values should be accepted and not return an error.

# Links

# Screenshots (if appropriate):