### PR TITLE
Cr 1075 update inline error messages

### DIFF
--- a/app/templates/common-confirm-address.html
+++ b/app/templates/common-confirm-address.html
@@ -61,7 +61,7 @@
 
 {% block main %}
 
-        {% if messages_dict %}
+    {% if messages_dict %}
         {% include 'partials/messages.html' with context %}
     {% endif %}
 

--- a/app/templates/common-enter-address.html
+++ b/app/templates/common-enter-address.html
@@ -28,16 +28,16 @@
 
 {% block main %}
 
+    {% if messages_dict %}
+        {% include 'partials/messages.html' with context %}
+    {% endif %}
+
     {% if sub_user_journey == 'unlinked' %}
 
         <h1 class="u-mb-l u-fs-xxl">{{_('Please supply your address')}}</h1>
 
         <p>{{_('The access code that you have entered is not currently linked to an address. Please select your address so we can make the link.')}}</p>
 
-    {% endif %}
-
-    {% if messages_dict %}
-        {% include 'partials/messages.html' with context %}
     {% endif %}
 
     {% call onsQuestion({

--- a/app/templates/common-select-address.html
+++ b/app/templates/common-select-address.html
@@ -28,7 +28,11 @@
 
 {% block main %}
 
-        {% if total_matches == 0: %}
+    {% if messages_dict %}
+        {% include 'partials/messages.html' with context %}
+    {% endif %}
+
+    {% if total_matches == 0: %}
 
         <h1>{{ _('We cannot find your address') }}</h1>
 

--- a/app/templates/partials/messages.html
+++ b/app/templates/partials/messages.html
@@ -4,9 +4,17 @@
 {% from './components/lists/_macro.njk' import onsList %}
 
 {% if messages | length == 1 %}
-    {% set errorTitle = _('This page has an error') %}
+    {% if page_url == '/start/' %}
+        {% set errorTitle = _('There is a problem with this page') %}
+    {% else %}
+        {% set errorTitle = _('There is a problem with your answer') %}
+    {% endif %}
 {% else %}
-    {% set errorTitle = _('This page has %(errorcount)s errors', errorcount= messages | length | string ) %}
+    {% if page_url == '/start/' %}
+        {% set errorTitle = _('There are %(errorcount)s problems with this page', errorcount= messages | length | string ) %}
+    {% else %}
+        {% set errorTitle = _('There are %(errorcount)s problems with your answer', errorcount= messages | length | string ) %}
+    {% endif %}
 {% endif %}
 
 {% set itemsList = [] %}
@@ -31,10 +39,6 @@
         'type': 'error'
     })
 %}
-
-{% autoescape false %}
-    <p>{{ _('These %(startbold)smust be corrected%(endbold)s to continue.', startbold='<strong>', endbold='</strong>')|safe }}</p>
-{% endautoescape %}
 
 {{
     onsList({


### PR DESCRIPTION
# Motivation and Context
Tweaks to the content (and some positioning) of in page error messages, to align with the Design System

# What has changed
Updates to text of in page messaging
Remove of line of text from error messaging
Some updates to ensure that initial error message appears above the page title in the page (incorrectly positioned on a couple of pages)

# How to test?
Run and trigger an error on the pages (submit form without selection or input, invalid input etc)
No Cucumber changes required

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1075
https://ons-design-system.netlify.app/patterns/error-validation/