### PR TITLE
Cr 1143 add large print option

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -54,6 +54,12 @@ async def check_services(app: Application) -> bool:
         return True
 
 
+def jinja_filter_set_attributes(dictionary, attributes):
+    for key in attributes:
+        dictionary[key] = attributes[key]
+    return dictionary
+
+
 def create_app(config_name=None) -> Application:
     """
     App factory. Sets up routes and all plugins.
@@ -116,10 +122,9 @@ def create_app(config_name=None) -> Application:
             flash.context_processor, aiohttp_jinja2.request_processor,
             google_analytics.ga_ua_id_processor, domains.domain_processor
         ],
-        # extensions=['jinja2.ext.i18n'],
         extensions=['app.i18n.i18n'])
-    # Required to add the default gettext and ngettext functions for rendering
-    # env.install_null_translations()
+
+    env.filters['setAttributes'] = jinja_filter_set_attributes
     env.install_gettext_translations(i18n, newstyle=True)
 
     # JWT KeyStore

--- a/app/templates/request-common-confirm-name-address.html
+++ b/app/templates/request-common-confirm-name-address.html
@@ -1,24 +1,28 @@
-{% extends 'base-' + display_region + '.html' %}
+{%- extends 'base-' + display_region + '.html' -%}
 
-{% set messages_dict=dict(get_flashed_messages()|groupby('level')) %}
-{% set field_messages_dict=dict(messages_dict['ERROR']|groupby('field')) %}
+{%- set messages_dict=dict(get_flashed_messages()|groupby('level')) -%}
+{%- set field_messages_dict=dict(messages_dict['ERROR']|groupby('field')) -%}
 
-{% from 'components/question/_macro.njk' import onsQuestion %}
-{% from 'components/button/_macro.njk' import onsButton %}
-{% from 'components/radios/_macro.njk' import onsRadios %}
-{% from 'components/checkboxes/_macro.njk' import onsCheckboxes %}
+{%- from 'components/question/_macro.njk' import onsQuestion -%}
+{%- from 'components/button/_macro.njk' import onsButton -%}
+{%- from 'components/radios/_macro.njk' import onsRadios -%}
+{%- from 'components/checkboxes/_macro.njk' import onsCheckboxes -%}
 
-{% set request_common_enter_name_link = url('RequestCommonEnterName:get', display_region=display_region, request_type=request_type) %}
+{%- set request_common_enter_name_link = url('RequestCommonEnterName:get', display_region=display_region, request_type=request_type) -%}
 
-{% set form =  {
+{%- set form =  {
     'method': 'POST',
     'attributes': {
         'action': url('RequestCommonConfirmNameAddress:post', display_region=display_region, request_type=request_type)
     }
-} %}
+} -%}
 
-{% if (request_type == 'paper-form') %}
-{% set form_options = [
+{%- if 'request-name-address-confirmation' in field_messages_dict -%}
+    {%- set error_radio = { 'text': _('Select an option') } -%}
+{%- endif -%}
+
+{%- if (request_type == 'paper-form') -%}
+{%- set form_options = [
                     {
                         'id': 'yes',
                         'label': {
@@ -34,9 +38,9 @@
                         'value': 'no'
                     }
                 ]
-    %}
-{% else %}
-    {% set form_options = [
+    -%}
+{%- else -%}
+    {%- set form_options = [
                     {
                         'id': 'yes',
                         'label': {
@@ -52,79 +56,67 @@
                         'value': 'no'
                     }
                 ]
-    %}
-{% endif %}
+    -%}
+{%- endif -%}
 
-{% if (request_type == 'paper-form') %}
-    {% set question_title = _('Do you want to send a paper questionnaire to this address?') %}
-{% elif (request_type == 'individual-code') or (case_type == 'CE' and address_level == 'U') %}
-    {% set question_title = _('Do you want to send a new individual access code to this address?') %}
-{% elif (case_type == 'CE' and address_level == 'E') %}
-    {% set question_title = _('Do you want to send a new manager access code to this address?') %}
-{% else %}
-    {% set question_title = _('Do you want to send a new household access code to this address?') %}
-{% endif %}
+{%- if (request_type == 'paper-form') -%}
+    {%- set question_title = _('Do you want to send a paper questionnaire to this address?') -%}
+{%- elif (request_type == 'individual-code') or (case_type == 'CE' and address_level == 'U') -%}
+    {%- set question_title = _('Do you want to send a new individual access code to this address?') -%}
+{%- elif (case_type == 'CE' and address_level == 'E') -%}
+    {%- set question_title = _('Do you want to send a new manager access code to this address?') -%}
+{%- else -%}
+    {%- set question_title = _('Do you want to send a new household access code to this address?') -%}
+{%- endif -%}
 
-{% block main %}
+{%- block main -%}
 
-    {% if messages_dict %}
-        {% include 'partials/messages.html' with context %}
-    {% endif %}
+    {%- if messages_dict -%}
+        {%- include 'partials/messages.html' with context -%}
+    {%- endif -%}
 
-    {% call onsQuestion({
-        'title': question_title
-    }) %}
+    {%- call onsQuestion({ 'title': question_title }) -%}
 
-    <p><div><strong>{{ first_name }} {{ last_name }}</strong></div>
-        {{ addressLine1 }}<br>
-        {% if addressLine2 %}{{ addressLine2 }}<br>{% endif %}
-        {% if addressLine3 %}{{ addressLine3 }}<br>{% endif %}
-        {% if townName %}{{ townName }}<br>{% endif %}
-        {{ postcode }}
-    </p>
+        <p><div><strong>{{ first_name }} {{ last_name }}</strong></div>
+            {{ addressLine1 }}<br>
+            {%- if addressLine2 -%}{{ addressLine2 }}<br>{%- endif -%}
+            {%- if addressLine3 -%}{{ addressLine3 }}<br>{%- endif -%}
+            {%- if townName -%}{{ townName }}<br>{%- endif -%}
+            {{ postcode }}
+        </p>
 
-    <p><a href="{{ request_common_enter_name_link }}">Change name</a></p>
+        <p><a href="{{ request_common_enter_name_link }}">Change name</a></p>
 
-
-{% if 'request-name-address-confirmation' in field_messages_dict %}
-    {{
-        onsRadios({
-            'name': 'request-name-address-confirmation',
-            'radios': form_options,
-            'error': {
-                'text': _('Select an option')
-            }
-        })
-    }}
-{% else %}
-    {{
-        onsRadios({
-            'name': 'request-name-address-confirmation',
-            'radios': form_options
-        })
-    }}
-{% endif %}
-    {% endcall %}
-
-    {%- if (request_type == 'paper-form') -%}
-
-        <h2 class="u-fs-m">Large print</h2>
         {{
-            onsCheckboxes({
-                "name": "format",
-                "checkboxes": [
-                    {
-                        "id": "large-print-yes",
-                        "label": {
-                            "text": "I need a large-print questionnaire"
-                        },
-                        "value": "large-print"
-                    }
-                ]
+            onsRadios({
+                'name': 'request-name-address-confirmation',
+                'radios': form_options,
+                'error': error_radio
             })
         }}
 
-    {%- endif -%}
+        {%- if (request_type == 'paper-form') -%}
+
+            {{
+                onsCheckboxes({
+                    'legend': 'Large print',
+                    'legendClasses': 'u-fs-m u-mt-l',
+                    'checkboxes': [
+                        {
+                            'id': 'large-print-yes',
+                            'name': 'request-name-address-large-print',
+                            'label': {
+                                'text': 'I need a large-print questionnaire'
+                            },
+                            'value': 'large-print'
+                        }
+                    ]
+                })
+            }}
+
+        {%- endif -%}
+
+    {%- endcall -%}
 
     {{
         onsButton({
@@ -133,4 +125,4 @@
         })
     }}
 
-{% endblock %}
+{%- endblock -%}

--- a/app/templates/request-common-confirm-name-address.html
+++ b/app/templates/request-common-confirm-name-address.html
@@ -6,6 +6,7 @@
 {% from 'components/question/_macro.njk' import onsQuestion %}
 {% from 'components/button/_macro.njk' import onsButton %}
 {% from 'components/radios/_macro.njk' import onsRadios %}
+{% from 'components/checkboxes/_macro.njk' import onsCheckboxes %}
 
 {% set request_common_enter_name_link = url('RequestCommonEnterName:get', display_region=display_region, request_type=request_type) %}
 
@@ -84,6 +85,26 @@
     }}
 {% endif %}
     {% endcall %}
+
+    {%- if (request_type == 'paper-form') -%}
+
+        <h2 class="u-fs-m">Large print</h2>
+        {{
+            onsCheckboxes({
+                "name": "format",
+                "checkboxes": [
+                    {
+                        "id": "large-print-yes",
+                        "label": {
+                            "text": "I need a large-print questionnaire"
+                        },
+                        "value": "large-print"
+                    }
+                ]
+            })
+        }}
+
+    {%- endif -%}
 
     {{
         onsButton({

--- a/app/templates/request-form-sent-post.html
+++ b/app/templates/request-form-sent-post.html
@@ -1,36 +1,39 @@
-{% extends 'base-' + display_region + '.html' %}
+{%- extends 'base-' + display_region + '.html' -%}
 
-{% if display_region == 'ni' %}
-    {% set census_home_link = domain_url_ni %}
-{% elif display_region == 'cy' %}
-    {% set census_home_link = domain_url_cy %}
-{% else %}
-    {% set census_home_link = domain_url_en %}
-{% endif %}
+{%- if display_region == 'ni' -%}
+    {%- set census_home_link = domain_url_ni -%}
+{%- elif display_region == 'cy' -%}
+    {%- set census_home_link = domain_url_cy -%}
+{%- else -%}
+    {%- set census_home_link = domain_url_en -%}
+{%- endif -%}
 
-{% set display_name = first_name + ' ' + last_name %}
-{% set display_address %}{{ addressLine1 }}, {% if addressLine2 %}{{ addressLine2 }}{% elif addressLine3 %}{{ addressLine3 }}{% elif townName %}{{ townName }}{% elif postcode %}{{ postcode }}{% endif %}{% endset %}
+{%- set display_name = first_name + ' ' + last_name -%}
+{%- set display_address -%}{{ addressLine1 }}, {% if addressLine2 %}{{ addressLine2 }}{% elif addressLine3 %}{{ addressLine3 }}{% elif townName %}{{ townName }}{% elif postcode %}{{ postcode }}{% endif %}{%- endset -%}
 
-{% from 'components/button/_macro.njk' import onsButton %}
-{% from "components/panel/_macro.njk" import onsPanel %}
+{%- from 'components/button/_macro.njk' import onsButton -%}
+{%- from "components/panel/_macro.njk" import onsPanel -%}
 
-{% block main %}
+{%- block main -%}
 
-    {%
+    {%-
         call onsPanel({
             'type': 'success',
             'id': 'success-id',
             'icon': 'check-green',
             'classes': 'u-mt-xl'
         })
-    %}
+    -%}
 
-        <h1 class="u-mb-xs u-fs-l">{{ _('A paper questionnaire will be sent to %(name)s at %(address)s', name=display_name, address=display_address)|safe }} </h1>
+        {%- if request_type == 'large-print' -%}
+            <h1 class="u-mb-xs u-fs-l">{{ _('A large-print paper questionnaire will be sent to %(name)s at %(address)s', name=display_name, address=display_address)|safe }} </h1>
+        {%- else -%}
+            <h1 class="u-mb-xs u-fs-l">{{ _('A paper questionnaire will be sent to %(name)s at %(address)s', name=display_name, address=display_address)|safe }} </h1>
+        {%- endif -%}
 
         <p>{{ _('This should arrive soon for you to complete your census') }}</p>
 
-
-    {% endcall %}
+    {%- endcall -%}
 
     {{
         onsButton({
@@ -41,4 +44,4 @@
         })
     }}
 
-{% endblock %}
+{%- endblock -%}

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -915,6 +915,12 @@ class RHTestCase(AioHTTPTestCase):
             'request-name-address-confirmation': 'yes', 'action[save_continue]': ''
         }
 
+        self.request_common_confirm_name_address_data_yes_large_print = {
+            'request-name-address-confirmation': 'yes',
+            'request-name-address-large-print': 'large-print',
+            'action[save_continue]': ''
+        }
+
         self.request_common_confirm_name_address_data_no = {
             'request-name-address-confirmation': 'no', 'action[save_continue]': ''
         }
@@ -1742,11 +1748,16 @@ class RHTestCase(AioHTTPTestCase):
 
         self.content_request_form_sent_post_title_en = \
             'A paper questionnaire will be sent to Bob Bobbington at 1 Gate Reach, Exeter'
+        self.content_request_form_sent_post_title_large_print_en = \
+            'A large-print paper questionnaire will be sent to Bob Bobbington at 1 Gate Reach, Exeter'
         self.content_request_form_sent_post_secondary_en = \
             'This should arrive soon for you to complete your census'
         # TODO: add welsh translation
         self.content_request_form_sent_post_title_cy = \
             'A paper questionnaire will be sent to Bob Bobbington at 1 Gate Reach, Exeter'
+        # TODO: add welsh translation
+        self.content_request_form_sent_post_title_large_print_cy = \
+            'A large-print paper questionnaire will be sent to Bob Bobbington at 1 Gate Reach, Exeter'
         # TODO Add Welsh Translation
         self.content_request_form_sent_post_secondary_cy = \
             'This should arrive soon for you to complete your census'
@@ -1755,6 +1766,7 @@ class RHTestCase(AioHTTPTestCase):
             'Do you want to send a paper questionnaire to this address?'
         self.content_request_form_confirm_name_address_option_yes_en = 'Yes, send the questionnaire by post'
         self.content_request_form_confirm_name_address_option_no_en = 'No, cancel and return'
+        self.content_request_form_confirm_name_address_large_print_checkbox_en = 'I need a large-print questionnaire'
 
         # TODO Add Welsh Translation
         self.content_request_form_confirm_name_address_title_cy = \
@@ -1763,6 +1775,8 @@ class RHTestCase(AioHTTPTestCase):
         self.content_request_form_confirm_name_address_option_yes_cy = 'Yes, send the questionnaire by post'
         # TODO Add Welsh Translation
         self.content_request_form_confirm_name_address_option_no_cy = 'No, cancel and return'
+        # TODO Add Welsh Translation
+        self.content_request_form_confirm_name_address_large_print_checkbox_cy = 'I need a large-print questionnaire'
 
         self.content_request_form_manager_title_en = 'We cannot send census forms to managers by post'
         # TODO Add Welsh Translation

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -175,6 +175,7 @@ class TestHelpers(RHTestCase):
             if (self.sub_user_journey == 'paper-form') and (override_sub_user_journey is False):
                 self.assertIn(self.content_request_form_confirm_name_address_option_yes_cy, contents)
                 self.assertIn(self.content_request_form_confirm_name_address_option_no_cy, contents)
+                self.assertIn(self.content_request_form_confirm_name_address_large_print_checkbox_cy, contents)
             else:
                 self.assertIn(self.content_request_common_confirm_name_address_option_yes_cy, contents)
                 self.assertIn(self.content_request_common_confirm_name_address_option_no_cy, contents)
@@ -193,6 +194,7 @@ class TestHelpers(RHTestCase):
             if (self.sub_user_journey == 'paper-form') and (override_sub_user_journey is False):
                 self.assertIn(self.content_request_form_confirm_name_address_option_yes_en, contents)
                 self.assertIn(self.content_request_form_confirm_name_address_option_no_en, contents)
+                self.assertIn(self.content_request_form_confirm_name_address_large_print_checkbox_en, contents)
             else:
                 self.assertIn(self.content_request_common_confirm_name_address_option_yes_en, contents)
                 self.assertIn(self.content_request_common_confirm_name_address_option_no_en, contents)
@@ -882,7 +884,12 @@ class TestHelpers(RHTestCase):
             mocked_get_fulfilment.return_value = self.rhsvc_get_fulfilment_multi_post
             mocked_request_fulfilment_post.return_value = self.rhsvc_request_fulfilment_post
 
-            response = await self.client.request('POST', url, data=self.request_common_confirm_name_address_data_yes)
+            if fulfilment_type == 'LARGE_PRINT':
+                data = self.request_common_confirm_name_address_data_yes_large_print
+            else:
+                data = self.request_common_confirm_name_address_data_yes
+            response = await self.client.request('POST', url, data=data)
+
             if override_sub_user_journey:
                 self.assertLogEvent(cm, self.build_url_log_entry(override_sub_user_journey + '/confirm-name-address',
                                                                  display_region, 'POST', False))
@@ -892,7 +899,10 @@ class TestHelpers(RHTestCase):
                                 ", fulfilment_type=" + fulfilment_type +
                                 ", region=" + region + ", individual=" + individual)
             if self.sub_user_journey == 'paper-form' and not override_sub_user_journey:
-                self.assertLogEvent(cm, self.build_url_log_entry('form-sent-post', display_region, 'GET'))
+                if fulfilment_type == 'LARGE_PRINT':
+                    self.assertLogEvent(cm, self.build_url_log_entry('large-print-sent-post', display_region, 'GET'))
+                else:
+                    self.assertLogEvent(cm, self.build_url_log_entry('form-sent-post', display_region, 'GET'))
             else:
                 if override_sub_user_journey:
                     self.assertLogEvent(cm, self.build_url_log_entry(override_sub_user_journey + '/code-sent-post',
@@ -905,12 +915,21 @@ class TestHelpers(RHTestCase):
             self.assertIn(self.get_logo(display_region), contents)
             if self.sub_user_journey == 'paper-form' and not override_sub_user_journey:
                 if not display_region == 'ni':
-                    self.assertIn(self.build_translation_link('form-sent-post', display_region), contents)
+                    if fulfilment_type == 'LARGE_PRINT':
+                        self.assertIn(self.build_translation_link('large-print-sent-post', display_region), contents)
+                    else:
+                        self.assertIn(self.build_translation_link('form-sent-post', display_region), contents)
                 if display_region == 'cy':
-                    self.assertIn(self.content_request_form_sent_post_title_cy, contents)
+                    if fulfilment_type == 'LARGE_PRINT':
+                        self.assertIn(self.content_request_form_sent_post_title_large_print_cy, contents)
+                    else:
+                        self.assertIn(self.content_request_form_sent_post_title_cy, contents)
                     self.assertIn(self.content_request_form_sent_post_secondary_cy, contents)
                 else:
-                    self.assertIn(self.content_request_form_sent_post_title_en, contents)
+                    if fulfilment_type == 'LARGE_PRINT':
+                        self.assertIn(self.content_request_form_sent_post_title_large_print_en, contents)
+                    else:
+                        self.assertIn(self.content_request_form_sent_post_title_en, contents)
                     self.assertIn(self.content_request_form_sent_post_secondary_en, contents)
             else:
                 if not display_region == 'ni':

--- a/tests/unit/test_requests_handlers_form.py
+++ b/tests/unit/test_requests_handlers_form.py
@@ -55,8 +55,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
         await self.check_post_select_address_no_selection_made(self.post_request_paper_form_select_address_cy, 'cy')
 
     @unittest_run_loop
-    async def test_post_request_paper_form_select_address_no_selection_ni(
-            self):
+    async def test_post_request_paper_form_select_address_no_selection_ni(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_ni, 'ni')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_ni, 'ni')
         await self.check_post_select_address_no_selection_made(self.post_request_paper_form_select_address_ni, 'ni')
@@ -1921,7 +1920,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_ni, 'ni')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_hh_ew_e(self):
+    async def test_request_paper_form_sent_post_hh_ew_e(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
@@ -1932,7 +1931,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_en, 'en', 'HH', 'QUESTIONNAIRE', 'E', 'false')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_hh_ew_w(self):
+    async def test_request_paper_form_sent_post_hh_ew_w(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
@@ -1943,7 +1942,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_en, 'en', 'HH', 'QUESTIONNAIRE', 'W', 'false')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_hh_cy(self):
+    async def test_request_paper_form_sent_post_hh_cy(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_cy, 'cy')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_paper_form_select_address_cy, 'cy')
@@ -1954,7 +1953,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_cy, 'cy', 'HH', 'QUESTIONNAIRE', 'W', 'false')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_hh_ni(self):
+    async def test_request_paper_form_sent_post_hh_ni(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_ni, 'ni')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_paper_form_select_address_ni, 'ni')
@@ -1965,7 +1964,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_ni, 'ni', 'HH', 'QUESTIONNAIRE', 'N', 'false')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_spg_ew_e(self):
+    async def test_request_paper_form_sent_post_spg_ew_e(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
@@ -1976,7 +1975,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_en, 'en', 'SPG', 'QUESTIONNAIRE', 'E', 'false')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_spg_ew_w(self):
+    async def test_request_paper_form_sent_post_spg_ew_w(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
@@ -1987,7 +1986,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_en, 'en', 'SPG', 'QUESTIONNAIRE', 'W', 'false')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_spg_cy(self):
+    async def test_request_paper_form_sent_post_spg_cy(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_cy, 'cy')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_paper_form_select_address_cy, 'cy')
@@ -1998,7 +1997,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_cy, 'cy', 'SPG', 'QUESTIONNAIRE', 'W', 'false')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_spg_ni(self):
+    async def test_request_paper_form_sent_post_spg_ni(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_ni, 'ni')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_paper_form_select_address_ni, 'ni')
@@ -2009,7 +2008,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_ni, 'ni', 'SPG', 'QUESTIONNAIRE', 'N', 'false')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_select_resident_ce_m_ew_e(self):
+    async def test_request_paper_form_sent_post_select_resident_ce_m_ew_e(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
@@ -2022,7 +2021,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_en, 'en', 'CE', 'QUESTIONNAIRE', 'E', 'true')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_select_resident_ce_m_ew_w(self):
+    async def test_request_paper_form_sent_post_select_resident_ce_m_ew_w(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
@@ -2035,7 +2034,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_en, 'en', 'CE', 'QUESTIONNAIRE', 'W', 'true')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_select_resident_ce_m_cy(self):
+    async def test_request_paper_form_sent_post_select_resident_ce_m_cy(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_cy, 'cy')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_paper_form_select_address_cy, 'cy')
@@ -2048,7 +2047,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_cy, 'cy', 'CE', 'QUESTIONNAIRE', 'W', 'true')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_select_resident_ce_m_ni(self):
+    async def test_request_paper_form_sent_post_select_resident_ce_m_ni(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_ni, 'ni')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_paper_form_select_address_ni, 'ni')
@@ -2061,7 +2060,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_ni, 'ni', 'CE', 'QUESTIONNAIRE', 'N', 'true')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_ce_r_ew_e(self):
+    async def test_request_paper_form_sent_post_ce_r_ew_e(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
@@ -2072,7 +2071,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_en, 'en', 'CE', 'QUESTIONNAIRE', 'E', 'true')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_ce_r_ew_w(self):
+    async def test_request_paper_form_sent_post_ce_r_ew_w(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
@@ -2083,7 +2082,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_en, 'en', 'CE', 'QUESTIONNAIRE', 'W', 'true')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_ce_r_cy(self):
+    async def test_request_paper_form_sent_post_ce_r_cy(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_cy, 'cy')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_paper_form_select_address_cy, 'cy')
@@ -2094,7 +2093,7 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             self.post_request_paper_form_confirm_name_address_cy, 'cy', 'CE', 'QUESTIONNAIRE', 'W', 'true')
 
     @unittest_run_loop
-    async def test_request_paper_form_code_sent_post_ce_r_ni(self):
+    async def test_request_paper_form_sent_post_ce_r_ni(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_ni, 'ni')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_paper_form_select_address_ni, 'ni')
@@ -2103,6 +2102,190 @@ class TestRequestsHandlersPaperForm(TestHelpers):
         await self.check_post_enter_name(self.post_request_paper_form_enter_name_ni, 'ni', 'individual')
         await self.check_post_confirm_name_address_input_yes(
             self.post_request_paper_form_confirm_name_address_ni, 'ni', 'CE', 'QUESTIONNAIRE', 'N', 'true')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_hh_ew_e(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_form_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_en, 'en', 'household')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_en, 'en', 'HH', 'LARGE_PRINT', 'E', 'false')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_hh_ew_w(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_form_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_en, 'en', 'household')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_en, 'en', 'HH', 'LARGE_PRINT', 'W', 'false')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_hh_cy(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_cy, 'cy')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_form_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_cy, 'cy', 'household')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_cy, 'cy', 'HH', 'LARGE_PRINT', 'W', 'false')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_hh_ni(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_ni, 'ni')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_form_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_ni, 'ni', 'household')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_ni, 'ni', 'HH', 'LARGE_PRINT', 'N', 'false')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_spg_ew_e(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_form_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_en, 'en', 'household')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_en, 'en', 'SPG', 'LARGE_PRINT', 'E', 'false')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_spg_ew_w(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_form_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_en, 'en', 'household')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_en, 'en', 'SPG', 'LARGE_PRINT', 'W', 'false')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_spg_cy(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_cy, 'cy')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_form_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_cy, 'cy', 'household')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_cy, 'cy', 'SPG', 'LARGE_PRINT', 'W', 'false')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_spg_ni(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_ni, 'ni')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_form_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_ni, 'ni', 'household')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_ni, 'ni', 'SPG', 'LARGE_PRINT', 'N', 'false')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_select_resident_ce_m_ew_e(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
+        await self.check_post_confirm_address_input_yes_ce(
+            self.post_request_paper_form_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_m_e)
+        await self.check_post_resident_or_manager_form_resident(
+            self.post_request_paper_form_resident_or_manager_en, 'en')
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_en, 'en', 'individual')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_en, 'en', 'CE', 'LARGE_PRINT', 'E', 'true')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_select_resident_ce_m_ew_w(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
+        await self.check_post_confirm_address_input_yes_ce(
+            self.post_request_paper_form_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_m_w)
+        await self.check_post_resident_or_manager_form_resident(
+            self.post_request_paper_form_resident_or_manager_en, 'en')
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_en, 'en', 'individual')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_en, 'en', 'CE', 'LARGE_PRINT', 'W', 'true')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_select_resident_ce_m_cy(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_cy, 'cy')
+        await self.check_post_confirm_address_input_yes_ce(
+            self.post_request_paper_form_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_m_w)
+        await self.check_post_resident_or_manager_form_resident(
+            self.post_request_paper_form_resident_or_manager_cy, 'cy')
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_cy, 'cy', 'individual')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_cy, 'cy', 'CE', 'LARGE_PRINT', 'W', 'true')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_select_resident_ce_m_ni(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_ni, 'ni')
+        await self.check_post_confirm_address_input_yes_ce(
+            self.post_request_paper_form_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_m_n)
+        await self.check_post_resident_or_manager_form_resident(
+            self.post_request_paper_form_resident_or_manager_ni, 'ni')
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_ni, 'ni', 'individual')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_ni, 'ni', 'CE', 'LARGE_PRINT', 'N', 'true')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_ce_r_ew_e(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_form_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e)
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_en, 'en', 'individual')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_en, 'en', 'CE', 'LARGE_PRINT', 'E', 'true')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_ce_r_ew_w(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_en, 'en')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_form_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w)
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_en, 'en', 'individual')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_en, 'en', 'CE', 'LARGE_PRINT', 'W', 'true')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_ce_r_cy(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_cy, 'cy')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_form_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w)
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_cy, 'cy', 'individual')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_cy, 'cy', 'CE', 'LARGE_PRINT', 'W', 'true')
+
+    @unittest_run_loop
+    async def test_request_paper_form_large_print_sent_post_ce_r_ni(self):
+        await self.check_get_enter_address(self.get_request_paper_form_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_paper_form_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_paper_form_select_address_ni, 'ni')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_form_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n)
+        await self.check_post_enter_name(self.post_request_paper_form_enter_name_ni, 'ni', 'individual')
+        await self.check_post_confirm_name_address_input_yes(
+            self.post_request_paper_form_confirm_name_address_ni, 'ni', 'CE', 'LARGE_PRINT', 'N', 'true')
 
     @unittest_run_loop
     async def test_request_paper_form_select_manager_ce_m_ew_e(self):


### PR DESCRIPTION
# Motivation and Context
Adds the ability to request a large print paper form

# What has changed
Addition of check box for large print to the name/address confirmation screen. If ticked, get fulfilment and request fulfilment calls to RHSvc request 'LARGE_PRINT' instead of 'QUESTIONNAIRE'

# How to test?
From /en/requests/paper-form/enter-address/ complete paper form request as before, but tick the new checkbox on the confirm name/address screen
16 new unit tests added

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1143
