### PR TITLE
Cr 994 add ce question

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,6 +17,7 @@ MOBILE_CHECK_MSG = {'text': 'Please check and confirm your mobile phone number.'
 ADDRESS_SELECT_CHECK_MSG = {'text': 'Select an address', 'level': 'ERROR', 'type': 'ADDRESS_SELECT_CHECK_MSG', 'field': 'address-select'}
 VALIDATION_FAILURE_MSG = {'text': 'Session timed out or permission denied', 'level': 'ERROR', 'type': 'VALIDATION_FAILURE_MSG', 'field': 'uac'}
 START_LANGUAGE_OPTION_MSG = {'text': 'Select a language option', 'level': 'ERROR', 'type': 'START_LANGUAGE_OPTION_MSG', 'field': 'language-option'}
+NO_SELECTION_CHECK_MSG = {'text': 'Please select an option.', 'level': 'ERROR', 'type': 'NO_SELECTION_ERROR', 'field': 'no-selection'}  # NOQA
 
 BAD_CODE_MSG_CY = {'text': 'Rhowch eich cod mynediad.', 'clickable': True, 'level': 'ERROR', 'type': 'BAD_CODE', 'field': 'uac'}
 BAD_CODE_TYPE_MSG_CY = {'text': 'Rhowch eich cod mynediad eto a rhowch gynnig arall arni.', 'clickable': True, 'level': 'ERROR', 'type': 'NOT_HOUSEHOLD_CODE', 'field': 'uac'}  # NOQA
@@ -34,3 +35,5 @@ MOBILE_CHECK_MSG_CY = {'text': "Edrychwch eto ar eich rhif ffôn symudol a'i gad
 ADDRESS_SELECT_CHECK_MSG_CY = {'text': 'Dewiswch gyfeiriad', 'level': 'ERROR', 'type': 'ADDRESS_SELECT_CHECK_MSG', 'field': 'address-select'}
 VALIDATION_FAILURE_MSG_CY = {'text': "Mae'r sesiwn wedi cyrraedd y terfyn amser neu nid oes caniatâd wedi cael ei roi", 'level': 'ERROR', 'type': 'VALIDATION_FAILURE_MSG', 'field': 'uac'}  # NOQA
 START_LANGUAGE_OPTION_MSG_CY = {'text': 'Dewiswch opsiwn iaith', 'level': 'ERROR', 'type': 'START_LANGUAGE_OPTION_MSG', 'field': 'language-option'}
+# TODO ADD WELSH TRANSLATION
+NO_SELECTION_CHECK_MSG_CY = {'text': 'Please select an option.', 'level': 'ERROR', 'type': 'NO_SELECTION_ERROR', 'field': 'no-selection'}  # NOQA

--- a/app/common_handlers.py
+++ b/app/common_handlers.py
@@ -9,7 +9,9 @@ from aiohttp.client_exceptions import (ClientResponseError)
 from . import (ADDRESS_CHECK_MSG,
                ADDRESS_SELECT_CHECK_MSG,
                ADDRESS_CHECK_MSG_CY,
-               ADDRESS_SELECT_CHECK_MSG_CY)
+               ADDRESS_SELECT_CHECK_MSG_CY,
+               NO_SELECTION_CHECK_MSG,
+               NO_SELECTION_CHECK_MSG_CY)
 
 from .flash import flash
 from .security import check_permission
@@ -476,9 +478,16 @@ class CommonConfirmAddress(CommonCommon):
                     session['attributes']['case_type'] = uprn_return['caseType']
                     session['attributes']['address_level'] = uprn_return['addressLevel']
                     session.changed()
-                    raise HTTPFound(
-                        request.app.router['RequestCodeEnterMobile:get'].url_for(request_type=sub_user_journey,
-                                                                                 display_region=display_region))
+
+                    if uprn_return['caseType'] == 'CE' and uprn_return['addressLevel'] == 'E':
+                        raise HTTPFound(
+                            request.app.router['CommonCEMangerQuestion:get'].url_for(user_journey=user_journey,
+                                                                                     sub_user_journey=sub_user_journey,
+                                                                                     display_region=display_region))
+                    else:
+                        raise HTTPFound(
+                            request.app.router['RequestCodeEnterMobile:get'].url_for(request_type=sub_user_journey,
+                                                                                     display_region=display_region))
                 except ClientResponseError as ex:
                     if ex.status == 404:
                         logger.info('get cases by uprn error - unable to match uprn (404)',
@@ -513,3 +522,119 @@ class CommonConfirmAddress(CommonCommon):
             attributes['sub_user_journey'] = sub_user_journey
             attributes['locale'] = locale
             return attributes
+
+
+@common_routes.view(r'/' + View.valid_display_regions + '/' + View.valid_user_journeys
+                    + '/' + View.valid_sub_user_journeys + '/resident-or-manager/')
+class CommonCEMangerQuestion(CommonCommon):
+    """
+    Common route to enable address entry via postcode from start and request journeys
+    """
+    @aiohttp_jinja2.template('common-resident-or-manager.html')
+    async def get(self, request):
+        self.setup_request(request)
+        display_region = request.match_info['display_region']
+        user_journey = request.match_info['user_journey']
+        sub_user_journey = request.match_info['sub_user_journey']
+
+        self.log_entry(request, display_region + '/' + user_journey + '/' + sub_user_journey + '/resident-or-manager')
+
+        session = await get_session(request)
+
+        if display_region == 'cy':
+            locale = 'cy'
+            # TODO Add Welsh translation
+            page_title = 'Are you a resident or manager of this establishment?'
+        else:
+            locale = 'en'
+            page_title = 'Are you a resident or manager of this establishment?'
+        return {
+            'display_region': display_region,
+            'user_journey': user_journey,
+            'sub_user_journey': sub_user_journey,
+            'locale': locale,
+            'page_title': page_title,
+            'addressLine1': session['attributes']['addressLine1'],
+            'addressLine2': session['attributes']['addressLine2'],
+            'addressLine3': session['attributes']['addressLine3'],
+            'townName': session['attributes']['townName'],
+            'postcode': session['attributes']['postcode']
+        }
+
+    @aiohttp_jinja2.template('common-resident-or-manager.html')
+    async def post(self, request):
+        self.setup_request(request)
+        display_region = request.match_info['display_region']
+        user_journey = request.match_info['user_journey']
+        sub_user_journey = request.match_info['sub_user_journey']
+
+        if display_region == 'cy':
+            locale = 'cy'
+            # TODO Add Welsh translation
+            page_title = 'Are you a resident or manager of this establishment?'
+        else:
+            locale = 'en'
+            page_title = 'Are you a resident or manager of this establishment?'
+
+        self.log_entry(request, display_region + '/' + user_journey + '/' + sub_user_journey + '/resident-or-manager')
+
+        session = await get_session(request)
+
+        data = await request.post()
+
+        try:
+            resident_or_manager = data['form-resident-or-manager']
+        except KeyError:
+            logger.info('resident or manager question error',
+                        client_ip=request['client_ip'])
+            if display_region == 'cy':
+                flash(request, NO_SELECTION_CHECK_MSG_CY)
+            else:
+                flash(request, NO_SELECTION_CHECK_MSG)
+            return {
+                'page_title': page_title,
+                'display_region': display_region,
+                'user_journey': user_journey,
+                'sub_user_journey': sub_user_journey,
+                'locale': locale,
+                'addressLine1': session['attributes']['addressLine1'],
+                'addressLine2': session['attributes']['addressLine2'],
+                'addressLine3': session['attributes']['addressLine3'],
+                'townName': session['attributes']['townName'],
+                'postcode': session['attributes']['postcode']
+            }
+
+        if resident_or_manager == 'resident':
+
+            session['attributes']['address_level'] = 'U'
+            session.changed()
+
+            raise HTTPFound(
+                request.app.router['RequestCodeEnterMobile:get'].url_for(request_type=sub_user_journey,
+                                                                         display_region=display_region))
+
+        elif resident_or_manager == 'manager':
+            raise HTTPFound(
+                request.app.router['RequestCodeEnterMobile:get'].url_for(request_type=sub_user_journey,
+                                                                         display_region=display_region))
+
+        else:
+            # catch all just in case, should never get here
+            logger.info('resident or manager question error',
+                        client_ip=request['client_ip'])
+            if display_region == 'cy':
+                flash(request, NO_SELECTION_CHECK_MSG_CY)
+            else:
+                flash(request, NO_SELECTION_CHECK_MSG)
+            return {
+                'page_title': page_title,
+                'display_region': display_region,
+                'user_journey': user_journey,
+                'sub_user_journey': sub_user_journey,
+                'locale': locale,
+                'addressLine1': session['attributes']['addressLine1'],
+                'addressLine2': session['attributes']['addressLine2'],
+                'addressLine3': session['attributes']['addressLine3'],
+                'townName': session['attributes']['townName'],
+                'postcode': session['attributes']['postcode']
+            }

--- a/app/common_handlers.py
+++ b/app/common_handlers.py
@@ -528,7 +528,7 @@ class CommonConfirmAddress(CommonCommon):
                     + '/' + View.valid_sub_user_journeys + '/resident-or-manager/')
 class CommonCEMangerQuestion(CommonCommon):
     """
-    Common route to enable address entry via postcode from start and request journeys
+    Common route to ask whether user is a resident or manager if they select a CE Estab as an address in fulfilments
     """
     @aiohttp_jinja2.template('common-resident-or-manager.html')
     async def get(self, request):

--- a/app/requests_handlers.py
+++ b/app/requests_handlers.py
@@ -233,6 +233,10 @@ class RequestCodeConfirmMobile(RequestCommon):
             else:
                 fulfilment_language = 'eng'
 
+            logger.info(f"fulfilment query: case_type={attributes['case_type']}, region={attributes['region']}, "
+                        f"individual={fulfilment_individual}",
+                        client_ip=request['client_ip'])
+
             try:
                 available_fulfilments = await RHService.get_fulfilment(
                     request, attributes['case_type'], attributes['region'], 'SMS', 'UAC', fulfilment_individual)

--- a/app/templates/common-resident-or-manager.html
+++ b/app/templates/common-resident-or-manager.html
@@ -1,0 +1,83 @@
+{% extends 'base-' + display_region + '.html' %}
+
+{% set messages_dict=dict(get_flashed_messages()|groupby('level')) %}
+{% set field_messages_dict=dict(messages_dict['ERROR']|groupby('field')) %}
+
+{% from 'components/question/_macro.njk' import onsQuestion %}
+{% from 'components/button/_macro.njk' import onsButton %}
+{% from 'components/radios/_macro.njk' import onsRadios %}
+
+{% set form =  {
+    'method': 'POST',
+    'attributes': {
+        'action': url('CommonCEMangerQuestion:post', display_region=display_region, user_journey=user_journey, sub_user_journey=sub_user_journey)
+    }
+} %}
+
+{% set form_options = [
+        {
+            'id': 'yes',
+            'label': {
+                'text': _('Resident'),
+                'description': _('Residents are responsible for answering the census questions about themselves')
+            },
+            'value': 'resident'
+        },
+        {
+            'id': 'no',
+            'label': {
+                'text': _('Manager'),
+                'description': _('A manager is responsible for answering the census questions about this establishment')
+            },
+            'value': 'manager'
+        }
+    ]
+%}
+
+
+{% block main %}
+
+    {% if messages_dict %}
+        {% include 'partials/messages.html' with context %}
+    {% endif %}
+
+    {% call onsQuestion({
+        'title': _('Are you a resident or manager of this establishment?')
+    }) %}
+
+    <p class="rh-address-display">
+        {{ addressLine1 }}<br>
+        {% if addressLine2 %}{{ addressLine2 }}<br>{% endif %}
+        {% if addressLine3 %}{{ addressLine3 }}<br>{% endif %}
+        {% if townName %}{{ townName }}<br>{% endif %}
+        {{ postcode }}
+    </p>
+
+{% if 'no-selection' in field_messages_dict %}
+    {{
+        onsRadios({
+            'name': 'form-resident-or-manager',
+            'radios': form_options,
+            'error': {
+                'text': _('Please select an option.')
+            }
+        })
+    }}
+{% else %}
+    {{
+        onsRadios({
+            'name': 'form-resident-or-manager',
+            'radios': form_options
+        })
+    }}
+{% endif %}
+    {% endcall %}
+
+    {{
+        onsButton({
+            'text': _('Continue'),
+            'classes': 'u-mt-l'
+        })
+    }}
+
+{% endblock %}

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -304,6 +304,18 @@ class RHTestCase(AioHTTPTestCase):
             'form-confirm-address': 'invalid', 'action[save_continue]': ''
         }
 
+        self.common_resident_or_manager_input_resident = {
+            'form-resident-or-manager': 'resident', 'action[save_continue]': ''
+        }
+
+        self.common_resident_or_manager_input_manager = {
+            'form-resident-or-manager': 'manager', 'action[save_continue]': ''
+        }
+
+        self.common_resident_or_manager_input_invalid = {
+            'form-resident-or-manager': 'no', 'action[save_continue]': ''
+        }
+
         self.common_postcode_input_valid = {
             'form-enter-address-postcode': self.postcode_valid, 'action[save_continue]': '',
         }
@@ -417,6 +429,26 @@ class RHTestCase(AioHTTPTestCase):
 
         self.content_common_timeout_en = 'Your session has timed out due to inactivity'
         self.content_common_timeout_cy = 'Mae eich sesiwn wedi cyrraedd y terfyn amser oherwydd anweithgarwch'
+
+        self.content_common_resident_or_manager_title_en = 'Are you a resident or manager of this establishment?'
+        self.content_common_resident_or_manager_option_resident_en = 'Resident'
+        self.content_common_resident_or_manager_description_resident_en = \
+            'Residents are responsible for answering the census questions about themselves'
+        self.content_common_resident_or_manager_option_manager_en = 'Manager'
+        self.content_common_resident_or_manager_description_manager_en = \
+            'A manager is responsible for answering the census questions about this establishment'
+        # TODO: add welsh translation
+        self.content_common_resident_or_manager_title_cy = 'Are you a resident or manager of this establishment?'
+        # TODO: add welsh translation
+        self.content_common_resident_or_manager_option_resident_cy = 'Resident'
+        # TODO: add welsh translation
+        self.content_common_resident_or_manager_description_resident_cy = \
+            'Residents are responsible for answering the census questions about themselves'
+        # TODO: add welsh translation
+        self.content_common_resident_or_manager_option_manager_cy = 'Manager'
+        # TODO: add welsh translation
+        self.content_common_resident_or_manager_description_manager_cy = \
+            'A manager is responsible for answering the census questions about this establishment'
 
         # End Common
 
@@ -1149,6 +1181,16 @@ class RHTestCase(AioHTTPTestCase):
             display_region='cy', user_journey='requests', sub_user_journey='access-code'
         )
         self.post_request_access_code_confirm_address_ni = self.app.router['CommonConfirmAddress:post'].url_for(
+            display_region='ni', user_journey='requests', sub_user_journey='access-code'
+        )
+
+        self.post_request_access_code_resident_or_manager_en = self.app.router['CommonCEMangerQuestion:post'].url_for(
+            display_region='en', user_journey='requests', sub_user_journey='access-code'
+        )
+        self.post_request_access_code_resident_or_manager_cy = self.app.router['CommonCEMangerQuestion:post'].url_for(
+            display_region='cy', user_journey='requests', sub_user_journey='access-code'
+        )
+        self.post_request_access_code_resident_or_manager_ni = self.app.router['CommonCEMangerQuestion:post'].url_for(
             display_region='ni', user_journey='requests', sub_user_journey='access-code'
         )
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -313,7 +313,7 @@ class RHTestCase(AioHTTPTestCase):
         }
 
         self.common_resident_or_manager_input_invalid = {
-            'form-resident-or-manager': 'no', 'action[save_continue]': ''
+            'form-resident-or-manager': 'invalid', 'action[save_continue]': ''
         }
 
         self.common_postcode_input_valid = {
@@ -437,6 +437,7 @@ class RHTestCase(AioHTTPTestCase):
         self.content_common_resident_or_manager_option_manager_en = 'Manager'
         self.content_common_resident_or_manager_description_manager_en = \
             'A manager is responsible for answering the census questions about this establishment'
+        self.content_common_resident_or_manager_error_en = 'Please select an option.'
         # TODO: add welsh translation
         self.content_common_resident_or_manager_title_cy = 'Are you a resident or manager of this establishment?'
         # TODO: add welsh translation
@@ -449,6 +450,8 @@ class RHTestCase(AioHTTPTestCase):
         # TODO: add welsh translation
         self.content_common_resident_or_manager_description_manager_cy = \
             'A manager is responsible for answering the census questions about this establishment'
+        # TODO: add welsh translation
+        self.content_common_resident_or_manager_error_cy = 'Please select an option.'
 
         # End Common
 

--- a/tests/unit/test_requests_handlers_code.py
+++ b/tests/unit/test_requests_handlers_code.py
@@ -102,6 +102,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_en,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=HH, region=E, individual=false")
             self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -199,6 +200,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_en,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=HH, region=W, individual=false")
             self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -296,6 +298,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_cy,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=HH, region=W, individual=false")
             self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -393,6 +396,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_ni,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=HH, region=N, individual=false")
             self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -490,6 +494,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_en,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=SPG, region=E, individual=false")
             self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -587,6 +592,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_en,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=SPG, region=W, individual=false")
             self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -684,6 +690,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_cy,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=SPG, region=W, individual=false")
             self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -781,6 +788,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_ni,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=SPG, region=N, individual=false")
             self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -789,7 +797,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
             self.assertIn(self.content_request_code_sent_title_en, str(resp_content))
 
     @unittest_run_loop
-    async def test_request_access_code_sms_happy_path_ce_m_ew_e(
+    async def test_request_access_code_sms_happy_path_select_manager_ce_m_ew_e(
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.utils.AddressIndex.get_ai_postcode'
@@ -894,6 +902,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_en,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=CE, region=E, individual=false")
             self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -902,7 +911,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
             self.assertIn(self.content_request_code_sent_title_en, str(resp_content))
 
     @unittest_run_loop
-    async def test_request_access_code_sms_happy_path_ce_m_ew_w(
+    async def test_request_access_code_sms_happy_path_select_manager_ce_m_ew_w(
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.utils.AddressIndex.get_ai_postcode'
@@ -1007,6 +1016,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_en,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=CE, region=W, individual=false")
             self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -1015,7 +1025,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
             self.assertIn(self.content_request_code_sent_title_en, str(resp_content))
 
     @unittest_run_loop
-    async def test_request_access_code_sms_happy_path_ce_m_cy(
+    async def test_request_access_code_sms_happy_path_select_manager_ce_m_cy(
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.utils.AddressIndex.get_ai_postcode'
@@ -1120,6 +1130,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_cy,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=CE, region=W, individual=false")
             self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -1128,7 +1139,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
             self.assertIn(self.content_request_code_sent_title_cy, str(resp_content))
 
     @unittest_run_loop
-    async def test_request_access_code_sms_happy_path_ce_m_ni(
+    async def test_request_access_code_sms_happy_path_select_manager_ce_m_ni(
             self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.utils.AddressIndex.get_ai_postcode'
@@ -1233,6 +1244,463 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_ni,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=CE, region=N, individual=false")
+            self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/code-sent'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.nisra_logo, str(resp_content))
+            self.assertIn(self.content_request_code_sent_title_en, str(resp_content))
+
+    @unittest_run_loop
+    async def test_request_access_code_sms_happy_path_select_resident_ce_m_ew_e(
+            self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
+                'app.utils.AddressIndex.get_ai_postcode'
+        ) as mocked_get_ai_postcode, mock.patch(
+                'app.utils.AddressIndex.get_ai_uprn'
+        ) as mocked_get_ai_uprn, mock.patch(
+            'app.utils.RHService.get_case_by_uprn'
+        ) as mocked_get_case_by_uprn, mock.patch(
+            'app.utils.RHService.get_fulfilment'
+        ) as mocked_get_fulfilment, mock.patch(
+            'app.utils.RHService.request_fulfilment'
+        ) as mocked_request_fulfilment:
+
+            mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
+            mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_m_e
+            mocked_get_fulfilment.return_value = self.rhsvc_get_fulfilment_multi
+            mocked_request_fulfilment.return_value = self.rhsvc_request_fulfilment
+
+            response = await self.client.request('GET',
+                                                 self.get_request_access_code_enter_address_en)
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/enter-address'")
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.ons_logo_en, contents)
+            self.assertIn(self.content_request_enter_address_title_en, contents)
+            self.assertIn(self.content_request_enter_address_secondary_en, contents)
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_enter_address_en,
+                    data=self.common_postcode_input_valid)
+            self.assertLogEvent(cm, 'valid postcode')
+
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/enter-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/select-address'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_en, str(resp_content))
+            self.assertIn(self.content_common_select_address_title_en, str(resp_content))
+            self.assertIn(self.content_common_select_address_value_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_select_address_en,
+                    data=self.common_select_address_input_valid)
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/select-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/confirm-address'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_en, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_title_en, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_value_yes_en, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_value_change_en, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_value_no_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_confirm_address_en,
+                    data=self.common_confirm_address_input_yes)
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/confirm-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_title_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_resident_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_resident_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_manager_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_manager_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_resident_or_manager_en,
+                    data=self.common_resident_or_manager_input_resident)
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/resident-or-manager'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/enter-mobile'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_en, str(resp_content))
+            self.assertIn(self.content_request_enter_mobile_title_en, str(resp_content))
+            self.assertIn(self.content_request_enter_mobile_secondary_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_enter_mobile_en,
+                    data=self.request_code_enter_mobile_form_data_valid)
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/enter-mobile'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/confirm-mobile'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_en, str(resp_content))
+            self.assertIn(self.content_request_confirm_mobile_title_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_confirm_mobile_en,
+                    data=self.request_code_mobile_confirmation_data_yes)
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=CE, region=E, individual=true")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/code-sent'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_en, str(resp_content))
+            self.assertIn(self.content_request_code_sent_title_en, str(resp_content))
+
+    @unittest_run_loop
+    async def test_request_access_code_sms_happy_path_select_resident_ce_m_ew_w(
+            self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
+                'app.utils.AddressIndex.get_ai_postcode'
+        ) as mocked_get_ai_postcode, mock.patch(
+                'app.utils.AddressIndex.get_ai_uprn'
+        ) as mocked_get_ai_uprn, mock.patch(
+            'app.utils.RHService.get_case_by_uprn'
+        ) as mocked_get_case_by_uprn, mock.patch(
+            'app.utils.RHService.get_fulfilment'
+        ) as mocked_get_fulfilment, mock.patch(
+            'app.utils.RHService.request_fulfilment'
+        ) as mocked_request_fulfilment:
+
+            mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
+            mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_m_w
+            mocked_get_fulfilment.return_value = self.rhsvc_get_fulfilment_multi
+            mocked_request_fulfilment.return_value = self.rhsvc_request_fulfilment
+
+            response = await self.client.request('GET',
+                                                 self.get_request_access_code_enter_address_en)
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/enter-address'")
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.ons_logo_en, contents)
+            self.assertIn(self.content_request_enter_address_title_en, contents)
+            self.assertIn(self.content_request_enter_address_secondary_en, contents)
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_enter_address_en,
+                    data=self.common_postcode_input_valid)
+            self.assertLogEvent(cm, 'valid postcode')
+
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/enter-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/select-address'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_en, str(resp_content))
+            self.assertIn(self.content_common_select_address_title_en, str(resp_content))
+            self.assertIn(self.content_common_select_address_value_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_select_address_en,
+                    data=self.common_select_address_input_valid)
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/select-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/confirm-address'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_en, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_title_en, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_value_yes_en, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_value_change_en, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_value_no_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_confirm_address_en,
+                    data=self.common_confirm_address_input_yes)
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/confirm-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_title_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_resident_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_resident_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_manager_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_manager_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_resident_or_manager_en,
+                    data=self.common_resident_or_manager_input_resident)
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/resident-or-manager'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/enter-mobile'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_en, str(resp_content))
+            self.assertIn(self.content_request_enter_mobile_title_en, str(resp_content))
+            self.assertIn(self.content_request_enter_mobile_secondary_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_enter_mobile_en,
+                    data=self.request_code_enter_mobile_form_data_valid)
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/enter-mobile'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/confirm-mobile'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_en, str(resp_content))
+            self.assertIn(self.content_request_confirm_mobile_title_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_confirm_mobile_en,
+                    data=self.request_code_mobile_confirmation_data_yes)
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=CE, region=W, individual=true")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/code-sent'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_en, str(resp_content))
+            self.assertIn(self.content_request_code_sent_title_en, str(resp_content))
+
+    @unittest_run_loop
+    async def test_request_access_code_sms_happy_path_select_resident_ce_m_cy(
+            self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
+                'app.utils.AddressIndex.get_ai_postcode'
+        ) as mocked_get_ai_postcode, mock.patch(
+                'app.utils.AddressIndex.get_ai_uprn'
+        ) as mocked_get_ai_uprn, mock.patch(
+            'app.utils.RHService.get_case_by_uprn'
+        ) as mocked_get_case_by_uprn, mock.patch(
+            'app.utils.RHService.get_fulfilment'
+        ) as mocked_get_fulfilment, mock.patch(
+            'app.utils.RHService.request_fulfilment'
+        ) as mocked_request_fulfilment:
+
+            mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
+            mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_m_w
+            mocked_get_fulfilment.return_value = self.rhsvc_get_fulfilment_multi
+            mocked_request_fulfilment.return_value = self.rhsvc_request_fulfilment
+
+            response = await self.client.request('GET',
+                                                 self.get_request_access_code_enter_address_cy)
+            self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/enter-address'")
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.ons_logo_cy, contents)
+            self.assertIn(self.content_request_enter_address_title_cy, contents)
+            self.assertIn(self.content_request_enter_address_secondary_cy, contents)
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_enter_address_cy,
+                    data=self.common_postcode_input_valid)
+            self.assertLogEvent(cm, 'valid postcode')
+
+            self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/access-code/enter-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/select-address'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_cy, str(resp_content))
+            self.assertIn(self.content_common_select_address_title_cy, str(resp_content))
+            self.assertIn(self.content_common_select_address_value_cy, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_select_address_cy,
+                    data=self.common_select_address_input_valid)
+            self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/access-code/select-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/confirm-address'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_cy, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_title_cy, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_value_yes_cy, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_value_change_cy, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_value_no_cy, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_confirm_address_cy,
+                    data=self.common_confirm_address_input_yes)
+            self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/access-code/confirm-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_cy, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_title_cy, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_resident_cy, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_resident_cy, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_manager_cy, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_manager_cy, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_resident_or_manager_cy,
+                    data=self.common_resident_or_manager_input_resident)
+            self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/access-code/resident-or-manager'")
+            self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/enter-mobile'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_cy, str(resp_content))
+            self.assertIn(self.content_request_enter_mobile_title_cy, str(resp_content))
+            self.assertIn(self.content_request_enter_mobile_secondary_cy, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_enter_mobile_cy,
+                    data=self.request_code_enter_mobile_form_data_valid)
+            self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/access-code/enter-mobile'")
+            self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/confirm-mobile'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_cy, str(resp_content))
+            self.assertIn(self.content_request_confirm_mobile_title_cy, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_confirm_mobile_cy,
+                    data=self.request_code_mobile_confirmation_data_yes)
+            self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=CE, region=W, individual=true")
+            self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/code-sent'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_cy, str(resp_content))
+            self.assertIn(self.content_request_code_sent_title_cy, str(resp_content))
+
+    @unittest_run_loop
+    async def test_request_access_code_sms_happy_path_select_resident_ce_m_ni(
+            self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
+                'app.utils.AddressIndex.get_ai_postcode'
+        ) as mocked_get_ai_postcode, mock.patch(
+                'app.utils.AddressIndex.get_ai_uprn'
+        ) as mocked_get_ai_uprn, mock.patch(
+            'app.utils.RHService.get_case_by_uprn'
+        ) as mocked_get_case_by_uprn, mock.patch(
+            'app.utils.RHService.get_fulfilment'
+        ) as mocked_get_fulfilment, mock.patch(
+            'app.utils.RHService.request_fulfilment'
+        ) as mocked_request_fulfilment:
+
+            mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
+            mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_m_n
+            mocked_get_fulfilment.return_value = self.rhsvc_get_fulfilment_multi
+            mocked_request_fulfilment.return_value = self.rhsvc_request_fulfilment
+
+            response = await self.client.request('GET',
+                                                 self.get_request_access_code_enter_address_ni)
+            self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/enter-address'")
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.nisra_logo, contents)
+            self.assertIn(self.content_request_enter_address_title_en, contents)
+            self.assertIn(self.content_request_enter_address_secondary_en, contents)
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_enter_address_ni,
+                    data=self.common_postcode_input_valid)
+            self.assertLogEvent(cm, 'valid postcode')
+
+            self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/access-code/enter-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/select-address'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.nisra_logo, str(resp_content))
+            self.assertIn(self.content_common_select_address_title_en, str(resp_content))
+            self.assertIn(self.content_common_select_address_value_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_select_address_ni,
+                    data=self.common_select_address_input_valid)
+            self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/access-code/select-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/confirm-address'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.nisra_logo, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_title_en, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_value_yes_en, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_value_change_en, str(resp_content))
+            self.assertIn(self.content_common_confirm_address_value_no_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_confirm_address_ni,
+                    data=self.common_confirm_address_input_yes)
+            self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/access-code/confirm-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.nisra_logo, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_title_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_resident_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_resident_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_manager_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_manager_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_resident_or_manager_ni,
+                    data=self.common_resident_or_manager_input_resident)
+            self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/access-code/resident-or-manager'")
+            self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/enter-mobile'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.nisra_logo, str(resp_content))
+            self.assertIn(self.content_request_enter_mobile_title_en, str(resp_content))
+            self.assertIn(self.content_request_enter_mobile_secondary_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_enter_mobile_ni,
+                    data=self.request_code_enter_mobile_form_data_valid)
+            self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/access-code/enter-mobile'")
+            self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/confirm-mobile'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.nisra_logo, str(resp_content))
+            self.assertIn(self.content_request_confirm_mobile_title_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_confirm_mobile_ni,
+                    data=self.request_code_mobile_confirmation_data_yes)
+            self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=CE, region=N, individual=true")
             self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -1330,6 +1798,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_en,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=CE, region=E, individual=true")
             self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -1427,6 +1896,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_en,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=CE, region=W, individual=true")
             self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -1524,6 +1994,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_cy,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=CE, region=W, individual=true")
             self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -1621,6 +2092,7 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_mobile_ni,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/access-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=CE, region=N, individual=true")
             self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -3274,6 +3746,354 @@ class TestRequestsHandlersAccessCode(RHTestCase):
             self.assertIn(self.content_common_500_error_en, contents)
 
     @unittest_run_loop
+    async def test_post_request_access_code_resident_or_manager_invalid_ce_m_ew_e(self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
+                'app.utils.AddressIndex.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+            'app.utils.AddressIndex.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
+            'app.utils.RHService.get_case_by_uprn'
+        ) as mocked_get_case_by_uprn:
+            mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
+            mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_m_e
+
+            await self.client.request('GET', self.get_request_access_code_enter_address_en)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_enter_address_en,
+                data=self.common_postcode_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_select_address_en,
+                data=self.common_select_address_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_confirm_address_en,
+                data=self.common_confirm_address_input_yes)
+
+            response = await self.client.request('POST', self.post_request_access_code_resident_or_manager_en,
+                                                 data=self.common_resident_or_manager_input_invalid)
+
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/resident-or-manager'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.ons_logo_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_title_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_resident_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_resident_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_manager_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_manager_en, contents)
+
+    @unittest_run_loop
+    async def test_post_request_access_code_resident_or_manager_invalid_ce_m_ew_w(self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
+                'app.utils.AddressIndex.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+            'app.utils.AddressIndex.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
+            'app.utils.RHService.get_case_by_uprn'
+        ) as mocked_get_case_by_uprn:
+            mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
+            mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_m_w
+
+            await self.client.request('GET', self.get_request_access_code_enter_address_en)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_enter_address_en,
+                data=self.common_postcode_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_select_address_en,
+                data=self.common_select_address_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_confirm_address_en,
+                data=self.common_confirm_address_input_yes)
+
+            response = await self.client.request('POST', self.post_request_access_code_resident_or_manager_en,
+                                                 data=self.common_resident_or_manager_input_invalid)
+
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/resident-or-manager'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.ons_logo_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_title_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_resident_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_resident_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_manager_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_manager_en, contents)
+
+    @unittest_run_loop
+    async def test_post_request_access_code_resident_or_manager_invalid_ce_m_cy(self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
+                'app.utils.AddressIndex.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+            'app.utils.AddressIndex.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
+            'app.utils.RHService.get_case_by_uprn'
+        ) as mocked_get_case_by_uprn:
+            mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
+            mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_m_w
+
+            await self.client.request('GET', self.get_request_access_code_enter_address_cy)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_enter_address_cy,
+                data=self.common_postcode_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_select_address_cy,
+                data=self.common_select_address_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_confirm_address_cy,
+                data=self.common_confirm_address_input_yes)
+
+            response = await self.client.request('POST', self.post_request_access_code_resident_or_manager_cy,
+                                                 data=self.common_resident_or_manager_input_invalid)
+
+            self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/access-code/resident-or-manager'")
+            self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.ons_logo_cy, contents)
+            self.assertIn(self.content_common_resident_or_manager_title_cy, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_resident_cy, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_resident_cy, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_manager_cy, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_manager_cy, contents)
+
+    @unittest_run_loop
+    async def test_post_request_access_code_resident_or_manager_invalid_ce_m_ni(self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
+                'app.utils.AddressIndex.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+            'app.utils.AddressIndex.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
+            'app.utils.RHService.get_case_by_uprn'
+        ) as mocked_get_case_by_uprn:
+            mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
+            mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_m_n
+
+            await self.client.request('GET', self.get_request_access_code_enter_address_ni)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_enter_address_ni,
+                data=self.common_postcode_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_select_address_ni,
+                data=self.common_select_address_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_confirm_address_ni,
+                data=self.common_confirm_address_input_yes)
+
+            response = await self.client.request('POST', self.post_request_access_code_resident_or_manager_ni,
+                                                 data=self.common_resident_or_manager_input_invalid)
+
+            self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/access-code/resident-or-manager'")
+            self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.nisra_logo, contents)
+            self.assertIn(self.content_common_resident_or_manager_title_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_resident_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_resident_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_manager_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_manager_en, contents)
+
+    @unittest_run_loop
+    async def test_post_request_access_code_resident_or_manager_empty_ce_m_ew_e(self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
+                'app.utils.AddressIndex.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+            'app.utils.AddressIndex.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
+            'app.utils.RHService.get_case_by_uprn'
+        ) as mocked_get_case_by_uprn:
+            mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
+            mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_m_e
+
+            await self.client.request('GET', self.get_request_access_code_enter_address_en)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_enter_address_en,
+                data=self.common_postcode_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_select_address_en,
+                data=self.common_select_address_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_confirm_address_en,
+                data=self.common_confirm_address_input_yes)
+
+            response = await self.client.request('POST', self.post_request_access_code_resident_or_manager_en,
+                                                 data=self.common_form_data_empty)
+
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/resident-or-manager'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.ons_logo_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_title_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_error_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_resident_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_resident_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_manager_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_manager_en, contents)
+
+    @unittest_run_loop
+    async def test_post_request_access_code_resident_or_manager_empty_ce_m_ew_w(self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
+                'app.utils.AddressIndex.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+            'app.utils.AddressIndex.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
+            'app.utils.RHService.get_case_by_uprn'
+        ) as mocked_get_case_by_uprn:
+            mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
+            mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_m_w
+
+            await self.client.request('GET', self.get_request_access_code_enter_address_en)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_enter_address_en,
+                data=self.common_postcode_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_select_address_en,
+                data=self.common_select_address_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_confirm_address_en,
+                data=self.common_confirm_address_input_yes)
+
+            response = await self.client.request('POST', self.post_request_access_code_resident_or_manager_en,
+                                                 data=self.common_form_data_empty)
+
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/resident-or-manager'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.ons_logo_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_title_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_error_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_resident_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_resident_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_manager_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_manager_en, contents)
+
+    @unittest_run_loop
+    async def test_post_request_access_code_resident_or_manager_empty_ce_m_cy(self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
+                'app.utils.AddressIndex.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+            'app.utils.AddressIndex.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
+            'app.utils.RHService.get_case_by_uprn'
+        ) as mocked_get_case_by_uprn:
+            mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
+            mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_m_w
+
+            await self.client.request('GET', self.get_request_access_code_enter_address_cy)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_enter_address_cy,
+                data=self.common_postcode_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_select_address_cy,
+                data=self.common_select_address_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_confirm_address_cy,
+                data=self.common_confirm_address_input_yes)
+
+            response = await self.client.request('POST', self.post_request_access_code_resident_or_manager_cy,
+                                                 data=self.common_form_data_empty)
+
+            self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/access-code/resident-or-manager'")
+            self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.ons_logo_cy, contents)
+            self.assertIn(self.content_common_resident_or_manager_title_cy, contents)
+            self.assertIn(self.content_common_resident_or_manager_error_cy, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_resident_cy, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_resident_cy, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_manager_cy, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_manager_cy, contents)
+
+    @unittest_run_loop
+    async def test_post_request_access_code_resident_or_manager_empty_ce_m_ni(self):
+        with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
+                'app.utils.AddressIndex.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
+            'app.utils.AddressIndex.get_ai_uprn') as mocked_get_ai_uprn, mock.patch(
+            'app.utils.RHService.get_case_by_uprn'
+        ) as mocked_get_case_by_uprn:
+            mocked_get_ai_postcode.return_value = self.ai_postcode_results
+            mocked_get_ai_uprn.return_value = self.ai_uprn_result
+            mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_m_n
+
+            await self.client.request('GET', self.get_request_access_code_enter_address_ni)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_enter_address_ni,
+                data=self.common_postcode_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_select_address_ni,
+                data=self.common_select_address_input_valid)
+
+            await self.client.request(
+                'POST',
+                self.post_request_access_code_confirm_address_ni,
+                data=self.common_confirm_address_input_yes)
+
+            response = await self.client.request('POST', self.post_request_access_code_resident_or_manager_ni,
+                                                 data=self.common_form_data_empty)
+
+            self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/access-code/resident-or-manager'")
+            self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.nisra_logo, contents)
+            self.assertIn(self.content_common_resident_or_manager_title_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_error_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_resident_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_resident_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_option_manager_en, contents)
+            self.assertIn(self.content_common_resident_or_manager_description_manager_en, contents)
+
+    @unittest_run_loop
     async def test_post_request_access_code_enter_mobile_invalid_hh_ew_e(self):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.utils.AddressIndex.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
@@ -3367,21 +4187,21 @@ class TestRequestsHandlersAccessCode(RHTestCase):
             mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_hh_w
 
-            await self.client.request('GET', self.get_request_access_code_enter_address_en)
+            await self.client.request('GET', self.get_request_access_code_enter_address_cy)
 
             await self.client.request(
                     'POST',
-                    self.post_request_access_code_enter_address_en,
+                    self.post_request_access_code_enter_address_cy,
                     data=self.common_postcode_input_valid)
 
             await self.client.request(
                     'POST',
-                    self.post_request_access_code_select_address_en,
+                    self.post_request_access_code_select_address_cy,
                     data=self.common_select_address_input_valid)
 
             await self.client.request(
                     'POST',
-                    self.post_request_access_code_confirm_address_en,
+                    self.post_request_access_code_confirm_address_cy,
                     data=self.common_confirm_address_input_yes)
 
             response = await self.client.request('POST', self.post_request_access_code_enter_mobile_cy,
@@ -3408,21 +4228,21 @@ class TestRequestsHandlersAccessCode(RHTestCase):
             mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_hh_n
 
-            await self.client.request('GET', self.get_request_access_code_enter_address_en)
+            await self.client.request('GET', self.get_request_access_code_enter_address_ni)
 
             await self.client.request(
                     'POST',
-                    self.post_request_access_code_enter_address_en,
+                    self.post_request_access_code_enter_address_ni,
                     data=self.common_postcode_input_valid)
 
             await self.client.request(
                     'POST',
-                    self.post_request_access_code_select_address_en,
+                    self.post_request_access_code_select_address_ni,
                     data=self.common_select_address_input_valid)
 
             await self.client.request(
                     'POST',
-                    self.post_request_access_code_confirm_address_en,
+                    self.post_request_access_code_confirm_address_ni,
                     data=self.common_confirm_address_input_yes)
 
             response = await self.client.request('POST', self.post_request_access_code_enter_mobile_ni,
@@ -3528,21 +4348,21 @@ class TestRequestsHandlersAccessCode(RHTestCase):
             mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_spg_w
 
-            await self.client.request('GET', self.get_request_access_code_enter_address_en)
+            await self.client.request('GET', self.get_request_access_code_enter_address_cy)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_enter_address_en,
+                self.post_request_access_code_enter_address_cy,
                 data=self.common_postcode_input_valid)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_select_address_en,
+                self.post_request_access_code_select_address_cy,
                 data=self.common_select_address_input_valid)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_confirm_address_en,
+                self.post_request_access_code_confirm_address_cy,
                 data=self.common_confirm_address_input_yes)
 
             response = await self.client.request('POST', self.post_request_access_code_enter_mobile_cy,
@@ -3568,21 +4388,21 @@ class TestRequestsHandlersAccessCode(RHTestCase):
             mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_spg_n
 
-            await self.client.request('GET', self.get_request_access_code_enter_address_en)
+            await self.client.request('GET', self.get_request_access_code_enter_address_ni)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_enter_address_en,
+                self.post_request_access_code_enter_address_ni,
                 data=self.common_postcode_input_valid)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_select_address_en,
+                self.post_request_access_code_select_address_ni,
                 data=self.common_select_address_input_valid)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_confirm_address_en,
+                self.post_request_access_code_confirm_address_ni,
                 data=self.common_confirm_address_input_yes)
 
             response = await self.client.request('POST', self.post_request_access_code_enter_mobile_ni,
@@ -3688,21 +4508,21 @@ class TestRequestsHandlersAccessCode(RHTestCase):
             mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_m_w
 
-            await self.client.request('GET', self.get_request_access_code_enter_address_en)
+            await self.client.request('GET', self.get_request_access_code_enter_address_cy)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_enter_address_en,
+                self.post_request_access_code_enter_address_cy,
                 data=self.common_postcode_input_valid)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_select_address_en,
+                self.post_request_access_code_select_address_cy,
                 data=self.common_select_address_input_valid)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_confirm_address_en,
+                self.post_request_access_code_confirm_address_cy,
                 data=self.common_confirm_address_input_yes)
 
             response = await self.client.request('POST', self.post_request_access_code_enter_mobile_cy,
@@ -3728,21 +4548,21 @@ class TestRequestsHandlersAccessCode(RHTestCase):
             mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_m_n
 
-            await self.client.request('GET', self.get_request_access_code_enter_address_en)
+            await self.client.request('GET', self.get_request_access_code_enter_address_ni)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_enter_address_en,
+                self.post_request_access_code_enter_address_ni,
                 data=self.common_postcode_input_valid)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_select_address_en,
+                self.post_request_access_code_select_address_ni,
                 data=self.common_select_address_input_valid)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_confirm_address_en,
+                self.post_request_access_code_confirm_address_ni,
                 data=self.common_confirm_address_input_yes)
 
             response = await self.client.request('POST', self.post_request_access_code_enter_mobile_ni,
@@ -3848,21 +4668,21 @@ class TestRequestsHandlersAccessCode(RHTestCase):
             mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_r_w
 
-            await self.client.request('GET', self.get_request_access_code_enter_address_en)
+            await self.client.request('GET', self.get_request_access_code_enter_address_cy)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_enter_address_en,
+                self.post_request_access_code_enter_address_cy,
                 data=self.common_postcode_input_valid)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_select_address_en,
+                self.post_request_access_code_select_address_cy,
                 data=self.common_select_address_input_valid)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_confirm_address_en,
+                self.post_request_access_code_confirm_address_cy,
                 data=self.common_confirm_address_input_yes)
 
             response = await self.client.request('POST', self.post_request_access_code_enter_mobile_cy,
@@ -3888,21 +4708,21 @@ class TestRequestsHandlersAccessCode(RHTestCase):
             mocked_get_ai_uprn.return_value = self.ai_uprn_result
             mocked_get_case_by_uprn.return_value = self.rhsvc_case_by_uprn_ce_r_n
 
-            await self.client.request('GET', self.get_request_access_code_enter_address_en)
+            await self.client.request('GET', self.get_request_access_code_enter_address_ni)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_enter_address_en,
+                self.post_request_access_code_enter_address_ni,
                 data=self.common_postcode_input_valid)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_select_address_en,
+                self.post_request_access_code_select_address_ni,
                 data=self.common_select_address_input_valid)
 
             await self.client.request(
                 'POST',
-                self.post_request_access_code_confirm_address_en,
+                self.post_request_access_code_confirm_address_ni,
                 data=self.common_confirm_address_input_yes)
 
             response = await self.client.request('POST', self.post_request_access_code_enter_mobile_ni,
@@ -11042,6 +11862,7 @@ class TestRequestsHandlersIndividualCode(RHTestCase):
                     self.post_request_individual_code_confirm_mobile_en,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'en/requests/individual-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=HH, region=E, individual=true")
             self.assertLogEvent(cm, "received GET on endpoint 'en/requests/individual-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -11148,6 +11969,7 @@ class TestRequestsHandlersIndividualCode(RHTestCase):
                     self.post_request_individual_code_confirm_mobile_en,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'en/requests/individual-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=HH, region=W, individual=true")
             self.assertLogEvent(cm, "received GET on endpoint 'en/requests/individual-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -11254,6 +12076,7 @@ class TestRequestsHandlersIndividualCode(RHTestCase):
                     self.post_request_individual_code_confirm_mobile_cy,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/individual-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=HH, region=W, individual=true")
             self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/individual-code/code-sent'")
 
             self.assertEqual(response.status, 200)
@@ -11360,6 +12183,7 @@ class TestRequestsHandlersIndividualCode(RHTestCase):
                     self.post_request_individual_code_confirm_mobile_ni,
                     data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/individual-code/confirm-mobile'")
+            self.assertLogEvent(cm, "fulfilment query: case_type=HH, region=N, individual=true")
             self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/individual-code/code-sent'")
 
             self.assertEqual(response.status, 200)

--- a/tests/unit/test_requests_handlers_code.py
+++ b/tests/unit/test_requests_handlers_code.py
@@ -853,6 +853,22 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_address_en,
                     data=self.common_confirm_address_input_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/confirm-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_title_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_resident_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_resident_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_manager_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_manager_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_resident_or_manager_en,
+                    data=self.common_resident_or_manager_input_manager)
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/resident-or-manager'")
             self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/enter-mobile'")
 
             self.assertEqual(response.status, 200)
@@ -950,6 +966,22 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_address_en,
                     data=self.common_confirm_address_input_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/confirm-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_title_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_resident_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_resident_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_manager_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_manager_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_resident_or_manager_en,
+                    data=self.common_resident_or_manager_input_manager)
+            self.assertLogEvent(cm, "received POST on endpoint 'en/requests/access-code/resident-or-manager'")
             self.assertLogEvent(cm, "received GET on endpoint 'en/requests/access-code/enter-mobile'")
 
             self.assertEqual(response.status, 200)
@@ -1047,6 +1079,22 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_address_cy,
                     data=self.common_confirm_address_input_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/access-code/confirm-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.ons_logo_cy, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_title_cy, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_resident_cy, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_resident_cy, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_manager_cy, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_manager_cy, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_resident_or_manager_cy,
+                    data=self.common_resident_or_manager_input_manager)
+            self.assertLogEvent(cm, "received POST on endpoint 'cy/requests/access-code/resident-or-manager'")
             self.assertLogEvent(cm, "received GET on endpoint 'cy/requests/access-code/enter-mobile'")
 
             self.assertEqual(response.status, 200)
@@ -1144,6 +1192,22 @@ class TestRequestsHandlersAccessCode(RHTestCase):
                     self.post_request_access_code_confirm_address_ni,
                     data=self.common_confirm_address_input_yes)
             self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/access-code/confirm-address'")
+            self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/resident-or-manager'")
+
+            self.assertEqual(response.status, 200)
+            resp_content = await response.content.read()
+            self.assertIn(self.nisra_logo, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_title_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_resident_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_resident_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_option_manager_en, str(resp_content))
+            self.assertIn(self.content_common_resident_or_manager_description_manager_en, str(resp_content))
+
+            response = await self.client.request(
+                    'POST',
+                    self.post_request_access_code_resident_or_manager_ni,
+                    data=self.common_resident_or_manager_input_manager)
+            self.assertLogEvent(cm, "received POST on endpoint 'ni/requests/access-code/resident-or-manager'")
             self.assertLogEvent(cm, "received GET on endpoint 'ni/requests/access-code/enter-mobile'")
 
             self.assertEqual(response.status, 200)


### PR DESCRIPTION
# Motivation and Context
Adds additional question in CE request journey if selected address is CE Establishment

# What has changed
New common route for asking additional question if address selected by user is a CE and an Establishment to ask if they are a resident or a manager, and build the fulfilment request appropriately.

# How to test?
Unit tests added/updated for CE estab paths
Test by selecting a CE Estab in the address picker, and confirming question appears
No RHCuc update is required

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-994

# Screenshots (if appropriate):