### PR TITLE
CR-686 Remove case state from RHUI

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -64,8 +64,7 @@ class TestRespondentHome(AioHTTPTestCase):
         logger.debug('successfully retrieved case',
                      sample_unit_id=sample_unit_id)
         for case in response.json():
-            if case['state'] == 'ACTIONABLE':
-                return case
+            return case
 
     def get_address_by_sample_unit_id(self, sample_unit_id):
         logger.debug('retrieving sample unit', sample_unit_id=sample_unit_id)


### PR DESCRIPTION
Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
RM is removing case[state]. Change removes reference in RHUI integration test

# What has changed
Removed if clause from integration test

# How to test?

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-686

# Screenshots (if appropriate):