### PR TITLE
CR 701 Change of Region notification

### DIFF
--- a/app/start_handlers.py
+++ b/app/start_handlers.py
@@ -262,7 +262,42 @@ class Start(StartCommon):
         if data.get('adlocation'):
             session['adlocation'] = data.get('adlocation')
 
-        raise HTTPFound(request.app.router['StartConfirmAddress:get'].url_for(display_region=display_region))
+        if session['case']['region'][0] == 'N':
+            if display_region == 'ni':
+                raise HTTPFound(request.app.router['StartConfirmAddress:get'].url_for(display_region=display_region))
+            else:
+                raise HTTPFound(request.app.router['StartRegionChange:get'].url_for(display_region='ni'))
+        elif session['case']['region'][0] == 'W':
+            if display_region == 'ni':
+                raise HTTPFound(request.app.router['StartRegionChange:get'].url_for(display_region='en'))
+            else:
+                raise HTTPFound(request.app.router['StartConfirmAddress:get'].url_for(display_region=display_region))
+        else:
+            if display_region == 'en':
+                raise HTTPFound(request.app.router['StartConfirmAddress:get'].url_for(display_region=display_region))
+            else:
+                raise HTTPFound(request.app.router['StartRegionChange:get'].url_for(display_region='en'))
+
+
+@start_routes.view(r'/' + View.valid_display_regions + '/start/region-change/')
+class StartRegionChange(StartCommon):
+    @aiohttp_jinja2.template('start-region-change.html')
+    async def get(self, request):
+        self.setup_request(request)
+        display_region = request.match_info['display_region']
+        self.log_entry(request, display_region + '/start/region-change')
+
+        await check_permission(request)
+
+        locale = 'en'
+        page_title = 'Change of region'
+
+        self.log_entry(request, 'start/region-change')
+        return {
+            'display_region': display_region,
+            'locale': locale,
+            'page_title': page_title
+        }
 
 
 @start_routes.view(r'/' + View.valid_display_regions + '/start/confirm-address/')

--- a/app/templates/start-region-change.html
+++ b/app/templates/start-region-change.html
@@ -1,0 +1,20 @@
+{% extends 'base-' + display_region + '.html' %}
+
+{% from 'components/button/_macro.njk' import onsButton %}
+
+{% block main %}
+
+    <h1 class="u-mb-l u-fs-xxl">{{ _('Change of region') }}</h1>
+
+    <p>Please note that the region display of the page has been changed to match your access code. This ensures that you are presented with the appropriate Census questions and options for your region.</p>
+
+    {{
+        onsButton({
+            'type': 'button',
+            'text': _('Continue'),
+            'classes': 'u-mb-m',
+            'url': url('StartConfirmAddress:get', display_region=display_region)
+        })
+    }}
+
+{% endblock %}

--- a/app/templates/start-region-change.html
+++ b/app/templates/start-region-change.html
@@ -4,7 +4,7 @@
 
 {% block main %}
 
-    <h1 class="u-mb-l u-fs-xxl">{{ _('Change of region') }}</h1>
+    <h1 class="u-mb-l u-fs-xxl">Change of region</h1>
 
     <p>Please note that the region display of the page has been changed to match your access code. This ensures that you are presented with the appropriate Census questions and options for your region.</p>
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -268,7 +268,7 @@ class RHTestCase(AioHTTPTestCase):
         self.get_start_adlocation_invalid_en = self.app.router['Start:get'].url_for(display_region='en').with_query(
             {"adlocation": "invalid"})
         self.post_start_en = self.app.router['Start:post'].url_for(display_region='en')
-
+        self.get_start_region_change_en = self.app.router['StartRegionChange:get'].url_for(display_region='en')
         self.get_start_confirm_address_en = self.app.router['StartConfirmAddress:get'].url_for(display_region='en')
         self.post_start_confirm_address_en = self.app.router['StartConfirmAddress:post'].url_for(display_region='en')
         self.get_start_modify_address_en = self.app.router['StartModifyAddress:get'].url_for(display_region='en')
@@ -281,7 +281,7 @@ class RHTestCase(AioHTTPTestCase):
         self.get_start_adlocation_invalid_cy = self.app.router['Start:get'].url_for(display_region='cy').with_query(
             {"adlocation": "invalid"})
         self.post_start_cy = self.app.router['Start:post'].url_for(display_region='cy')
-
+        self.get_start_region_change_cy = self.app.router['StartRegionChange:get'].url_for(display_region='cy')
         self.get_start_confirm_address_cy = self.app.router['StartConfirmAddress:get'].url_for(display_region='cy')
         self.post_start_confirm_address_cy = self.app.router['StartConfirmAddress:post'].url_for(display_region='cy')
         self.get_start_modify_address_cy = self.app.router['StartModifyAddress:get'].url_for(display_region='cy')
@@ -294,7 +294,7 @@ class RHTestCase(AioHTTPTestCase):
         self.get_start_adlocation_invalid_ni = self.app.router['Start:get'].url_for(display_region='ni').with_query(
             {"adlocation": "invalid"})
         self.post_start_ni = self.app.router['Start:post'].url_for(display_region='ni')
-
+        self.get_start_region_change_ni = self.app.router['StartRegionChange:get'].url_for(display_region='ni')
         self.get_start_confirm_address_ni = self.app.router['StartConfirmAddress:get'].url_for(display_region='ni')
         self.post_start_confirm_address_ni = self.app.router['StartConfirmAddress:post'].url_for(display_region='ni')
         self.get_start_modify_address_ni = self.app.router['StartModifyAddress:get'].url_for(display_region='ni')

--- a/tests/unit/test_start_handlers.py
+++ b/tests/unit/test_start_handlers.py
@@ -2629,3 +2629,108 @@ class TestStartHandlers(RHTestCase):
         self.assertIn('type="submit"', contents)
         self.assertNotIn('type="hidden"', contents)
         self.assertNotIn('value="invalid"', contents)
+
+    @unittest_run_loop
+    async def test_get_change_of_region(self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, aioresponses(passthrough=[str(self.server._root)])\
+                as mocked:
+            mocked.get(self.rhsvc_url, payload=self.uac_json_ni)
+
+            await self.client.request('GET', self.get_start_en)
+            self.assertLogEvent(cm, "received GET on endpoint 'en/start'")
+
+            await self.client.request('POST', self.post_start_en, allow_redirects=False, data=self.start_data_valid)
+            self.assertLogEvent(cm, "received POST on endpoint 'en/start'")
+
+            response = await self.client.request('GET', self.get_start_region_change_ni, allow_redirects=False, data=self.start_data_valid)
+            self.assertLogEvent(cm, "received GET on endpoint 'ni/start/region-change'")
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.nisra_logo, contents)
+            self.assertIn('Change of region', contents)
+
+    @unittest_run_loop
+    async def test_get_change_of_region_en_ni(self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, aioresponses(passthrough=[str(self.server._root)])\
+                as mocked:
+            mocked.get(self.rhsvc_url, payload=self.uac_json_ni)
+
+            await self.client.request('GET', self.get_start_en)
+            self.assertLogEvent(cm, "received GET on endpoint 'en/start'")
+
+            response = await self.client.request('POST', self.post_start_en, allow_redirects=False, data=self.start_data_valid)
+            self.assertLogEvent(cm, "received POST on endpoint 'en/start'")
+
+            self.assertIn('/ni/start/region-change/', response.headers['Location'])
+
+    @unittest_run_loop
+    async def test_get_change_of_region_cy_ni(self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, aioresponses(passthrough=[str(self.server._root)])\
+                as mocked:
+            mocked.get(self.rhsvc_url, payload=self.uac_json_ni)
+
+            await self.client.request('GET', self.get_start_cy)
+            self.assertLogEvent(cm, "received GET on endpoint 'cy/start'")
+
+            response = await self.client.request('POST',
+                                                 self.post_start_cy,
+                                                 allow_redirects=False,
+                                                 data=self.start_data_valid)
+
+        self.assertEqual(response.status, 302)
+        self.assertIn('/ni/start/region-change/',
+                      response.headers['Location'])
+
+    @unittest_run_loop
+    async def test_get_change_of_region_cy_en(self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, aioresponses(passthrough=[str(self.server._root)]) \
+                as mocked:
+            mocked.get(self.rhsvc_url, payload=self.uac_json_en)
+
+            await self.client.request('GET', self.get_start_cy)
+            self.assertLogEvent(cm, "received GET on endpoint 'cy/start'")
+
+            response = await self.client.request('POST',
+                                                 self.post_start_cy,
+                                                 allow_redirects=False,
+                                                 data=self.start_data_valid)
+
+        self.assertEqual(response.status, 302)
+        self.assertIn('/en/start/region-change/',
+                      response.headers['Location'])
+
+    @unittest_run_loop
+    async def test_get_change_of_region_ni_cy(self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, aioresponses(passthrough=[str(self.server._root)]) \
+                as mocked:
+            mocked.get(self.rhsvc_url, payload=self.uac_json_cy)
+
+            await self.client.request('GET', self.get_start_ni)
+            self.assertLogEvent(cm, "received GET on endpoint 'ni/start'")
+
+            response = await self.client.request('POST',
+                                                 self.post_start_ni,
+                                                 allow_redirects=False,
+                                                 data=self.start_data_valid)
+
+        self.assertEqual(response.status, 302)
+        self.assertIn('/en/start/region-change/',
+                      response.headers['Location'])
+
+    @unittest_run_loop
+    async def test_get_change_of_region_ni_en(self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, aioresponses(passthrough=[str(self.server._root)]) \
+                as mocked:
+            mocked.get(self.rhsvc_url, payload=self.uac_json_en)
+
+            await self.client.request('GET', self.get_start_ni)
+            self.assertLogEvent(cm, "received GET on endpoint 'ni/start'")
+
+            response = await self.client.request('POST',
+                                                 self.post_start_ni,
+                                                 allow_redirects=False,
+                                                 data=self.start_data_valid)
+
+        self.assertEqual(response.status, 302)
+        self.assertIn('/en/start/region-change/',
+                      response.headers['Location'])


### PR DESCRIPTION
# Motivation and Context
Add a new notification page informing the user that the url/design has been switched when the user enters a UAC with a region value that does not match the current 'display region' ie a NI UAC on the English url

# What has changed
Add new page, and logic to check if it should be displayed depending on current display_region and region value from the case for the UAC entered.

# How to test?
Unit tests are included.
To test manually, enter a ni UAC on the /en/start/ url - page should be displayed.
Requires an update to the RH Cucumber tests to deploy, which is also in review

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-701
https://github.com/ONSdigital/census-rh-cucumber/pull/54