### PR TITLE
CR-713 Fix hidden field implementation

### DIFF
--- a/app/templates/start-launch-eq.html
+++ b/app/templates/start-launch-eq.html
@@ -20,14 +20,9 @@
         {{
             onsInput({
                 "type": "hidden",
-                "classes": "u-d-no",
                 "id": "token",
                 "name": "token",
-                "value": token,
-                "label": {
-                    "text": "Enter some text",
-                    "classes": "u-d-no"
-                }
+                "value": token
             })
         }}
     {% endif %}

--- a/app/templates/start.html
+++ b/app/templates/start.html
@@ -118,14 +118,9 @@
         {{
             onsInput({
                 "type": "hidden",
-                "classes": "u-d-no",
                 "id": "adlocation",
                 "name": "adlocation",
-                "value": adlocation,
-                "label": {
-                    "text": "Enter some text",
-                    "classes": "u-d-no"
-                }
+                "value": adlocation
             })
         }}
     {% endif %}

--- a/scripts/load_templates.sh
+++ b/scripts/load_templates.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "${DIR}"/.. || exit
 
-DESIGN_SYSTEM_VERSION="19.2.3"
+DESIGN_SYSTEM_VERSION="19.3.2"
 
 TEMP_DIR=$(mktemp -d)
 


### PR DESCRIPTION
Update to design system, and removal of now unnecessary fields

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
The Design System bug requiring a label on hidden fields has been fixed. This implements the fix in RHUI.

# What has changed
This ups the design system version to 17.3.2
Removes the call params for the label on the 2 hidden field usages
No required unit test or Cucumber updates

# How to test?
Visual check that page still renders with fields removed
Existing unit tests checking for adlocation value still pass
Tested against RHCucumber - no updates required

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-713
