### PR TITLE
Cr 1292 web chat welsh bug

### DIFF
--- a/app/webchat_handlers.py
+++ b/app/webchat_handlers.py
@@ -172,7 +172,7 @@ class WebChat(WebChat):
 
         context = {
             'screen_name': data.get('screen_name'),
-            'display_language': 'en',
+            'display_language': locale,
             'country': data.get('country'),
             'query': data.get('query'),
             'display_region': display_region,


### PR DESCRIPTION
# Motivation and Context
Value tweak to WebChat code to ensure language value is updated in the Serco iframe call

# What has changed
Changed hard-coded value to use existing 'locale' param instead

# How to test?
Fill in the WebChat form on both english and welsh versions and click 'Start web chat'
View source on next page, checking the url of the iframe call to the timeforstorm url.
The url param 'info_language' should be 'en' for english (and NI) version, and 'cy' for welsh version 

Tested against Cucumber in census-rh-dev - no updates required

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1292

# Screenshots (if appropriate):