### PR TITLE
CR-1172 Web Chat Updates

### DIFF
--- a/app/templates/macros/ad-lookup/_macro.njk
+++ b/app/templates/macros/ad-lookup/_macro.njk
@@ -1,7 +1,6 @@
 {%- macro rhTime(params) -%}
 
     {%- set time_string = params.time|string -%}
-    {%- set display_region_string = params.display_region|string -%}
 
     {%- if time_string|length == 3 -%}
         {% set hour = time_string[0:1] %}
@@ -20,18 +19,10 @@
     {%- endif -%}
 
     {%- if hour|int > 11 -%}
-        {%- if display_region_string == 'cy' %}
-            {%- set am_pm = 'y nos' -%}
-        {%- else -%}
-            {%- set am_pm = 'pm' -%}
-        {%- endif -%}
+        {%- set am_pm = 'pm' -%}
         {%- set hour = hour|int - 12 -%}
     {%- else -%}
-        {%- if display_region_string == 'cy' %}
-            {%- set am_pm = 'y bore' -%}
-        {%- else -%}
-            {%- set am_pm = 'am' -%}
-        {%- endif -%}
+        {%- set am_pm = 'am' -%}
     {%- endif -%}
 
     {{ hour }}{{ minutes_display }}{{ am_pm }}
@@ -45,9 +36,9 @@
     {%- set display_region_string = params.display_region|string -%}
 
     {%- if display_region_string == 'cy' -%}
-        {{ rhTime({'time': open_string, 'display_region': display_region_string }) }} to {{ rhTime({'time': close_string, 'display_region': display_region_string }) }}
+        {{ rhTime({'time': open_string }) }} tan {{ rhTime({'time': close_string }) }}
     {%- else -%}
-        {{ rhTime({'time': open_string, 'display_region': display_region_string }) }} to {{ rhTime({'time': close_string, 'display_region': display_region_string }) }}
+        {{ rhTime({'time': open_string }) }} to {{ rhTime({'time': close_string }) }}
     {%- endif -%}
 
 {%- endmacro -%}

--- a/app/templates/macros/time/_macro.njk
+++ b/app/templates/macros/time/_macro.njk
@@ -2,20 +2,10 @@
 
     {%- set time_string = params.time|string -%}
 
-    {%- if time_string|length == 3 -%}
+    {%- if (time_string|length == 1) or (time_string|length == 3) -%}
         {% set hour = time_string[0:1] %}
     {%- else -%}
         {% set hour = time_string[0:2] %}
-    {%- endif -%}
-
-    {%- if time_string|length == 3 -%}
-        {% set minutes = time_string[1:3] %}
-    {%- else -%}
-        {% set minutes = time_string[2:4] %}
-    {%- endif -%}
-
-    {%- if minutes != '00' -%}
-        {% set minutes_display = ':' + minutes %}
     {%- endif -%}
 
     {%- if hour|int > 11 -%}
@@ -25,6 +15,24 @@
         {%- set am_pm = 'am' -%}
     {%- endif -%}
 
-    {{ hour }}{{ minutes_display }}{{ am_pm }}
+    {%- if time_string|length < 3 -%}
+
+        {{ hour }}{{ am_pm }}
+
+    {%- else -%}
+
+        {%- if time_string|length == 3 -%}
+            {% set minutes = time_string[1:3] %}
+        {%- else -%}
+            {% set minutes = time_string[2:4] %}
+        {%- endif -%}
+
+        {%- if minutes != '00' -%}
+            {% set minutes_display = ':' + minutes %}
+        {%- endif -%}
+
+        {{ hour }}{{ minutes_display }}{{ am_pm }}
+
+    {%- endif -%}
 
 {%- endmacro -%}

--- a/app/templates/start.html
+++ b/app/templates/start.html
@@ -166,9 +166,7 @@
         "type": 'button',
         "classes": 'u-mb-m, u-mt-s',
         "url": webchat_link,
-        "newWindow": true,
-        'attributes':
-            {'onclick': "window.open(this.href,'targetWindow','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=360,height=680'); return false;"}
+        "newWindow": true
         })
     }}
 

--- a/app/templates/webchat-form.html
+++ b/app/templates/webchat-form.html
@@ -13,7 +13,6 @@
 {% from 'components/select/_macro.njk' import onsSelect %}
 {% from 'components/radios/_macro.njk' import onsRadios %}
 {% from 'components/textarea/_macro.njk' import onsTextarea %}
-{% from 'components/lists/_macro.njk' import onsList %}
 {% from 'components/panel/_macro.njk' import onsPanel %}
 
 {% from 'macros/time/_macro.njk' import rhTime %}

--- a/app/templates/webchat-form.html
+++ b/app/templates/webchat-form.html
@@ -1,11 +1,11 @@
-{% extends 'base-webchat-' + display_region + '.html' %}
+{% extends 'base-' + display_region + '.html' %}
 
 {% if display_region == 'cy' %}
-    {% set help_url = domain_url_cy + '/help/' %}
+    {% set web_form_url = '#' %}
 {% elif display_region == 'ni' %}
-    {% set help_url = domain_url_en + '/ni/help/' %}
+    {% set web_form_url = '#' %}
 {% else %}
-    {% set help_url = domain_url_en + '/help/' %}
+    {% set web_form_url = '#' %}
 {% endif %}
 
 {% from 'components/input/_macro.njk' import onsInput %}
@@ -15,6 +15,8 @@
 {% from 'components/textarea/_macro.njk' import onsTextarea %}
 {% from 'components/lists/_macro.njk' import onsList %}
 {% from 'components/panel/_macro.njk' import onsPanel %}
+
+{% from 'macros/time/_macro.njk' import rhTime %}
 
 {% set messages_dict=dict(get_flashed_messages()|groupby('level')) %}
 {% set field_messages_dict=dict(messages_dict['ERROR']|groupby('field')) %}
@@ -30,22 +32,26 @@
 
     {% if webchat_status == 'closed' %}
 
-        <h2 class="u-mt-m u-mb-no">{{_('Web chat')}}</h2>
+        <h1 class="u-fs-xxl u-mt-l">{{_('Web chat unavailable')}}</h1>
+
+        <p>{{ _('Our contact centre is now closed.') }}</p>
+
         {% autoescape false %}
-            <p>{{ _('Contact Centre is closed. Please contact during the working hours or %(open)sGet Help Online%(close)s.', open='<a href="%s">' %  help_url, close='</a>')|safe }}</p>
+            <p>{{ _('You can still contact us through our %(open)sweb form%(close)s.', open='<a href="%s">' %  web_form_url, close='</a>')|safe }}</p>
         {% endautoescape %}
-        <h3 class="u-mt-m u-mb-no">{{_('Opening times')}}</h3>
+
+        <h2 class="u-fs-l u-mt-l">{{_('Web chat opening times')}}</h2>
         <p>
-            {{_('Monday to Friday: 8am to 7pm')}}<br/>
-            {{_('Saturday: 8am to 1pm')}}<br/>
-            {{_('Sunday / Bank Holidays: Closed')}}<br>
-            {{_('Census weekend: 8am to 4pm')}}
+            {{_('Monday to Friday &ndash; %(open_time)s to %(close_time)s', open_time=rhTime({'time': weekday_open }), close_time=rhTime({'time': weekday_close }) )|safe }}<br/>
+            {{_('Saturday &ndash; %(open_time)s to %(close_time)s', open_time=rhTime({'time': saturday_open }), close_time=rhTime({'time': saturday_close }) )|safe }}<br/>
+            {{_('Census Saturday, 20 March &ndash; %(open_time)s to %(close_time)s', open_time=rhTime({'time': census_saturday_open }), close_time=rhTime({'time': census_saturday_close }) )|safe }}<br>
+            {{_('Census Day, 21 March &ndash; %(open_time)s to %(close_time)s', open_time=rhTime({'time': census_sunday_open }), close_time=rhTime({'time': census_sunday_close }) )|safe }}
         </p>
 
     {% else %}
 
         <noscript>
-            <h1>{{_('Javascript disabled')}}</h1>
+            <h1 class="u-fs-xxl u-mt-l">{{_('Javascript disabled')}}</h1>
 
             <p>{{_('Javascript on your browser is disabled. To start a Webchat session javascript needs to be enabled on your browser.')}}</p>
 
@@ -85,11 +91,11 @@
         {% set query_options =
             [
                 {
-                    'id': 'form',
+                    'id': 'missing_information',
                     'label': {
-                        'text': _('I have a question about my census form')
+                        'text': _('I don’t have everything I need to complete my census')
                     },
-                    'value': 'form'
+                    'value': 'missing_information'
                 },
                 {
                     'id': 'technical',
@@ -97,6 +103,13 @@
                         'text': _('I am having technical difficulties')
                     },
                     'value': 'technical'
+                },
+                {
+                    'id': 'form',
+                    'label': {
+                        'text': _('I need help with my census form')
+                    },
+                    'value': 'form'
                 },
                 {
                     'id': 'complaint',
@@ -108,38 +121,28 @@
                 {
                     'id': 'address',
                     'label': {
-                        'text': _('I have a question about my address')
+                        'text': _('I need help with my address')
                     },
                     'value': 'address'
                 },
                 {
-                    'id': 'send-something',
+                    'id': 'something_else',
                     'label': {
-                        'text': _('I need something sent to me')
+                        'text': _('Something else')
                     },
-                    'value': 'send-something'
-                },
-                {
-                    'id': 'face-to-face',
-                    'label': {
-                        'text': _('I need to speak to an adviser face-to-face')
-                    },
-                    'value': 'face-to-face'
-                },
-                {
-                    'id': 'help',
-                    'label': {
-                        'text': _('I need some help')
-                    },
-                    'value': 'help'
+                    'value': 'something_else'
                 }
             ]
         %}
 
         <div id="web-chat-form-display" class="web-chat-form__body" style="display:none;">
-            <h1>{{_('Web chat')}}</h1>
+            <h1 class="u-fs-xxl u-mt-l">{{_('Enter web chat details')}}</h1>
 
-            <p>{{_('Our advisers can help you with your census survey.')}}</p>
+            {{
+                onsPanel({
+                    'body': _('Data stored during web chat sessions will not be shared with third parties')
+                })
+            }}
 
             {% if 'screen_name' in field_messages_dict %}
                 {{
@@ -198,7 +201,7 @@
             {% if 'query' in field_messages_dict %}
                 {{
                     onsRadios({
-                        'legend': _('What type of query do you have'),
+                        'legend': _('What do you need help with?'),
                         'name': 'query',
                         'dontVisuallyHideLegend': true,
                         'value': form_value_query,
@@ -211,7 +214,7 @@
             {% else %}
                 {{
                     onsRadios({
-                        'legend': _('What type of query do you have'),
+                        'legend': _('What do you need help with?'),
                         'name': 'query',
                         'dontVisuallyHideLegend': true,
                         'value': form_value_query,
@@ -222,7 +225,7 @@
 
             {{
                 onsButton({
-                    'text': _('Start chat'),
+                    'text': _('Start web chat'),
                     'classes': 'btn-group__btn u-mb-m u-mt-m'
                 })
 

--- a/app/webchat_handlers.py
+++ b/app/webchat_handlers.py
@@ -119,8 +119,7 @@ class WebChatWindow(WebChat):
         return {
             'display_region': display_region,
             'page_title': page_title,
-            'locale': locale,
-            'page_url': View.gen_page_url(request)
+            'locale': locale
         }
 
 
@@ -153,7 +152,15 @@ class WebChat(WebChat):
                 'display_region': display_region,
                 'page_title': page_title,
                 'locale': locale,
-                'page_url': View.gen_page_url(request)
+                'page_url': View.gen_page_url(request),
+                'census_saturday_open': census_saturday_open,
+                'census_saturday_close':  census_saturday_close,
+                'census_sunday_open': census_sunday_open,
+                'census_sunday_close': census_sunday_close,
+                'saturday_open': saturday_open,
+                'saturday_close': saturday_close,
+                'weekday_open': weekday_open,
+                'weekday_close': weekday_close
             }
 
     @aiohttp_jinja2.template('webchat-form.html')
@@ -208,5 +215,13 @@ class WebChat(WebChat):
                 'display_region': display_region,
                 'page_title': page_title,
                 'locale': locale,
-                'page_url': View.gen_page_url(request)
+                'page_url': View.gen_page_url(request),
+                'census_saturday_open': census_saturday_open,
+                'census_saturday_close': census_saturday_close,
+                'census_sunday_open': census_sunday_open,
+                'census_sunday_close': census_sunday_close,
+                'saturday_open': saturday_open,
+                'saturday_close': saturday_close,
+                'weekday_open': weekday_open,
+                'weekday_close': weekday_close
             }

--- a/app/webchat_handlers.py
+++ b/app/webchat_handlers.py
@@ -103,26 +103,6 @@ class WebChat(View):
         return form_valid
 
 
-@webchat_routes.view(r'/' + View.valid_display_regions + '/web-chat/chat/')
-class WebChatWindow(WebChat):
-    @aiohttp_jinja2.template('webchat-window.html')
-    async def get(self, request):
-        self.setup_request(request)
-        display_region = request.match_info['display_region']
-        if display_region == 'cy':
-            page_title = 'Gwe-sgwrs'
-            locale = 'cy'
-        else:
-            page_title = 'Web Chat'
-            locale = 'en'
-        self.log_entry(request, display_region + '/web-chat/chat')
-        return {
-            'display_region': display_region,
-            'page_title': page_title,
-            'locale': locale
-        }
-
-
 @webchat_routes.view(r'/' + View.valid_display_regions + '/web-chat/')
 class WebChat(WebChat):
     @aiohttp_jinja2.template('webchat-form.html')

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1756,36 +1756,36 @@ class RHTestCase(AioHTTPTestCase):
 
         # TODO Add Welsh Translation
         self.content_support_centre_list_of_centres_result_open_monday_cy = \
-            'Monday &ndash;&nbsp;10:30y bore to 5:15y nos'
+            'Monday &ndash;&nbsp;10:30am tan 5:15pm'
         # TODO Add Welsh Translation
         self.content_support_centre_list_of_centres_result_open_tuesday_cy = \
-            'Tuesday &ndash;&nbsp;10y bore to 5y nos'
+            'Tuesday &ndash;&nbsp;10am tan 5pm'
         # TODO Add Welsh Translation
         self.content_support_centre_list_of_centres_result_open_wednesday_cy = \
-            'Wednesday &ndash;&nbsp;10y bore to 5y nos'
+            'Wednesday &ndash;&nbsp;10am tan 5pm'
         # TODO Add Welsh Translation
-        self.content_support_centre_list_of_centres_result_open_thursday_cy = 'Thursday &ndash;&nbsp;10y bore to 5y nos'
+        self.content_support_centre_list_of_centres_result_open_thursday_cy = 'Thursday &ndash;&nbsp;10am tan 5pm'
         # TODO Add Welsh Translation
-        self.content_support_centre_list_of_centres_result_open_friday_cy = 'Friday &ndash;&nbsp;10y bore to 5y nos'
+        self.content_support_centre_list_of_centres_result_open_friday_cy = 'Friday &ndash;&nbsp;10am tan 5pm'
         # TODO Add Welsh Translation
-        self.content_support_centre_list_of_centres_result_open_saturday_cy = 'Saturday &ndash;&nbsp;10y bore to 1y nos'
+        self.content_support_centre_list_of_centres_result_open_saturday_cy = 'Saturday &ndash;&nbsp;10am tan 1pm'
         # TODO Add Welsh Translation
-        self.content_support_centre_list_of_centres_result_open_sunday_cy = 'Sunday &ndash;&nbsp;10y bore to 1y nos'
+        self.content_support_centre_list_of_centres_result_open_sunday_cy = 'Sunday &ndash;&nbsp;10am tan 1pm'
         # TODO Add Welsh Translation
         self.content_support_centre_list_of_centres_result_open_census_saturday_cy = \
-            'Census Saturday, 20 March &ndash;&nbsp;10y bore to 4y nos'
+            'Census Saturday, 20 March &ndash;&nbsp;10am tan 4pm'
         # TODO Add Welsh Translation
         self.content_support_centre_list_of_centres_result_open_census_day_cy = \
-            'Census Day, 21 March &ndash;&nbsp;10y bore to 4y nos'
+            'Census Day, 21 March &ndash;&nbsp;10am tan 4pm'
         # TODO Add Welsh Translation
         self.content_support_centre_list_of_centres_result_open_good_friday_cy = \
-            'Good Friday, 2 April &ndash;&nbsp;10y bore to 5y nos'
+            'Good Friday, 2 April &ndash;&nbsp;10am tan 5pm'
         # TODO Add Welsh Translation
         self.content_support_centre_list_of_centres_result_open_easter_monday_cy = \
-            'Easter Monday, 5 April &ndash;&nbsp;10y bore to 5y nos'
+            'Easter Monday, 5 April &ndash;&nbsp;10am tan 5pm'
         # TODO Add Welsh Translation
         self.content_support_centre_list_of_centres_result_open_may_bank_holiday_cy = \
-            'May Bank Holiday, 3 May &ndash;&nbsp;10y bore to 5y nos'
+            'May Bank Holiday, 3 May &ndash;&nbsp;10am tan 5pm'
         # TODO Add Welsh Translation
         self.content_support_centre_list_of_centres_result_closed_monday_cy = 'Monday &ndash;&nbsp;Closed'
         # TODO Add Welsh Translation

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -737,9 +737,6 @@ class RHTestCase(AioHTTPTestCase):
         self.post_webchat_en = self.app.router['WebChat:post'].url_for(display_region='en')
         self.post_webchat_cy = self.app.router['WebChat:post'].url_for(display_region='cy')
         self.post_webchat_ni = self.app.router['WebChat:post'].url_for(display_region='ni')
-        self.get_webchat_chat_en = self.app.router['WebChatWindow:get'].url_for(display_region='en')
-        self.get_webchat_chat_cy = self.app.router['WebChatWindow:get'].url_for(display_region='cy')
-        self.get_webchat_chat_ni = self.app.router['WebChatWindow:get'].url_for(display_region='ni')
 
         self.webchat_form_data = {
             'screen_name': 'Test',

--- a/tests/unit/test_webchat_handlers.py
+++ b/tests/unit/test_webchat_handlers.py
@@ -119,7 +119,7 @@ class TestWebChatHandlers(RHTestCase):
             contents = str(await response.content.read())
             self.assertIn(logo, contents)
             self.assertIn(name_prompt, contents)
-            self.assertEqual(contents.count('radio__input'), 10)
+            self.assertEqual(contents.count('radio__input'), 9)
             self.assertIn('type="submit"', contents)
 
     @unittest_run_loop
@@ -169,36 +169,45 @@ class TestWebChatHandlers(RHTestCase):
     @unittest_run_loop
     async def test_get_webchat_not_open_200_en(self):
         mocked_now_utc = datetime.datetime(2019, 6, 16, 16, 30)
-        await self.should_respond_not_open_to_get(self.get_webchat_en, self.ons_logo_en, 'Bank Holidays',
+        await self.should_respond_not_open_to_get(self.get_webchat_en, self.ons_logo_en,
+                                                  'Our contact centre is now closed',
                                                   mocked_now_utc)
+
     @unittest_run_loop
     async def test_get_webchat_not_open_200_en_2021_bst(self):
         mocked_now_utc = datetime.datetime(2021, 3, 29, 19, 1)
-        await self.should_respond_not_open_to_get(self.get_webchat_en, self.ons_logo_en, 'Bank Holidays',
+        await self.should_respond_not_open_to_get(self.get_webchat_en, self.ons_logo_en,
+                                                  'Our contact centre is now closed',
                                                   mocked_now_utc)
 
+    # TODO Add Welsh Translation
     @unittest_run_loop
     async def test_get_webchat_not_open_200_cy(self):
         mocked_now_utc = datetime.datetime(2019, 6, 16, 16, 30)
-        await self.should_respond_not_open_to_get(self.get_webchat_cy, self.ons_logo_cy, 'Gwyliau Banc',
+        await self.should_respond_not_open_to_get(self.get_webchat_cy, self.ons_logo_cy,
+                                                  'Our contact centre is now closed',
                                                   mocked_now_utc)
 
+    # TODO Add Welsh Translation
     @unittest_run_loop
     async def test_get_webchat_not_open_200_cy_2021_bst(self):
         mocked_now_utc = datetime.datetime(2021, 3, 29, 19, 1)
-        await self.should_respond_not_open_to_get(self.get_webchat_cy, self.ons_logo_cy, 'Gwyliau Banc',
+        await self.should_respond_not_open_to_get(self.get_webchat_cy, self.ons_logo_cy,
+                                                  'Our contact centre is now closed',
                                                   mocked_now_utc)
 
     @unittest_run_loop
     async def test_get_webchat_not_open_200_ni(self):
         mocked_now_utc = datetime.datetime(2019, 6, 16, 16, 30)
-        await self.should_respond_not_open_to_get(self.get_webchat_ni, self.nisra_logo, 'Bank Holidays',
+        await self.should_respond_not_open_to_get(self.get_webchat_ni, self.nisra_logo,
+                                                  'Our contact centre is now closed',
                                                   mocked_now_utc)
 
     @unittest_run_loop
     async def test_get_webchat_not_open_200_ni_2021_bst(self):
         mocked_now_utc = datetime.datetime(2021, 3, 29, 19, 1)
-        await self.should_respond_not_open_to_get(self.get_webchat_ni, self.nisra_logo, 'Bank Holidays',
+        await self.should_respond_not_open_to_get(self.get_webchat_ni, self.nisra_logo,
+                                                  'Our contact centre is now closed',
                                                   mocked_now_utc)
 
     @unittest_run_loop
@@ -384,38 +393,40 @@ class TestWebChatHandlers(RHTestCase):
     @unittest_run_loop
     async def test_post_webchat_not_open_200_en(self):
         mocked_now_utc = datetime.datetime(2019, 6, 16, 16, 30)
-        await self.should_respond_not_open_to_post(self.post_webchat_en, 'Bank Holidays', self.ons_logo_en,
-                                                   mocked_now_utc)
+        await self.should_respond_not_open_to_post(self.post_webchat_en, 'Our contact centre is now closed',
+                                                   self.ons_logo_en, mocked_now_utc)
 
     @unittest_run_loop
     async def test_post_webchat_not_open_200_en_2021_bst(self):
         mocked_now_utc = datetime.datetime(2021, 3, 29, 19, 1)
-        await self.should_respond_not_open_to_post(self.post_webchat_en, 'Bank Holidays', self.ons_logo_en,
-                                                   mocked_now_utc)
+        await self.should_respond_not_open_to_post(self.post_webchat_en, 'Our contact centre is now closed',
+                                                   self.ons_logo_en, mocked_now_utc)
 
+    # TODO Add Welsh Translation
     @unittest_run_loop
     async def test_post_webchat_not_open_200_cy(self):
         mocked_now_utc = datetime.datetime(2019, 6, 16, 16, 30)
-        await self.should_respond_not_open_to_post(self.post_webchat_cy, 'Gwyliau Banc', self.ons_logo_cy,
-                                                   mocked_now_utc)
+        await self.should_respond_not_open_to_post(self.post_webchat_cy, 'Our contact centre is now closed',
+                                                   self.ons_logo_cy, mocked_now_utc)
 
+    # TODO Add Welsh Translation
     @unittest_run_loop
     async def test_post_webchat_not_open_200_cy_2021_bst(self):
         mocked_now_utc = datetime.datetime(2021, 3, 29, 19, 1)
-        await self.should_respond_not_open_to_post(self.post_webchat_cy, 'Gwyliau Banc', self.ons_logo_cy,
-                                                   mocked_now_utc)
+        await self.should_respond_not_open_to_post(self.post_webchat_cy, 'Our contact centre is now closed',
+                                                   self.ons_logo_cy, mocked_now_utc)
 
     @unittest_run_loop
     async def test_post_webchat_not_open_200_ni(self):
         mocked_now_utc = datetime.datetime(2019, 6, 16, 16, 30)
-        await self.should_respond_not_open_to_post(self.post_webchat_ni, 'Bank Holidays', self.nisra_logo,
-                                                   mocked_now_utc)
+        await self.should_respond_not_open_to_post(self.post_webchat_ni, 'Our contact centre is now closed',
+                                                   self.nisra_logo, mocked_now_utc)
 
     @unittest_run_loop
     async def test_post_webchat_not_open_200_ni_2021_bst(self):
         mocked_now_utc = datetime.datetime(2021, 3, 29, 19, 1)
-        await self.should_respond_not_open_to_post(self.post_webchat_ni, 'Bank Holidays', self.nisra_logo,
-                                                   mocked_now_utc)
+        await self.should_respond_not_open_to_post(self.post_webchat_ni, 'Our contact centre is now closed',
+                                                   self.nisra_logo, mocked_now_utc)
 
     async def should_respond_not_open_to_post(self, path, reason, logo, mocked_now_utc):
         with mock.patch('app.webchat_handlers.WebChat.get_now_utc') as mocked_get_now_utc:


### PR DESCRIPTION
Mostly textual updates for web chat, plus a few tweaks to change the welsh time outputs (am/pm is acceptable in welsh)

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Design changes to Web Chat

# What has changed
Web Chat now opens in a full size new window, rather than a pop-up when triggered from RH start
Removal of one category option on the form, and adjustment of some others
Text changes on the form, and 'web chat is closed' page
Updated open/close times to be driven from variables in web chat code to ensure consistency
Update to rhTime macro to cope with 1/2 characters times as well as existing 3/4
Removal of am/pm welsh translations (effects ad Lookup as well), as am/pm is acceptable in welsh

# How to test?
Unit tests have been tweaked to match revised implementation
Requires matching RHCucumber change for text and design changes

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1172
https://github.com/ONSdigital/census-rh-cucumber/pull/88

# Screenshots (if appropriate):