### PR TITLE
CR-830 RHUI - entered UAC should be converted to UPPERCASE before has…

### DIFF
--- a/app/start_handlers.py
+++ b/app/start_handlers.py
@@ -47,11 +47,11 @@ class StartCommon(View):
     @staticmethod
     def uac_hash(uac, expected_length=16):
         if uac:
-            combined = uac.lower().replace(' ', '')
+            combined = uac.upper().replace(' ', '')
         else:
             combined = ''
 
-        uac_validation_pattern = re.compile(r'^[a-z0-9]{16}$')
+        uac_validation_pattern = re.compile(r'^[A-Z0-9]{16}$')
 
         if (len(combined) < expected_length) or not (uac_validation_pattern.fullmatch(combined)):  # yapf: disable
             raise TypeError

--- a/tests/test_data/rhsvc/uac-cy.json
+++ b/tests/test_data/rhsvc/uac-cy.json
@@ -1,5 +1,5 @@
 {
-	"uacHash": "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4",
+	"uacHash": "54598f02da027026a584fd0bc7176de55a3e6472f4b3c74f68d0ae7be206e17c",
 	"active": "True",
 	"caseStatus": "OK",
 	"questionnaireId": "11100000009",

--- a/tests/test_data/rhsvc/uac-ni.json
+++ b/tests/test_data/rhsvc/uac-ni.json
@@ -1,5 +1,5 @@
 {
-	"uacHash": "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4",
+	"uacHash": "54598f02da027026a584fd0bc7176de55a3e6472f4b3c74f68d0ae7be206e17c",
 	"active": "True",
 	"caseStatus": "OK",
 	"questionnaireId": "11100000009",

--- a/tests/test_data/rhsvc/uac_en.json
+++ b/tests/test_data/rhsvc/uac_en.json
@@ -1,5 +1,5 @@
 {
-	"uacHash": "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4",
+	"uacHash": "54598f02da027026a584fd0bc7176de55a3e6472f4b3c74f68d0ae7be206e17c",
 	"active": "True",
 	"caseStatus": "OK",
 	"questionnaireId": "11100000009",

--- a/tests/unit/test_requests_handlers.py
+++ b/tests/unit/test_requests_handlers.py
@@ -7,6 +7,7 @@ from aioresponses import aioresponses
 from . import RHTestCase
 
 
+# noinspection PyTypeChecker
 class TestRequestsHandlers(RHTestCase):
 
     @unittest_run_loop
@@ -1986,10 +1987,12 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn\
                 :
 
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_en
 
             await self.client.request('GET', self.get_requestcode_household_en)
@@ -2034,10 +2037,12 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn\
                 :
 
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_cy
 
             await self.client.request('GET', self.get_requestcode_household_cy)
@@ -2082,10 +2087,12 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn\
                 :
 
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_ni
 
             await self.client.request('GET', self.get_requestcode_household_ni)
@@ -2130,10 +2137,12 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn\
                 :
 
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_en
 
             await self.client.request('GET', self.get_requestcode_individual_en)
@@ -2178,10 +2187,12 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn\
                 :
 
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_cy
 
             await self.client.request('GET', self.get_requestcode_individual_cy)
@@ -2226,10 +2237,12 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn\
                 :
 
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_ni
 
             await self.client.request('GET', self.get_requestcode_individual_ni)
@@ -2274,10 +2287,12 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn\
                 :
 
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_en
 
             await self.client.request('GET', self.get_requestcode_household_en)
@@ -2321,10 +2336,12 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn\
                 :
 
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_cy
 
             await self.client.request('GET', self.get_requestcode_household_cy)
@@ -2368,10 +2385,12 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn\
                 :
 
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_ni
 
             await self.client.request('GET', self.get_requestcode_household_ni)
@@ -2415,10 +2434,12 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn\
                 :
 
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_en
 
             await self.client.request('GET', self.get_requestcode_individual_en)
@@ -2462,10 +2483,12 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn\
                 :
 
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_cy
 
             await self.client.request('GET', self.get_requestcode_individual_cy)
@@ -2509,10 +2532,12 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn\
                 :
 
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_ni
 
             await self.client.request('GET', self.get_requestcode_individual_ni)
@@ -2556,9 +2581,11 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn \
                 :
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_en
 
             await self.client.request('GET', self.get_requestcode_household_en)
@@ -2602,9 +2629,11 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn \
                 :
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_cy
 
             await self.client.request('GET', self.get_requestcode_household_cy)
@@ -2648,9 +2677,11 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn \
                 :
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_ni
 
             await self.client.request('GET', self.get_requestcode_household_ni)
@@ -2694,9 +2725,11 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn \
                 :
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_en
 
             await self.client.request('GET', self.get_requestcode_individual_en)
@@ -2740,9 +2773,11 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn \
                 :
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_cy
 
             await self.client.request('GET', self.get_requestcode_individual_cy)
@@ -2786,9 +2821,11 @@ class TestRequestsHandlers(RHTestCase):
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.requests_handlers.RequestCommon.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+                'app.requests_handlers.RequestCommon.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
             'app.requests_handlers.RequestCommon.get_cases_by_uprn') as mocked_get_cases_by_uprn \
                 :
             mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_cases_by_uprn.return_value = self.rhsvc_cases_by_uprn_ni
 
             await self.client.request('GET', self.get_requestcode_individual_ni)

--- a/tests/unit/test_start_handlers.py
+++ b/tests/unit/test_start_handlers.py
@@ -1585,7 +1585,7 @@ class TestStartHandlers(RHTestCase):
         result = Start.uac_hash(post_data['uac'])
 
         # Then a single string built from the uac values is returned
-        self.assertEqual(result, '8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4')
+        self.assertEqual(result, '54598f02da027026a584fd0bc7176de55a3e6472f4b3c74f68d0ae7be206e17c')
 
     def test_join_uac_cy(self):
         # Given some post data
@@ -1595,7 +1595,7 @@ class TestStartHandlers(RHTestCase):
         result = Start.uac_hash(post_data['uac'])
 
         # Then a single string built from the uac values is returned
-        self.assertEqual(result, '8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4')
+        self.assertEqual(result, '54598f02da027026a584fd0bc7176de55a3e6472f4b3c74f68d0ae7be206e17c')
 
     def test_join_uac_ni(self):
         # Given some post data
@@ -1605,7 +1605,7 @@ class TestStartHandlers(RHTestCase):
         result = Start.uac_hash(post_data['uac'])
 
         # Then a single string built from the uac values is returned
-        self.assertEqual(result, '8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4')
+        self.assertEqual(result, '54598f02da027026a584fd0bc7176de55a3e6472f4b3c74f68d0ae7be206e17c')
 
     def test_join_uac_missing_en(self):
         # Given some missing post data

--- a/tests/unit/test_start_handlers.py
+++ b/tests/unit/test_start_handlers.py
@@ -1577,7 +1577,7 @@ class TestStartHandlers(RHTestCase):
                           contents)
             self.assertIn(self.ons_logo_cy, contents)
 
-    def test_uac_hash_en(self):
+    def test_uac_hash(self):
         # Given some post data
         post_data = {'uac': 'w4nw wpph jjpt p7fn', 'action[save_continue]': ''}
 
@@ -1587,27 +1587,7 @@ class TestStartHandlers(RHTestCase):
         # Then a single string built from the uac values is returned
         self.assertEqual(result, '54598f02da027026a584fd0bc7176de55a3e6472f4b3c74f68d0ae7be206e17c')
 
-    def test_join_uac_cy(self):
-        # Given some post data
-        post_data = {'uac': 'w4nw wpph jjpt p7fn', 'action[save_continue]': ''}
-
-        # When join_uac is called
-        result = Start.uac_hash(post_data['uac'])
-
-        # Then a single string built from the uac values is returned
-        self.assertEqual(result, '54598f02da027026a584fd0bc7176de55a3e6472f4b3c74f68d0ae7be206e17c')
-
-    def test_join_uac_ni(self):
-        # Given some post data
-        post_data = {'uac': 'w4nw wpph jjpt p7fn', 'action[save_continue]': ''}
-
-        # When join_uac is called
-        result = Start.uac_hash(post_data['uac'])
-
-        # Then a single string built from the uac values is returned
-        self.assertEqual(result, '54598f02da027026a584fd0bc7176de55a3e6472f4b3c74f68d0ae7be206e17c')
-
-    def test_join_uac_missing_en(self):
+    def test_join_uac_missing(self):
         # Given some missing post data
         post_data = {'uac': '', 'action[save_continue]': ''}
 
@@ -1616,25 +1596,7 @@ class TestStartHandlers(RHTestCase):
             Start.uac_hash(post_data['uac'])
         # Then a TypeError is raised
 
-    def test_join_uac_missing_cy(self):
-        # Given some missing post data
-        post_data = {'uac': '', 'action[save_continue]': ''}
-
-        # When join_uac is called
-        with self.assertRaises(TypeError):
-            Start.uac_hash(post_data['uac'])
-        # Then a TypeError is raised
-
-    def test_join_uac_missing_ni(self):
-        # Given some missing post data
-        post_data = {'uac': '', 'action[save_continue]': ''}
-
-        # When join_uac is called
-        with self.assertRaises(TypeError):
-            Start.uac_hash(post_data['uac'])
-        # Then a TypeError is raised
-
-    def test_join_uac_some_missing_en(self):
+    def test_join_uac_some_missing(self):
         # Given some missing post data
         post_data = {'uac': '123456781234', 'action[save_continue]': ''}
 
@@ -1643,25 +1605,7 @@ class TestStartHandlers(RHTestCase):
             Start.uac_hash(post_data['uac'])
         # Then a TypeError is raised
 
-    def test_join_uac_some_missing_cy(self):
-        # Given some missing post data
-        post_data = {'uac': '123456781234', 'action[save_continue]': ''}
-
-        # When join_uac is called
-        with self.assertRaises(TypeError):
-            Start.uac_hash(post_data['uac'])
-        # Then a TypeError is raised
-
-    def test_join_uac_some_missing_ni(self):
-        # Given some missing post data
-        post_data = {'uac': '123456781234', 'action[save_continue]': ''}
-
-        # When join_uac is called
-        with self.assertRaises(TypeError):
-            Start.uac_hash(post_data['uac'])
-        # Then a TypeError is raised
-
-    def test_validate_case_en(self):
+    def test_validate_case(self):
         # Given a dict with an active key and value
         case_json = {'active': True, 'caseStatus': 'OK'}
 
@@ -1670,25 +1614,7 @@ class TestStartHandlers(RHTestCase):
 
         # Nothing happens
 
-    def test_validate_case_cy(self):
-        # Given a dict with an active key and value
-        case_json = {'active': True, 'caseStatus': 'OK'}
-
-        # When validate_case is called
-        Start.validate_case(case_json)
-
-        # Nothing happens
-
-    def test_validate_case_ni(self):
-        # Given a dict with an active key and value
-        case_json = {'active': True, 'caseStatus': 'OK'}
-
-        # When validate_case is called
-        Start.validate_case(case_json)
-
-        # Nothing happens
-
-    def test_validate_case_inactive_en(self):
+    def test_validate_case_inactive(self):
         # Given a dict with an active key and value
         case_json = {'active': False, 'caseStatus': 'OK'}
 
@@ -1698,27 +1624,7 @@ class TestStartHandlers(RHTestCase):
 
         # Then an InactiveCaseError is raised
 
-    def test_validate_case_inactive_cy(self):
-        # Given a dict with an active key and value
-        case_json = {'active': False, 'caseStatus': 'OK'}
-
-        # When validate_case is called
-        with self.assertRaises(InactiveCaseError):
-            Start.validate_case(case_json)
-
-        # Then an InactiveCaseError is raised
-
-    def test_validate_case_inactive_ni(self):
-        # Given a dict with an active key and value
-        case_json = {'active': False, 'caseStatus': 'OK'}
-
-        # When validate_case is called
-        with self.assertRaises(InactiveCaseError):
-            Start.validate_case(case_json)
-
-        # Then an InactiveCaseError is raised
-
-    def test_validate_caseStatus_notfound_en(self):
+    def test_validate_caseStatus_notfound(self):
         # Given a dict with an active key and value
         case_json = {'active': True, 'caseStatus': 'NOT_FOUND'}
 
@@ -1728,47 +1634,7 @@ class TestStartHandlers(RHTestCase):
 
         # Then an InvalidEqPayload is raised
 
-    def test_validate_caseStatus_notfound_cy(self):
-        # Given a dict with an active key and value
-        case_json = {'active': True, 'caseStatus': 'NOT_FOUND'}
-
-        # When validate_case is called
-        with self.assertRaises(InvalidEqPayLoad):
-            Start.validate_case(case_json)
-
-        # Then an InvalidEqPayload is raised
-
-    def test_validate_caseStatus_notfound_ni(self):
-        # Given a dict with an active key and value
-        case_json = {'active': True, 'caseStatus': 'NOT_FOUND'}
-
-        # When validate_case is called
-        with self.assertRaises(InvalidEqPayLoad):
-            Start.validate_case(case_json)
-
-        # Then an InvalidEqPayload is raised
-
-    def test_validate_case_empty_en(self):
-        # Given an empty dict
-        case_json = {}
-
-        # When validate_case is called
-        with self.assertRaises(InactiveCaseError):
-            Start.validate_case(case_json)
-
-        # Then an InactiveCaseError is raised
-
-    def test_validate_case_empty_cy(self):
-        # Given an empty dict
-        case_json = {}
-
-        # When validate_case is called
-        with self.assertRaises(InactiveCaseError):
-            Start.validate_case(case_json)
-
-        # Then an InactiveCaseError is raised
-
-    def test_validate_case_empty_ni(self):
+    def test_validate_case_empty(self):
         # Given an empty dict
         case_json = {}
 


### PR DESCRIPTION
…hing

Complete, ready for dev testing

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Change UAC lowercasing to uppercasing to match change in RM

Matching change in Cucumber

# What has changed
uac is upper()
update to regex for validation
Update to unit tests so hash matches uppercased version
Also includes additional fixes to unit tests to stop them calling AIMS during testing

# How to test?
Unit tests
Tested in dev against updated Cucumber test

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-830

# Screenshots (if appropriate):