### PR TITLE
CR-1302 Bug fix for request fulfilments

### DIFF
--- a/app/requests_handlers.py
+++ b/app/requests_handlers.py
@@ -311,9 +311,9 @@ class RequestCodeConfirmMobile(RequestCommon):
                 fulfilment_individual = 'false'
 
             if display_region == 'cy':
-                fulfilment_language = 'wel'
+                fulfilment_language = 'W'
             else:
-                fulfilment_language = 'eng'
+                fulfilment_language = 'E'
 
             logger.info(f"fulfilment query: case_type={attributes['case_type']}, region={attributes['region']}, "
                         f"individual={fulfilment_individual}",
@@ -545,9 +545,9 @@ class RequestCommonConfirmNameAddress(RequestCommon):
                 fulfilment_individual = 'false'
 
             if display_region == 'cy':
-                fulfilment_language = 'wel'
+                fulfilment_language = 'W'
             else:
-                fulfilment_language = 'eng'
+                fulfilment_language = 'E'
 
             if request_type == 'paper-form':
 

--- a/tests/test_data/rhsvc/get_fulfilment_multi_post.json
+++ b/tests/test_data/rhsvc/get_fulfilment_multi_post.json
@@ -1,40 +1,18 @@
 [
-   {
-       "caseType": "HH",
-       "deliveryChannel": "POST",
-       "description": "Household Unique Access Code for England",
-       "fieldDistributionCode": "",
-       "fulfilmentCode": "UACIT1",
-       "handler": "NOTIFY",
-       "initialContactCode": "",
-       "language": "E",
-       "regions": [
-           "W"
-       ],
-       "reminderContactCode": "",
-       "requestChannels": [
-           "CC",
-           "FIELD",
-           "RH"
-       ]
-   },
     {
-        "caseType": "HH",
-        "deliveryChannel": "POST",
-        "description": "Household Unique Access Code for England",
-        "fieldDistributionCode": "",
-        "fulfilmentCode": "UACIT2",
-        "handler": "NOTIFY",
-        "initialContactCode": "",
-        "language": "W",
+        "fulfilmentCode": "P_UAC_UACHHP2B",
+        "productGroup": "UAC",
+        "description": "Household Unique Access Code for Wales (English/Welsh - Bilingual) via paper",
+        "language": "B",
+        "caseTypes": [
+            "HH",
+            "SPG"
+        ],
+        "individual": false,
         "regions": [
             "W"
         ],
-        "reminderContactCode": "",
-        "requestChannels": [
-            "CC",
-            "FIELD",
-            "RH"
-        ]
+        "deliveryChannel": "POST",
+        "handler": "PRINT"
     }
 ]

--- a/tests/test_data/rhsvc/get_fulfilment_multi_post.json
+++ b/tests/test_data/rhsvc/get_fulfilment_multi_post.json
@@ -7,7 +7,7 @@
        "fulfilmentCode": "UACIT1",
        "handler": "NOTIFY",
        "initialContactCode": "",
-       "language": "eng",
+       "language": "E",
        "regions": [
            "W"
        ],
@@ -26,7 +26,7 @@
         "fulfilmentCode": "UACIT2",
         "handler": "NOTIFY",
         "initialContactCode": "",
-        "language": "wel",
+        "language": "W",
         "regions": [
             "W"
         ],

--- a/tests/test_data/rhsvc/get_fulfilment_multi_sms.json
+++ b/tests/test_data/rhsvc/get_fulfilment_multi_sms.json
@@ -1,40 +1,34 @@
 [
-   {
-       "caseType": "HH",
-       "deliveryChannel": "SMS",
-       "description": "Household Unique Access Code for England",
-       "fieldDistributionCode": "",
-       "fulfilmentCode": "UACIT1",
-       "handler": "NOTIFY",
-       "initialContactCode": "",
-       "language": "eng",
-       "regions": [
-           "W"
-       ],
-       "reminderContactCode": "",
-       "requestChannels": [
-           "CC",
-           "FIELD",
-           "RH"
-       ]
-   },
     {
-        "caseType": "HH",
-        "deliveryChannel": "SMS",
-        "description": "Household Unique Access Code for England",
-        "fieldDistributionCode": "",
-        "fulfilmentCode": "UACIT2",
-        "handler": "NOTIFY",
-        "initialContactCode": "",
-        "language": "wel",
+        "fulfilmentCode": "UACHHT2",
+        "productGroup": "UAC",
+        "description": "Household Unique Access Code for Wales (in English) via SMS",
+        "language": "E",
+        "caseTypes": [
+            "HH",
+            "SPG"
+        ],
+        "individual": false,
         "regions": [
             "W"
         ],
-        "reminderContactCode": "",
-        "requestChannels": [
-            "CC",
-            "FIELD",
-            "RH"
-        ]
+        "deliveryChannel": "SMS",
+        "handler": "NOTIFY"
+    },
+    {
+        "fulfilmentCode": "UACHHT2W",
+        "productGroup": "UAC",
+        "description": "Household Unique Access Code for Wales (in Welsh) via SMS",
+        "language": "W",
+        "caseTypes": [
+            "HH",
+            "SPG"
+        ],
+        "individual": false,
+        "regions": [
+            "W"
+        ],
+        "deliveryChannel": "SMS",
+        "handler": "NOTIFY"
     }
 ]

--- a/tests/test_data/rhsvc/get_fulfilment_single_post.json
+++ b/tests/test_data/rhsvc/get_fulfilment_single_post.json
@@ -7,7 +7,7 @@
        "fulfilmentCode": "UACIT1",
        "handler": "NOTIFY",
        "initialContactCode": "",
-       "language": "eng",
+       "language": "E",
        "regions": [
            "W"
        ],

--- a/tests/test_data/rhsvc/get_fulfilment_single_post.json
+++ b/tests/test_data/rhsvc/get_fulfilment_single_post.json
@@ -1,21 +1,18 @@
 [
-   {
-       "caseType": "HH",
-       "deliveryChannel": "POST",
-       "description": "Household Unique Access Code for England",
-       "fieldDistributionCode": "",
-       "fulfilmentCode": "UACIT1",
-       "handler": "NOTIFY",
-       "initialContactCode": "",
-       "language": "E",
-       "regions": [
-           "W"
-       ],
-       "reminderContactCode": "",
-       "requestChannels": [
-           "CC",
-           "FIELD",
-           "RH"
-       ]
-   }
+    {
+        "fulfilmentCode": "P_UAC_UACHHP1",
+        "productGroup": "UAC",
+        "description": "Household Unique Access Code for England via paper",
+        "language": "E",
+        "caseTypes": [
+            "HH",
+            "SPG"
+        ],
+        "individual": false,
+        "regions": [
+            "E"
+        ],
+        "deliveryChannel": "POST",
+        "handler": "PRINT"
+    }
 ]

--- a/tests/test_data/rhsvc/get_fulfilment_single_sms.json
+++ b/tests/test_data/rhsvc/get_fulfilment_single_sms.json
@@ -7,7 +7,7 @@
        "fulfilmentCode": "UACIT1",
        "handler": "NOTIFY",
        "initialContactCode": "",
-       "language": "eng",
+       "language": "E",
        "regions": [
            "W"
        ],

--- a/tests/test_data/rhsvc/get_fulfilment_single_sms.json
+++ b/tests/test_data/rhsvc/get_fulfilment_single_sms.json
@@ -1,21 +1,18 @@
 [
-   {
-       "caseType": "HH",
-       "deliveryChannel": "SMS",
-       "description": "Household Unique Access Code for England",
-       "fieldDistributionCode": "",
-       "fulfilmentCode": "UACIT1",
-       "handler": "NOTIFY",
-       "initialContactCode": "",
-       "language": "E",
-       "regions": [
-           "W"
-       ],
-       "reminderContactCode": "",
-       "requestChannels": [
-           "CC",
-           "FIELD",
-           "RH"
-       ]
-   }
+    {
+        "fulfilmentCode": "UACHHT1",
+        "productGroup": "UAC",
+        "description": "Household Unique Access Code for England via SMS",
+        "language": "E",
+        "caseTypes": [
+            "HH",
+            "SPG"
+        ],
+        "individual": false,
+        "regions": [
+            "E"
+        ],
+        "deliveryChannel": "SMS",
+        "handler": "NOTIFY"
+    }
 ]


### PR DESCRIPTION
Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Fix bug introduced by RHSvc change

# What has changed
An update to RHSvc changed the return value for language in the get_fulfilments call, breaking RHUI when more than one code was returned. This change makes RHUI use the revised values for language.

# How to test?
Request a fulfilment for a welsh postcode (in english or welsh), and confirm journey completes without error

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1302
