### PR TITLE
CR-706 Add Language Switching to Fulfilments

### DIFF
--- a/app/requests_handlers.py
+++ b/app/requests_handlers.py
@@ -177,7 +177,8 @@ class RequestCode(RequestCommon):
             'locale': locale,
             'page_title': page_title,
             'request_type': request_type,
-            'partial_name': 'request-' + request_type + '-code'
+            'partial_name': 'request-' + request_type + '-code',
+            'page_url': '/requests/' + request_type + '-code/'
         }
 
 


### PR DESCRIPTION
Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Add language switching to fulfilments initial page

# What has changed
Language option now appears on household and individual request initial pages for England and Wales

# How to test?
Also has Cucumber change to remove old test blocking this, which must be deployed first

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-706
https://github.com/ONSdigital/census-rh-cucumber/pull/55

# Screenshots (if appropriate):