### PR TITLE
CR-982 fix retry concurrency

### DIFF
--- a/app/app_logging.py
+++ b/app/app_logging.py
@@ -5,7 +5,7 @@ import structlog
 from collections import OrderedDict
 from pythonjsonlogger import jsonlogger
 
-date_format = '%Y-%m-%dT%H:%M:%s'
+date_format = '%Y-%m-%dT%H:%M:%S'
 service = 'rhui'
 
 # Standard fields on logging records that we don't want directly inserted into the data dictionary

--- a/app/config.py
+++ b/app/config.py
@@ -64,7 +64,6 @@ class BaseConfig:
     REDIS_PORT = env('REDIS_PORT', default='7379')
 
     SESSION_AGE = env('SESSION_AGE', default='600')
-    WAIT_BEFORE_RETRY_EXPONENT = env('WAIT_BEFORE_RETRY_EXPONENT', default='1')  # rising scale for retry wait times
 
     WEBCHAT_SVC_URL = env('WEBCHAT_SVC_URL')
 
@@ -109,7 +108,6 @@ class DevelopmentConfig:
     REDIS_PORT = env('REDIS_PORT', default='7379')
 
     SESSION_AGE = env('SESSION_AGE', default='300')  # 5 minutes
-    WAIT_BEFORE_RETRY_EXPONENT = env('WAIT_BEFORE_RETRY_EXPONENT', default='1')  # rising scale for retry wait times
 
     WEBCHAT_SVC_URL = env.str(
         'WEBCHAT_SVC_URL',
@@ -149,7 +147,6 @@ class TestingConfig:
     REDIS_PORT = ''
 
     SESSION_AGE = ''
-    WAIT_BEFORE_RETRY_EXPONENT = '0'  # no wait.
 
     WEBCHAT_SVC_URL = 'https://www.timeforstorm.com/IM/endpoint/client/5441/ONSWebchat/ce033298af0c07067a77b7940c011ec8ef670d66b7fe15c5776a16e205478221'
 

--- a/app/config.py
+++ b/app/config.py
@@ -116,7 +116,7 @@ class DevelopmentConfig:
 
     ADDRESS_INDEX_SVC_URL = env.str('ADDRESS_INDEX_SVC_URL', default='http://localhost:9000')
     ADDRESS_INDEX_SVC_AUTH = (env.str('ADDRESS_INDEX_SVC_USERNAME', default='admin'),
-                  env.str('ADDRESS_INDEX_SVC_PASSWORD', default='secret'))
+                              env.str('ADDRESS_INDEX_SVC_PASSWORD', default='secret'))
 
 
 class TestingConfig:

--- a/app/eq.py
+++ b/app/eq.py
@@ -73,20 +73,17 @@ class EqPayloadConstructor(object):
         try:
             self._uprn = case['address']['uprn']
         except KeyError:
-            raise InvalidEqPayLoad(
-                f'Could not retrieve address uprn from case JSON ')
+            raise InvalidEqPayLoad('Could not retrieve address uprn from case JSON')
 
         try:
             self._region = case['region'][0]
         except KeyError:
-            raise InvalidEqPayLoad(
-                f'Could not retrieve region from case JSON ')
+            raise InvalidEqPayLoad('Could not retrieve region from case JSON')
 
         try:
             self._form_type = case['formType']
         except KeyError:
-            raise InvalidEqPayLoad(
-                f'Could not retrieve formType from case JSON ')
+            raise InvalidEqPayLoad('Could not retrieve formType from case JSON')
 
     async def build(self):
         """__init__ is not a coroutine function, so I/O needs to go here"""
@@ -157,7 +154,6 @@ class EqPayloadConstructor(object):
 
     @staticmethod
     def convert_region_code(case_region):
-        region_value = ''
         if case_region == 'N':
             region_value = 'GB-NIR'
         elif case_region == 'W':

--- a/app/request.py
+++ b/app/request.py
@@ -15,7 +15,7 @@ logger = get_logger('respondent-home')
 
 pooled_attempts_limit = 2
 basic_attempt_limit = 3
-wait_multiplier = 1.5
+wait_multiplier = 0.01
 
 
 def after_failed_attempt(request_type, retry_state):
@@ -51,7 +51,7 @@ class RetryRequest:
             logger.debug('successfully connected to service', url=self.url)
 
     @retry(reraise=True, stop=stop_after_attempt(basic_attempt_limit),
-           wait=wait_exponential(multiplier=wait_multiplier),
+           wait=wait_exponential(multiplier=wait_multiplier, exp_base=25),
            after=after_failed_basic,
            retry=(retry_if_exception_message(match='503.*') | retry_if_exception_type((ClientConnectionError,
                                                                                        ClientConnectorError))))

--- a/app/request.py
+++ b/app/request.py
@@ -1,0 +1,110 @@
+import aiohttp
+from aiohttp.client_exceptions import (ClientConnectionError,
+                                       ClientConnectorError,
+                                       ClientResponseError)
+
+from tenacity import (retry,
+                      stop_after_attempt,
+                      retry_if_exception_message,
+                      retry_if_exception_type,
+                      wait_exponential,
+                      RetryError)
+from structlog import get_logger
+
+logger = get_logger('respondent-home')
+
+pooled_attempts_limit = 2
+basic_attempt_limit = 3
+wait_multiplier = 1.5
+
+
+def after_failed_attempt(request_type, retry_state):
+    logger.warn(request_type + ' request attempt failed', attempts=retry_state.attempt_number)
+
+
+def after_failed_basic(retry_state):
+    after_failed_attempt('basic', retry_state)
+
+
+def after_failed_pooled(retry_state):
+    after_failed_attempt('pooled', retry_state)
+
+
+class RetryRequest:
+    """
+    Make requests to a URL, but retry under certain conditions to tolerate server graceful shutdown.
+    """
+    def __init__(self, request, method, url, auth, json, return_json):
+        self.request = request
+        self.method = method
+        self.url = url
+        self.auth = auth
+        self.json = json
+        self.return_json = return_json
+
+    def __handle_response(self, response):
+        try:
+            response.raise_for_status()
+        except ClientResponseError as ex:
+            raise ex
+        else:
+            logger.debug('successfully connected to service', url=self.url)
+
+    @retry(reraise=True, stop=stop_after_attempt(basic_attempt_limit),
+           wait=wait_exponential(multiplier=wait_multiplier),
+           after=after_failed_basic,
+           retry=(retry_if_exception_message(match='503.*') | retry_if_exception_type((ClientConnectionError,
+                                                                                       ClientConnectorError))))
+    async def _request_basic(self):
+        # basic request without keep-alive to avoid terminating service.
+        logger.info('request using basic connection')
+        async with aiohttp.request(
+                self.method, self.url, auth=self.auth, json=self.json) as resp:
+            self.__handle_response(resp)
+            if self.return_json:
+                return await resp.json()
+            else:
+                return None
+
+    @retry(stop=stop_after_attempt(pooled_attempts_limit),
+           wait=wait_exponential(multiplier=wait_multiplier),
+           after=after_failed_pooled,
+           retry=(retry_if_exception_message(match='503.*') | retry_if_exception_type((ClientConnectionError,
+                                                                                       ClientConnectorError))))
+    async def _request_using_pool(self):
+        async with self.request.app.http_session_pool.request(
+                self.method, self.url, auth=self.auth, json=self.json, ssl=False) as resp:
+            self.__handle_response(resp)
+            if self.return_json:
+                return await resp.json()
+            else:
+                return None
+
+    async def make_request(self):
+        """
+        Make a request with retries.
+        First the fast pooled connection will be tried, but if certain failures are detected, then it will be retried.
+        If the retry limit is reached then a basic connection will be tried (and retried if necessary)
+        Finally the error will be propagated.
+        """
+        logger.debug('making request with handler',
+                     method=self.method,
+                     url=self.url)
+        try:
+            try:
+                return await self._request_using_pool()
+            except RetryError as retry_ex:
+                attempts = retry_ex.last_attempt.attempt_number
+                logger.warn('Could not make request using normal pooled connection', attempts=attempts)
+                return await self._request_basic()
+        except ClientResponseError as ex:
+            if not ex.status == 404:
+                logger.error('error in response',
+                             url=self.url,
+                             status_code=ex.status)
+            raise ex
+        except (ClientConnectionError, ClientConnectorError) as ex:
+            logger.error('client failed to connect',
+                         url=self.url,
+                         client_ip=self.request['client_ip'])
+            raise ex

--- a/app/requests_handlers.py
+++ b/app/requests_handlers.py
@@ -99,7 +99,6 @@ class RequestCommon(View):
         return await self._make_request(request,
                                         'GET',
                                         url,
-                                        self._handle_response,
                                         auth=request.app['ADDRESS_INDEX_SVC_AUTH'],
                                         return_json=True)
 
@@ -109,7 +108,6 @@ class RequestCommon(View):
         return await self._make_request(request,
                                         'GET',
                                         url,
-                                        self._handle_response,
                                         auth=request.app['ADDRESS_INDEX_SVC_AUTH'],
                                         return_json=True)
 
@@ -118,7 +116,6 @@ class RequestCommon(View):
         return await self._make_request(request,
                                         'GET',
                                         f'{rhsvc_url}/cases/uprn/{uprn}',
-                                        self._handle_response,
                                         return_json=True)
 
     async def get_fulfilment(self, request, case_type, region,
@@ -129,7 +126,6 @@ class RequestCommon(View):
         return await self._make_request(request,
                                         'GET',
                                         url,
-                                        self._handle_response,
                                         return_json=True)
 
     async def request_fulfilment(self, request, case_id, tel_no,
@@ -145,7 +141,6 @@ class RequestCommon(View):
         return await self._make_request(request,
                                         'POST',
                                         url,
-                                        self._handle_response,
                                         auth=request.app['RHSVC_AUTH'],
                                         json=fulfilment_json)
 

--- a/app/start_handlers.py
+++ b/app/start_handlers.py
@@ -85,7 +85,6 @@ class StartCommon(View):
         return await self._make_request(request,
                                         'POST',
                                         f'{rhsvc_url}/surveyLaunched',
-                                        self._handle_response,
                                         auth=request.app['RHSVC_AUTH'],
                                         json=launch_json)
 
@@ -105,7 +104,6 @@ class StartCommon(View):
         return await self._make_request(request,
                                         'GET',
                                         f'{rhsvc_url}/uacs/{uac_hash}',
-                                        self._handle_response,
                                         auth=request.app['RHSVC_AUTH'],
                                         return_json=True)
 
@@ -125,7 +123,6 @@ class StartCommon(View):
                                         'PUT',
                                         f'{rhsvc_url}/cases/' +
                                         case['caseId'] + '/address',
-                                        self._handle_response,
                                         auth=rhsvc_auth,
                                         json=case_json)
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,5 @@
 import string
 import re
-from aiohttp.client_exceptions import (ClientResponseError)
 from .request import RetryRequest
 from structlog import get_logger
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,14 +1,9 @@
 import string
-import time
 import re
-import aiohttp
-
-from aiohttp.client_exceptions import (ClientConnectionError,
-                                       ClientConnectorError,
-                                       ClientResponseError)
-
-from tenacity import retry, stop_after_attempt, retry_if_exception_message, retry_if_exception_type
+from aiohttp.client_exceptions import (ClientResponseError)
+from .request import RetryRequest
 from structlog import get_logger
+
 logger = get_logger('respondent-home')
 
 OBSCURE_WHITESPACE = (
@@ -21,7 +16,6 @@ OBSCURE_WHITESPACE = (
 )
 
 uk_prefix = '44'
-attempts_retry_limit = 5
 
 
 class View:
@@ -39,37 +33,9 @@ class View:
                     path=request.path)
 
     @staticmethod
-    def _handle_response(response, attempt_number):
-        try:
-            response.raise_for_status()
-        except ClientResponseError as ex:
-            if ex.status == 503:
-                if attempt_number < attempts_retry_limit:
-                    logger.warn('503 returned. Could be during service scale back',
-                                url=response.url,
-                                status_code=response.status,
-                                attempt_number=attempt_number)
-                else:
-                    logger.error('503 returned. Giving up retries',
-                                 url=response.url,
-                                 status_code=response.status)
-            elif not ex.status == 404:
-                logger.error('error in response',
-                             url=response.url,
-                             status_code=response.status)
-            raise ex
-        else:
-            logger.debug('successfully connected to service',
-                         url=str(response.url))
-
-    @staticmethod
-    @retry(reraise=True, stop=stop_after_attempt(attempts_retry_limit), retry=(
-            retry_if_exception_message(match='503.*') | retry_if_exception_type((ClientConnectionError,
-                                                                                ClientConnectorError))))
     async def _make_request(request,
                             method,
                             url,
-                            func,
                             auth=None,
                             json=None,
                             return_json=False):
@@ -79,51 +45,10 @@ class View:
         :param url: The target URL
         :param auth: Authorization
         :param json: JSON payload to pass as request data
-        :param func: Function to call on the response
         :param return_json: If True, the response JSON will be returned
         """
-        logger.debug('making request with handler',
-                     method=method,
-                     url=url,
-                     handler=func.__name__)
-
-        attempt_number = View._make_request.retry.statistics['attempt_number']
-        try:
-            if attempt_number > 1:
-                # sleep with a rising sleep time as the attempt numbers grow, starting at 0 seconds.
-                wait_exp = float(request.app['WAIT_BEFORE_RETRY_EXPONENT'])
-                base = attempt_number - 1
-                wait_secs = 0 if (wait_exp == 0 or base == 0) else (base ** wait_exp)
-                logger.info('retrying using basic connection', attempt_number=attempt_number, wait_secs=wait_secs)
-                time.sleep(wait_secs)
-                # basic request without keep-alive to avoid terminating service.
-                async with aiohttp.request(
-                        method, url, auth=auth, json=json) as resp:
-                    func(resp, attempt_number)
-                    if return_json:
-                        return await resp.json()
-                    else:
-                        return None
-            else:
-                # normal path. pooled ; keep-alive request for performance
-                async with request.app.http_session_pool.request(
-                        method, url, auth=auth, json=json, ssl=False) as resp:
-                    func(resp, attempt_number)
-                    if return_json:
-                        return await resp.json()
-                    else:
-                        return None
-        except (ClientConnectionError, ClientConnectorError) as ex:
-            if attempt_number < attempts_retry_limit:
-                logger.warn('client failed to connect, could be during service scale back',
-                            url=url,
-                            client_ip=request['client_ip'],
-                            attempt_number=attempt_number)
-            else:
-                logger.error('client failed to connect. Giving up retries',
-                             url=url,
-                             client_ip=request['client_ip'])
-            raise ex
+        retry_request = RetryRequest(request, method, url, auth, json, return_json)
+        return await retry_request.make_request()
 
 
 class InvalidDataError(Exception):
@@ -139,7 +64,6 @@ class InvalidDataErrorWelsh(Exception):
 
 
 class ProcessPostcode:
-
     postcode_validation_pattern = re.compile(
         r'^((AB|AL|B|BA|BB|BD|BH|BL|BN|BR|BS|BT|BX|CA|CB|CF|CH|CM|CO|CR|CT|CV|CW|DA|DD|DE|DG|DH|DL|DN|DT|DY|E|EC|EH|EN|EX|FK|FY|G|GL|GY|GU|HA|HD|HG|HP|HR|HS|HU|HX|IG|IM|IP|IV|JE|KA|KT|KW|KY|L|LA|LD|LE|LL|LN|LS|LU|M|ME|MK|ML|N|NE|NG|NN|NP|NR|NW|OL|OX|PA|PE|PH|PL|PO|PR|RG|RH|RM|S|SA|SE|SG|SK|SL|SM|SN|SO|SP|SR|SS|ST|SW|SY|TA|TD|TF|TN|TQ|TR|TS|TW|UB|W|WA|WC|WD|WF|WN|WR|WS|WV|YO|ZE)(\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}))|BFPO[ ]?\d{1,4}$'  # NOQA
     )

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -5,10 +5,11 @@ import time
 import uuid
 
 from aiohttp.test_utils import AioHTTPTestCase
+from tenacity import wait_exponential
 
 from app import app
 
-from app import session
+from app import session, request
 from aiohttp_session import session_middleware
 from aiohttp_session import SimpleCookieStorage
 
@@ -153,6 +154,9 @@ class RHTestCase(AioHTTPTestCase):
     async def get_application(self):
         # Monkey patch the session setup function to remove Redis dependency for unit tests
         session.setup = self.session_storage
+        # Monkey patch request retry wait time for faster tests
+        request.RetryRequest._request_using_pool.retry.wait = wait_exponential(multiplier=0)
+        request.RetryRequest._request_basic.retry.wait = wait_exponential(multiplier=0)
         return app.create_app('TestingConfig')
 
     async def setUpAsync(self):

--- a/tests/unit/test_requests_handlers.py
+++ b/tests/unit/test_requests_handlers.py
@@ -259,7 +259,7 @@ class TestRequestsHandlers(RHTestCase):
                     'POST',
                     self.post_requestcode_enter_address_hh_en,
                     data=self.request_postcode_input_valid)
-            self.assertLogEvent(cm, '503 returned. Giving up retries', status_code=503)
+            self.assertLogEvent(cm, 'error in response', status_code=503)
 
         self.assertEqual(response.status, 500)
         contents = str(await response.content.read())
@@ -276,7 +276,7 @@ class TestRequestsHandlers(RHTestCase):
                     'POST',
                     self.post_requestcode_enter_address_hh_cy,
                     data=self.request_postcode_input_valid)
-            self.assertLogEvent(cm, '503 returned. Giving up retries', status_code=503)
+            self.assertLogEvent(cm, 'error in response', status_code=503)
 
         self.assertEqual(response.status, 500)
         contents = str(await response.content.read())
@@ -293,7 +293,7 @@ class TestRequestsHandlers(RHTestCase):
                     'POST',
                     self.post_requestcode_enter_address_hh_ni,
                     data=self.request_postcode_input_valid)
-            self.assertLogEvent(cm, '503 returned. Giving up retries', status_code=503)
+            self.assertLogEvent(cm, 'error in response', status_code=503)
 
         self.assertEqual(response.status, 500)
         contents = str(await response.content.read())

--- a/tests/unit/test_start_handlers.py
+++ b/tests/unit/test_start_handlers.py
@@ -1,6 +1,5 @@
 import json
 
-from unittest import mock
 from urllib.parse import urlsplit, parse_qs
 
 from aiohttp.client_exceptions import ClientConnectionError, ClientConnectorError
@@ -1173,7 +1172,7 @@ class TestStartHandlers(RHTestCase):
                 response = await self.client.request('POST',
                                                      self.post_start_en,
                                                      data=self.start_data_valid)
-            self.assertLogEvent(cm, '503 returned. Giving up retries', status_code=503)
+            self.assertLogEvent(cm, 'error in response', status_code=503)
 
         self.assertEqual(response.status, 500)
         contents = str(await response.content.read())
@@ -1189,7 +1188,7 @@ class TestStartHandlers(RHTestCase):
                 response = await self.client.request('POST',
                                                      self.post_start_cy,
                                                      data=self.start_data_valid)
-            self.assertLogEvent(cm, '503 returned. Giving up retries', status_code=503)
+            self.assertLogEvent(cm, 'error in response', status_code=503)
 
         self.assertEqual(response.status, 500)
         contents = str(await response.content.read())
@@ -1205,7 +1204,7 @@ class TestStartHandlers(RHTestCase):
                 response = await self.client.request('POST',
                                                      self.post_start_ni,
                                                      data=self.start_data_valid)
-            self.assertLogEvent(cm, '503 returned. Giving up retries', status_code=503)
+            self.assertLogEvent(cm, 'error in response', status_code=503)
 
         self.assertEqual(response.status, 500)
         contents = str(await response.content.read())


### PR DESCRIPTION
# Motivation and Context
The fix for CR-872 had some deficiencies for the concurrency of the retry attempts and the efficiency of the wait period.

# What has changed
- The request logic has been factored out into an object for the retries.
- The wait mechanism uses the tenacity attibutes.  The time is monkey-patched to 0 for the unit-tests
- The retry logic has been recoded to retry first with pooled connection, then basic connection.

# Testing
- local testing (duplicating the example from @MartinHumphrey) without an RHSvc and using 2 browsers shows the problem has been fixed at a basic level
- locust testing by scaling back RHSvc shows no errors as before
- checking the RHUI logs from locust testing shows consistent and efficient concurrent behaviour

