### PR TITLE
Cr 1152 correct datetime dst

### DIFF
--- a/app/webchat_handlers.py
+++ b/app/webchat_handlers.py
@@ -18,6 +18,13 @@ from .utils import View
 logger = get_logger('respondent-home')
 webchat_routes = RouteTableDef()
 
+bank_holidays = [
+    date(2021, 4, 2),
+    date(2021, 4, 5),
+    date(2021, 5, 3),
+    date(2021, 5, 31)
+]
+
 census_saturday = date(2021, 3, 20)
 census_sunday = date(2021, 3, 21)
 
@@ -54,7 +61,7 @@ class WebChat(View):
             return census_sunday_open, census_sunday_close, hour
         elif weekday == 5:  # Saturday
             return saturday_open, saturday_close, hour
-        elif weekday == 6:  # Sunday
+        elif weekday == 6 or now_date in bank_holidays:  # Sunday or bank holiday
             return None, None, None
         else:
             return weekday_open, weekday_close, hour

--- a/tests/unit/test_webchat_handlers.py
+++ b/tests/unit/test_webchat_handlers.py
@@ -104,6 +104,12 @@ class TestWebChatHandlers(RHTestCase):
         self.should_be_closed(2021, 3, 28, 11, 30)      # 2021 GMT spring
         self.should_be_closed(2021, 4, 4, 11, 30)       # 2021 BST summer
 
+    def test_check_open_bank_holidays_closed(self):
+        self.should_be_closed(2021, 4, 2, 10, 30)       # 2021 Good Friday
+        self.should_be_closed(2021, 4, 5, 10, 30)       # 2021 Easter Monday
+        self.should_be_closed(2021, 5, 3, 10, 30)       # 2021 Mayday bank holiday
+        self.should_be_closed(2021, 5, 31, 10, 30)      # 2021 Spring bank holiday
+
     async def should_respond_open_to_get(self, path, logo, name_prompt, mocked_now_utc):
         with mock.patch('app.webchat_handlers.WebChat.get_now_utc') as mocked_get_now_utc:
             mocked_get_now_utc.return_value = mocked_now_utc

--- a/tests/unit/test_webchat_handlers.py
+++ b/tests/unit/test_webchat_handlers.py
@@ -30,36 +30,48 @@ class TestWebChatHandlers(RHTestCase):
             mocked_get_now_utc.return_value = mocked_now_utc
             self.assertFalse(WebChat.check_open())
 
-    def test_check_open_saturday_census_rehearsal_weekend_open(self):
-        self.should_be_open(2019, 10, 12, 9, 30)
+    def test_check_open_census_saturday_open(self):
+        self.should_be_open(2021, 3, 20, 8, 1)      # just after opening
+        self.should_be_open(2021, 3, 20, 10, 30)    # mid morning
+        self.should_be_open(2021, 3, 20, 15, 59)    # before closing
 
-    def test_check_open_sunday_census_rehearsal_weekend_closed(self):
-        self.should_be_closed(2019, 10, 13, 6, 30)
+    def test_check_open_census_saturday_closed(self):
+        self.should_be_closed(2021, 3, 20, 7, 59)   # just before opening
+        self.should_be_closed(2021, 3, 20, 16, 1)   # just after closing
+
+    def test_check_open_census_sunday_open(self):
+        self.should_be_open(2021, 3, 21, 8, 1)      # just after opening
+        self.should_be_open(2021, 3, 21, 10, 30)    # mid morning
+        self.should_be_open(2021, 3, 21, 15, 59)    # before closing
+
+    def test_check_open_census_sunday_closed(self):
+        self.should_be_closed(2021, 3, 21, 7, 59)   # just before opening
+        self.should_be_closed(2021, 3, 21, 16, 1)   # just after closing
 
     def test_check_open_weekday_open(self):
         self.should_be_open(2019, 6, 17, 9, 30)     # 2019 BST summer
         self.should_be_open(2020, 8, 12, 7, 1)      # 2020 BST summer just after opening
-        self.should_be_open(2020, 8, 12, 17, 59)    # 2020 BST summer just before closing
+        self.should_be_open(2020, 8, 12, 18, 59)    # 2020 BST summer just before closing
         self.should_be_open(2020, 11, 10, 8, 1)     # 2020 GMT winter just after opening
-        self.should_be_open(2020, 11, 10, 18, 59)   # 2020 GMT winter just before closing
+        self.should_be_open(2020, 11, 10, 19, 59)   # 2020 GMT winter just before closing
         self.should_be_open(2021, 3, 26, 8, 1)      # 2021 GMT spring just after opening
         self.should_be_open(2021, 3, 26, 13, 30)    # 2021 GMT spring mid day
-        self.should_be_open(2021, 3, 26, 18, 59)    # 2021 GMT spring just before closing
+        self.should_be_open(2021, 3, 26, 19, 59)    # 2021 GMT spring just before closing
         self.should_be_open(2021, 3, 29, 7, 1)      # 2021 BST summer just after opening
         self.should_be_open(2021, 3, 29, 12, 30)    # 2021 BST summer mid day
-        self.should_be_open(2021, 3, 29, 17, 59)    # 2021 BST summer just before closing
+        self.should_be_open(2021, 3, 29, 18, 59)    # 2021 BST summer just before closing
 
     def test_check_open_weekday_closed(self):
         self.should_be_closed(2019, 6, 16, 4, 30)   # 2019 BST summer before opening
         self.should_be_closed(2019, 6, 16, 21, 30)  # 2019 BST summer after closing
         self.should_be_closed(2020, 8, 12, 6, 59)   # 2020 BST summer just before opening
-        self.should_be_closed(2020, 8, 12, 18, 1)   # 2020 BST summer just after closing
+        self.should_be_closed(2020, 8, 12, 19, 1)   # 2020 BST summer just after closing
         self.should_be_closed(2020, 11, 10, 7, 59)  # 2020 GMT winter just before opening
-        self.should_be_closed(2020, 11, 10, 19, 1)  # 2020 GMT winter just after closing
+        self.should_be_closed(2020, 11, 10, 20, 1)  # 2020 GMT winter just after closing
         self.should_be_closed(2021, 3, 26, 7, 59)   # 2021 GMT spring just before opening
-        self.should_be_closed(2021, 3, 26, 19, 1)   # 2021 GMT spring just after closing
+        self.should_be_closed(2021, 3, 26, 20, 1)   # 2021 GMT spring just after closing
         self.should_be_closed(2021, 3, 29, 6, 59)   # 2021 BST summer just before opening
-        self.should_be_closed(2021, 3, 29, 18, 1)   # 2021 BST summer just after closing
+        self.should_be_closed(2021, 3, 29, 19, 1)   # 2021 BST summer just after closing
 
     def test_check_open_saturday_open(self):
         self.should_be_open(2019, 6, 15, 9, 30)     # 2019 BST summer
@@ -155,7 +167,7 @@ class TestWebChatHandlers(RHTestCase):
                                                   mocked_now_utc)
     @unittest_run_loop
     async def test_get_webchat_not_open_200_en_2021_bst(self):
-        mocked_now_utc = datetime.datetime(2021, 3, 29, 18, 1)
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 19, 1)
         await self.should_respond_not_open_to_get(self.get_webchat_en, self.ons_logo_en, 'Bank Holidays',
                                                   mocked_now_utc)
 
@@ -167,7 +179,7 @@ class TestWebChatHandlers(RHTestCase):
 
     @unittest_run_loop
     async def test_get_webchat_not_open_200_cy_2021_bst(self):
-        mocked_now_utc = datetime.datetime(2021, 3, 29, 18, 1)
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 19, 1)
         await self.should_respond_not_open_to_get(self.get_webchat_cy, self.ons_logo_cy, 'Gwyliau Banc',
                                                   mocked_now_utc)
 
@@ -179,7 +191,7 @@ class TestWebChatHandlers(RHTestCase):
 
     @unittest_run_loop
     async def test_get_webchat_not_open_200_ni_2021_bst(self):
-        mocked_now_utc = datetime.datetime(2021, 3, 29, 18, 1)
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 19, 1)
         await self.should_respond_not_open_to_get(self.get_webchat_ni, self.nisra_logo, 'Bank Holidays',
                                                   mocked_now_utc)
 
@@ -371,7 +383,7 @@ class TestWebChatHandlers(RHTestCase):
 
     @unittest_run_loop
     async def test_post_webchat_not_open_200_en_2021_bst(self):
-        mocked_now_utc = datetime.datetime(2021, 3, 29, 18, 1)
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 19, 1)
         await self.should_respond_not_open_to_post(self.post_webchat_en, 'Bank Holidays', self.ons_logo_en,
                                                    mocked_now_utc)
 
@@ -383,7 +395,7 @@ class TestWebChatHandlers(RHTestCase):
 
     @unittest_run_loop
     async def test_post_webchat_not_open_200_cy_2021_bst(self):
-        mocked_now_utc = datetime.datetime(2021, 3, 29, 18, 1)
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 19, 1)
         await self.should_respond_not_open_to_post(self.post_webchat_cy, 'Gwyliau Banc', self.ons_logo_cy,
                                                    mocked_now_utc)
 
@@ -395,7 +407,7 @@ class TestWebChatHandlers(RHTestCase):
 
     @unittest_run_loop
     async def test_post_webchat_not_open_200_ni_2021_bst(self):
-        mocked_now_utc = datetime.datetime(2021, 3, 29, 18, 1)
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 19, 1)
         await self.should_respond_not_open_to_post(self.post_webchat_ni, 'Bank Holidays', self.nisra_logo,
                                                    mocked_now_utc)
 

--- a/tests/unit/test_webchat_handlers.py
+++ b/tests/unit/test_webchat_handlers.py
@@ -17,146 +17,171 @@ from . import RHTestCase
 
 
 class TestWebChatHandlers(RHTestCase):
-    def test_check_open_weekday_open_census_weekend(self):
-        mocked_now = datetime.datetime(2019, 10, 12, 9, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
+
+    def should_be_open(self, year, month=None, day=None, hour=0, minute=0, second=0):
+        mocked_now_utc = datetime.datetime(year, month, day, hour, minute, second, 0)
+        with mock.patch('app.webchat_handlers.WebChat.get_now_utc') as mocked_get_now_utc:
+            mocked_get_now_utc.return_value = mocked_now_utc
             self.assertTrue(WebChat.check_open())
 
-    def test_check_open_weekday_closed_census_weekend(self):
-        mocked_now = datetime.datetime(2019, 10, 13, 6, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
+    def should_be_closed(self, year, month=None, day=None, hour=0, minute=0, second=0):
+        mocked_now_utc = datetime.datetime(year, month, day, hour, minute, second, 0)
+        with mock.patch('app.webchat_handlers.WebChat.get_now_utc') as mocked_get_now_utc:
+            mocked_get_now_utc.return_value = mocked_now_utc
             self.assertFalse(WebChat.check_open())
+
+    def test_check_open_saturday_census_rehearsal_weekend_open(self):
+        self.should_be_open(2019, 10, 12, 9, 30)
+
+    def test_check_open_sunday_census_rehearsal_weekend_closed(self):
+        self.should_be_closed(2019, 10, 13, 6, 30)
 
     def test_check_open_weekday_open(self):
-        mocked_now = datetime.datetime(2019, 6, 17, 9, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
-            self.assertTrue(WebChat.check_open())
+        self.should_be_open(2019, 6, 17, 9, 30)     # 2019 BST summer
+        self.should_be_open(2020, 8, 12, 7, 1)      # 2020 BST summer just after opening
+        self.should_be_open(2020, 8, 12, 17, 59)    # 2020 BST summer just before closing
+        self.should_be_open(2020, 11, 10, 8, 1)     # 2020 GMT winter just after opening
+        self.should_be_open(2020, 11, 10, 18, 59)   # 2020 GMT winter just before closing
+        self.should_be_open(2021, 3, 26, 8, 1)      # 2021 GMT spring just after opening
+        self.should_be_open(2021, 3, 26, 13, 30)    # 2021 GMT spring mid day
+        self.should_be_open(2021, 3, 26, 18, 59)    # 2021 GMT spring just before closing
+        self.should_be_open(2021, 3, 29, 7, 1)      # 2021 BST summer just after opening
+        self.should_be_open(2021, 3, 29, 12, 30)    # 2021 BST summer mid day
+        self.should_be_open(2021, 3, 29, 17, 59)    # 2021 BST summer just before closing
 
-    def test_check_open_weekday_closed_am(self):
-        mocked_now = datetime.datetime(2019, 6, 16, 4, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
-            self.assertFalse(WebChat.check_open())
-
-    def test_check_open_weekday_closed_pm(self):
-        mocked_now = datetime.datetime(2019, 6, 16, 21, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
-            self.assertFalse(WebChat.check_open())
+    def test_check_open_weekday_closed(self):
+        self.should_be_closed(2019, 6, 16, 4, 30)   # 2019 BST summer before opening
+        self.should_be_closed(2019, 6, 16, 21, 30)  # 2019 BST summer after closing
+        self.should_be_closed(2020, 8, 12, 6, 59)   # 2020 BST summer just before opening
+        self.should_be_closed(2020, 8, 12, 18, 1)   # 2020 BST summer just after closing
+        self.should_be_closed(2020, 11, 10, 7, 59)  # 2020 GMT winter just before opening
+        self.should_be_closed(2020, 11, 10, 19, 1)  # 2020 GMT winter just after closing
+        self.should_be_closed(2021, 3, 26, 7, 59)   # 2021 GMT spring just before opening
+        self.should_be_closed(2021, 3, 26, 19, 1)   # 2021 GMT spring just after closing
+        self.should_be_closed(2021, 3, 29, 6, 59)   # 2021 BST summer just before opening
+        self.should_be_closed(2021, 3, 29, 18, 1)   # 2021 BST summer just after closing
 
     def test_check_open_saturday_open(self):
-        mocked_now = datetime.datetime(2019, 6, 15, 9, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
-            self.assertTrue(WebChat.check_open())
+        self.should_be_open(2019, 6, 15, 9, 30)     # 2019 BST summer
+        self.should_be_open(2020, 8, 15, 7, 1)      # 2020 BST summer just after opening
+        self.should_be_open(2020, 8, 15, 11, 59)    # 2020 BST summer just before closing
+        self.should_be_open(2020, 11, 14, 8, 1)     # 2020 GMT winter just after opening
+        self.should_be_open(2020, 11, 14, 12, 59)   # 2020 GMT winter just before closing
+        self.should_be_open(2021, 3, 27, 8, 1)      # 2021 GMT spring just after opening
+        self.should_be_open(2021, 3, 27, 10, 30)    # 2021 GMT spring mid morning
+        self.should_be_open(2021, 3, 27, 12, 59)    # 2021 GMT spring just before closing
+        self.should_be_open(2021, 4, 3, 7, 1)       # 2021 BST summer just after opening
+        self.should_be_open(2021, 4, 3, 9, 30)      # 2021 BST summer mid morning
+        self.should_be_open(2021, 4, 3, 11, 59)     # 2021 BST summer just before closing
 
     def test_check_open_saturday_closed(self):
-        mocked_now = datetime.datetime(2019, 6, 15, 16, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
-            self.assertFalse(WebChat.check_open())
+        self.should_be_closed(2019, 6, 15, 16, 30)  # 2019 BST summer
+        self.should_be_closed(2020, 8, 15, 6, 59)   # 2020 BST summer just before opening
+        self.should_be_closed(2020, 8, 15, 12, 1)   # 2020 BST summer just after closing
+        self.should_be_closed(2020, 11, 14, 7, 59)  # 2020 GMT winter just before opening
+        self.should_be_closed(2020, 11, 14, 13, 1)  # 2020 GMT winter just after closing
+        self.should_be_closed(2021, 3, 27, 7, 59)   # 2021 GMT spring just before opening
+        self.should_be_closed(2021, 3, 27, 13, 1)   # 2021 GMT spring just after closing
+        self.should_be_closed(2021, 4, 3, 6, 59)    # 2021 BST summer just before opening
+        self.should_be_closed(2021, 4, 3, 12, 1)    # 2021 BST summer just after closing
 
     def test_check_open_sunday_closed(self):
-        mocked_now = datetime.datetime(2019, 6, 16, 16, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
-            self.assertFalse(WebChat.check_open())
+        self.should_be_closed(2019, 6, 16, 16, 30)      # 2019 BST summer
+        self.should_be_closed(2020, 8, 16, 11, 30)      # 2020 BST summer
+        self.should_be_closed(2020, 11, 15, 11, 30)     # 2020 GMT winter
+        self.should_be_closed(2021, 3, 28, 11, 30)      # 2021 GMT spring
+        self.should_be_closed(2021, 4, 4, 11, 30)       # 2021 BST summer
+
+    async def should_respond_open_to_get(self, path, logo, name_prompt, mocked_now_utc):
+        with mock.patch('app.webchat_handlers.WebChat.get_now_utc') as mocked_get_now_utc:
+            mocked_get_now_utc.return_value = mocked_now_utc
+
+            response = await self.client.request('GET', path)
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(logo, contents)
+            self.assertIn(name_prompt, contents)
+            self.assertEqual(contents.count('radio__input'), 10)
+            self.assertIn('type="submit"', contents)
 
     @unittest_run_loop
     async def test_get_webchat_open_en(self):
-        mocked_now = datetime.datetime(2019, 6, 15, 9, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
+        mocked_now_utc = datetime.datetime(2019, 6, 15, 9, 30)
+        await self.should_respond_open_to_get(self.get_webchat_en, self.ons_logo_en, 'Enter your name', mocked_now_utc)
 
-            response = await self.client.request('GET', self.get_webchat_en)
-            self.assertEqual(response.status, 200)
-            contents = str(await response.content.read())
-            self.assertIn(self.ons_logo_en, contents)
-            self.assertIn('Enter your name', contents)
-            self.assertEqual(contents.count('radio__input'), 10)
-            self.assertIn('type="submit"', contents)
+    @unittest_run_loop
+    async def test_get_webchat_open_en_2021_bst(self):
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 7, 1)
+        await self.should_respond_open_to_get(self.get_webchat_en, self.ons_logo_en, 'Enter your name', mocked_now_utc)
 
     @unittest_run_loop
     async def test_get_webchat_open_cy(self):
-        mocked_now = datetime.datetime(2019, 6, 15, 9, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
+        mocked_now_utc = datetime.datetime(2019, 6, 15, 9, 30)
+        await self.should_respond_open_to_get(self.get_webchat_cy, self.ons_logo_cy, 'Nodwch eich enw', mocked_now_utc)
 
-            response = await self.client.request('GET', self.get_webchat_cy)
-            self.assertEqual(response.status, 200)
-            contents = str(await response.content.read())
-            self.assertIn(self.ons_logo_cy, contents)
-            self.assertIn('Nodwch eich enw', contents)
-            self.assertEqual(contents.count('radio__input'), 10)
-            self.assertIn('type="submit"', contents)
+    @unittest_run_loop
+    async def test_get_webchat_open_cy_2021_bst(self):
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 7, 1)
+        await self.should_respond_open_to_get(self.get_webchat_cy, self.ons_logo_cy, 'Nodwch eich enw', mocked_now_utc)
 
     @unittest_run_loop
     async def test_get_webchat_open_ni(self):
-        mocked_now = datetime.datetime(2019, 6, 15, 9, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
+        mocked_now_utc = datetime.datetime(2019, 6, 15, 9, 30)
+        await self.should_respond_open_to_get(self.get_webchat_ni, self.nisra_logo, 'Enter your name', mocked_now_utc)
 
-            response = await self.client.request('GET', self.get_webchat_ni)
+    @unittest_run_loop
+    async def test_get_webchat_open_ni_2021_bst(self):
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 7, 1)
+        await self.should_respond_open_to_get(self.get_webchat_ni, self.nisra_logo, 'Enter your name', mocked_now_utc)
+
+    async def should_respond_not_open_to_get(self, path, logo, reason, mocked_now_utc):
+        with mock.patch('app.webchat_handlers.WebChat.get_now_utc') as mocked_get_now_utc:
+            mocked_get_now_utc.return_value = mocked_now_utc
+
+            with aioresponses(passthrough=[str(self.server._root)]) as mocked:
+                mocked.get(self.webchatsvc_url, status=200)
+
+                response = await self.client.request('GET', path)
+
             self.assertEqual(response.status, 200)
             contents = str(await response.content.read())
-            self.assertIn(self.nisra_logo, contents)
-            self.assertIn('Enter your name', contents)
-            self.assertEqual(contents.count('radio__input'), 10)
-            self.assertIn('type="submit"', contents)
+            self.assertIn(logo, contents)
+            self.assertIn(reason, contents)
 
     @unittest_run_loop
     async def test_get_webchat_not_open_200_en(self):
-        mocked_now = datetime.datetime(2019, 6, 16, 16, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
-
-            with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-                mocked.get(self.webchatsvc_url, status=200)
-
-                response = await self.client.request('GET',
-                                                     self.get_webchat_en)
-
-            self.assertEqual(response.status, 200)
-            contents = str(await response.content.read())
-            self.assertIn(self.ons_logo_en, contents)
-            self.assertIn('Bank Holidays', contents)
+        mocked_now_utc = datetime.datetime(2019, 6, 16, 16, 30)
+        await self.should_respond_not_open_to_get(self.get_webchat_en, self.ons_logo_en, 'Bank Holidays',
+                                                  mocked_now_utc)
+    @unittest_run_loop
+    async def test_get_webchat_not_open_200_en_2021_bst(self):
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 18, 1)
+        await self.should_respond_not_open_to_get(self.get_webchat_en, self.ons_logo_en, 'Bank Holidays',
+                                                  mocked_now_utc)
 
     @unittest_run_loop
     async def test_get_webchat_not_open_200_cy(self):
-        mocked_now = datetime.datetime(2019, 6, 16, 16, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
+        mocked_now_utc = datetime.datetime(2019, 6, 16, 16, 30)
+        await self.should_respond_not_open_to_get(self.get_webchat_cy, self.ons_logo_cy, 'Gwyliau Banc',
+                                                  mocked_now_utc)
 
-            with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-                mocked.get(self.webchatsvc_url, status=200)
-
-                response = await self.client.request('GET',
-                                                     self.get_webchat_cy)
-
-            self.assertEqual(response.status, 200)
-            contents = str(await response.content.read())
-            self.assertIn(self.ons_logo_cy, contents)
-            self.assertIn('Gwyliau Banc', contents)
+    @unittest_run_loop
+    async def test_get_webchat_not_open_200_cy_2021_bst(self):
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 18, 1)
+        await self.should_respond_not_open_to_get(self.get_webchat_cy, self.ons_logo_cy, 'Gwyliau Banc',
+                                                  mocked_now_utc)
 
     @unittest_run_loop
     async def test_get_webchat_not_open_200_ni(self):
-        mocked_now = datetime.datetime(2019, 6, 16, 16, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
+        mocked_now_utc = datetime.datetime(2019, 6, 16, 16, 30)
+        await self.should_respond_not_open_to_get(self.get_webchat_ni, self.nisra_logo, 'Bank Holidays',
+                                                  mocked_now_utc)
 
-            with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-                mocked.get(self.webchatsvc_url, status=200)
-
-                response = await self.client.request('GET',
-                                                     self.get_webchat_ni)
-
-            self.assertEqual(response.status, 200)
-            contents = str(await response.content.read())
-            self.assertIn(self.nisra_logo, contents)
-            self.assertIn('Bank Holidays', contents)
+    @unittest_run_loop
+    async def test_get_webchat_not_open_200_ni_2021_bst(self):
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 18, 1)
+        await self.should_respond_not_open_to_get(self.get_webchat_ni, self.nisra_logo, 'Bank Holidays',
+                                                  mocked_now_utc)
 
     @unittest_run_loop
     async def test_post_webchat_incomplete_query_en(self):
@@ -304,120 +329,108 @@ class TestWebChatHandlers(RHTestCase):
 
     @unittest_run_loop
     async def test_post_webchat_open_en(self):
-        mocked_now = datetime.datetime(2019, 6, 15, 9, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
+        mocked_now_utc = datetime.datetime(2019, 6, 15, 9, 30)
+        await self.should_be_open_to_post(self.post_webchat_en, 'Web Chat', self.ons_logo_en, mocked_now_utc,
+                                          'en/web-chat')
 
-            with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request('POST',
-                                                     self.post_webchat_en,
-                                                     allow_redirects=False,
-                                                     data=self.webchat_form_data)
-            self.assertEqual(response.status, 200)
-            self.assertLogEvent(cm, "received POST on endpoint 'en/web-chat'")
-            self.assertLogEvent(cm, "date/time check")
-
-            contents = str(await response.content.read())
-            self.assertIn(self.ons_logo_en, contents)
-            self.assertIn('iframe', contents)
-            self.assertIn('Web Chat', contents)
+    @unittest_run_loop
+    async def test_post_webchat_open_en_2021_bst(self):
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 7, 1)
+        await self.should_be_open_to_post(self.post_webchat_en, 'Web Chat', self.ons_logo_en, mocked_now_utc,
+                                          'en/web-chat')
 
     @unittest_run_loop
     async def test_post_webchat_open_cy(self):
-        mocked_now = datetime.datetime(2019, 6, 15, 9, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
+        mocked_now_utc = datetime.datetime(2019, 6, 15, 9, 30)
+        await self.should_be_open_to_post(self.post_webchat_cy, 'Gwe-sgwrs', self.ons_logo_cy, mocked_now_utc,
+                                          'cy/web-chat')
 
-            with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request('POST',
-                                                     self.post_webchat_cy,
-                                                     allow_redirects=False,
-                                                     data=self.webchat_form_data)
-            self.assertEqual(response.status, 200)
-            self.assertLogEvent(cm, "received POST on endpoint 'cy/web-chat'")
-            self.assertLogEvent(cm, "date/time check")
-
-            contents = str(await response.content.read())
-            self.assertIn(self.ons_logo_cy, contents)
-            self.assertIn('iframe', contents)
-            self.assertIn('Gwe-sgwrs', contents)
+    @unittest_run_loop
+    async def test_post_webchat_open_cy_2021_bst(self):
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 7, 1)
+        await self.should_be_open_to_post(self.post_webchat_cy, 'Gwe-sgwrs', self.ons_logo_cy, mocked_now_utc,
+                                          'cy/web-chat')
 
     @unittest_run_loop
     async def test_post_webchat_open_ni(self):
-        mocked_now = datetime.datetime(2019, 6, 15, 9, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
+        mocked_now_utc = datetime.datetime(2019, 6, 15, 9, 30)
+        await self.should_be_open_to_post(self.post_webchat_ni, 'Web Chat', self.nisra_logo, mocked_now_utc,
+                                          'ni/web-chat')
 
-            with self.assertLogs('respondent-home', 'INFO') as cm:
-                response = await self.client.request('POST',
-                                                     self.post_webchat_ni,
-                                                     allow_redirects=False,
-                                                     data=self.webchat_form_data)
-            self.assertEqual(response.status, 200)
-            self.assertLogEvent(cm, "received POST on endpoint 'ni/web-chat'")
-            self.assertLogEvent(cm, "date/time check")
-
-            contents = str(await response.content.read())
-            self.assertIn(self.nisra_logo, contents)
-            self.assertIn('iframe', contents)
-            self.assertIn('Web Chat', contents)
+    @unittest_run_loop
+    async def test_post_webchat_open_ni_2021_bst(self):
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 7, 1)
+        await self.should_be_open_to_post(self.post_webchat_ni, 'Web Chat', self.nisra_logo, mocked_now_utc,
+                                          'ni/web-chat')
 
     @unittest_run_loop
     async def test_post_webchat_not_open_200_en(self):
-        mocked_now = datetime.datetime(2019, 6, 16, 16, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
+        mocked_now_utc = datetime.datetime(2019, 6, 16, 16, 30)
+        await self.should_respond_not_open_to_post(self.post_webchat_en, 'Bank Holidays', self.ons_logo_en,
+                                                   mocked_now_utc)
 
-            with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-                mocked.get(self.webchatsvc_url, status=200)
-
-                response = await self.client.request(
-                    'POST',
-                    self.post_webchat_en,
-                    allow_redirects=False,
-                    data=self.webchat_form_data)
-
-        self.assertEqual(response.status, 200)
-        contents = str(await response.content.read())
-        self.assertIn(self.ons_logo_en, contents)
-        self.assertIn('Bank Holidays', contents)
+    @unittest_run_loop
+    async def test_post_webchat_not_open_200_en_2021_bst(self):
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 18, 1)
+        await self.should_respond_not_open_to_post(self.post_webchat_en, 'Bank Holidays', self.ons_logo_en,
+                                                   mocked_now_utc)
 
     @unittest_run_loop
     async def test_post_webchat_not_open_200_cy(self):
-        mocked_now = datetime.datetime(2019, 6, 16, 16, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
+        mocked_now_utc = datetime.datetime(2019, 6, 16, 16, 30)
+        await self.should_respond_not_open_to_post(self.post_webchat_cy, 'Gwyliau Banc', self.ons_logo_cy,
+                                                   mocked_now_utc)
 
-            with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-                mocked.get(self.webchatsvc_url, status=200)
-
-                response = await self.client.request(
-                    'POST',
-                    self.post_webchat_cy,
-                    allow_redirects=False,
-                    data=self.webchat_form_data)
-
-        self.assertEqual(response.status, 200)
-        contents = str(await response.content.read())
-        self.assertIn(self.ons_logo_cy, contents)
-        self.assertIn('Gwyliau Banc', contents)
+    @unittest_run_loop
+    async def test_post_webchat_not_open_200_cy_2021_bst(self):
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 18, 1)
+        await self.should_respond_not_open_to_post(self.post_webchat_cy, 'Gwyliau Banc', self.ons_logo_cy,
+                                                   mocked_now_utc)
 
     @unittest_run_loop
     async def test_post_webchat_not_open_200_ni(self):
-        mocked_now = datetime.datetime(2019, 6, 16, 16, 30, 00, 0)
-        with mock.patch('app.webchat_handlers.WebChat.get_now') as mocked_get_now:
-            mocked_get_now.return_value = mocked_now
+        mocked_now_utc = datetime.datetime(2019, 6, 16, 16, 30)
+        await self.should_respond_not_open_to_post(self.post_webchat_ni, 'Bank Holidays', self.nisra_logo,
+                                                   mocked_now_utc)
+
+    @unittest_run_loop
+    async def test_post_webchat_not_open_200_ni_2021_bst(self):
+        mocked_now_utc = datetime.datetime(2021, 3, 29, 18, 1)
+        await self.should_respond_not_open_to_post(self.post_webchat_ni, 'Bank Holidays', self.nisra_logo,
+                                                   mocked_now_utc)
+
+    async def should_respond_not_open_to_post(self, path, reason, logo, mocked_now_utc):
+        with mock.patch('app.webchat_handlers.WebChat.get_now_utc') as mocked_get_now_utc:
+            mocked_get_now_utc.return_value = mocked_now_utc
 
             with aioresponses(passthrough=[str(self.server._root)]) as mocked:
                 mocked.get(self.webchatsvc_url, status=200)
 
                 response = await self.client.request(
                     'POST',
-                    self.post_webchat_ni,
+                    path,
                     allow_redirects=False,
                     data=self.webchat_form_data)
 
         self.assertEqual(response.status, 200)
         contents = str(await response.content.read())
-        self.assertIn(self.nisra_logo, contents)
-        self.assertIn('Bank Holidays', contents)
+        self.assertIn(logo, contents)
+        self.assertIn(reason, contents)
+
+    async def should_be_open_to_post(self, path, reason, logo, mocked_now_utc, logged_endpoint):
+        with mock.patch('app.webchat_handlers.WebChat.get_now_utc') as mocked_get_now_utc:
+            mocked_get_now_utc.return_value = mocked_now_utc
+
+            with self.assertLogs('respondent-home', 'INFO') as cm:
+                response = await self.client.request('POST',
+                                                     path,
+                                                     allow_redirects=False,
+                                                     data=self.webchat_form_data)
+            self.assertEqual(response.status, 200)
+            self.assertLogEvent(cm, "received POST on endpoint '" + logged_endpoint + "'")
+            self.assertLogEvent(cm, "date/time check")
+
+            contents = str(await response.content.read())
+            self.assertIn(logo, contents)
+            self.assertIn('iframe', contents)
+            self.assertIn(reason, contents)


### PR DESCRIPTION
# Motivation and Context
The RHUI CC opening hours check for Web-Chat is currently incorrect:
- it has old code , based on the rehearsal
- it has hard-coded timezone adjustment for one time period only
- it needs updating for new dates and times
- RH cucumber PR for CR-828 https://github.com/ONSdigital/census-rh-cucumber/pull/81 is currently being reviewed which incorrectly tests to the old date/times. It would be good to have RHUI fixed first.

# What has changed
- made use of timezone **pytz** library for timezone handling
- adjusted times for the new opening date/times as supplied by Ameet
- although the Contact Centre does not open till 10th February 2021 , this is not currently policed. I assume that this is not needed, and is more convenient for continuous testing
- added extra tests across different timezones and years, including before and after the DST change
- refactored some tests to avoid repetition

# How to test?
- battery of RHUI unit tests which patches the date/time "now" to test many combinations.
- Date/time testing is a little awkward, because you either wait for a time of day to run the test, or try to affect the notion of date/time for RHUI running.
- the pending CR-828 PR has some tests for WebChat.

