### PR TITLE
CR-553 Update to GTM codes, and removal of javascript nonce

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -98,8 +98,8 @@ class DevelopmentConfig:
 
     URL_PATH_PREFIX = env('URL_PATH_PREFIX', default='')
 
-    GTM_AUTH = env.str('GTM_AUTH', default='vuQRI_k4d1EW3h4EP_sXyw')
-    GTM_PREVIEW = env.str('GTM_PREVIEW', default='env-5')
+    GTM_AUTH = env.str('GTM_AUTH', default='QZTzNzZrlo_z0DCT4veo1A')
+    GTM_PREVIEW = env.str('GTM_PREVIEW', default='env-13')
     GTM_COOKIES_WIN = env.str('GTM_COOKIES_WIN', default='x')
 
     REDIS_SERVER = env('REDIS_SERVER', default='localhost')
@@ -135,8 +135,8 @@ class TestingConfig:
 
     URL_PATH_PREFIX = ''
 
-    GTM_AUTH = 'vuQRI_k4d1EW3h4EP_sXyw'
-    GTM_PREVIEW = 'env-5'
+    GTM_AUTH = 'QZTzNzZrlo_z0DCT4veo1A'
+    GTM_PREVIEW = 'env-13'
     GTM_COOKIES_WIN = 'x'
 
     REDIS_SERVER = ''

--- a/app/templates/partials/gtm-no-script.html
+++ b/app/templates/partials/gtm-no-script.html
@@ -1,4 +1,4 @@
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PR9MMKG&gtm_auth={{ gtm_auth }}&gtm_preview={{ gtm_preview }}&gtm_cookies_win={{ gtm_cookies_win }}"
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TLWR59T&gtm_auth={{ gtm_auth }}&gtm_preview={{ gtm_preview }}&gtm_cookies_win={{ gtm_cookies_win }}"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->

--- a/app/templates/partials/gtm.html
+++ b/app/templates/partials/gtm.html
@@ -1,12 +1,12 @@
 <!-- Google Tag Manager -->
-<script nonce="{{ request.csp_nonce }}">
+<script>
     var a = /^(.*)?\s*'usage':true\s*[^;]+(.*)?$/;
     if (document.cookie.match(a)) {
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth={{ gtm_auth }}&gtm_preview={{ gtm_preview }}&gtm_cookies_win={{ gtm_cookies_win }}';f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','GTM-PR9MMKG');
+        })(window,document,'script','dataLayer','GTM-TLWR59T');
     }
 </script>
 <!-- End Google Tag Manager -->


### PR DESCRIPTION
Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Changes to enable GTM tracking of RH

# What has changed
REmoved nonce from script block
Updated to new codes in call and config - additional changes need to be added to environment variables at rollout

# How to test?
To be tested by Andy Pitt in Whitelodge to confirm revisions have enabled GTM to function correctly

# Links
Source of new codes https://docs.google.com/document/d/1FsaWECKMrWCDA7M1JHC1c9SaDG0pvP5hKTokC2uYBa8

# Screenshots (if appropriate):