### PR TITLE
CR-1206 implementation and unittests. Also fixed other eq related tests

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -133,7 +133,7 @@ class View:
                         key_store=app['key_store'],
                         key_purpose='authentication')
 
-        await RHService.post_surveylaunched(request, case, adlocation)
+        await RHService.post_surveylaunched(request, case, adlocation, eq_payload)
 
         logger.info('redirecting to eq', client_ip=request['client_ip'])
         eq_url = app['EQ_URL']
@@ -478,11 +478,11 @@ class RHService(View):
                                         return_json=True)
 
     @staticmethod
-    async def post_surveylaunched(request, case, adlocation):
+    async def post_surveylaunched(request, case, adlocation, eq_payload):
         if not adlocation:
             adlocation = ''
         launch_json = {
-            'questionnaireId': case['questionnaireId'],
+            'questionnaireId': eq_payload['questionnaire_id'],
             'caseId': case['caseId'],
             'agentId': adlocation
         }

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -629,7 +629,7 @@ class RHTestCase(AioHTTPTestCase):
             'account_service_log_out_url': f'{account_svc_url}{url_path_prefix}/start/save-and-exit',
             'channel': self.channel,
             'user_id': '',
-            'questionnaire_id': self.questionnaire_id,
+            'questionnaire_id': self.response_id,
             'eq_id': self.eq_id,
             'period_id': self.period_id,
             'form_type': self.form_type,

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -56,6 +56,15 @@ class TestEq(RHTestCase):
             self.assertIn(f'Could not retrieve address uprn from case JSON',
                           ex.exception.message)
 
+    @staticmethod
+    async def patch_response_id(payload, eq_payload):
+        rid_generated = payload.get("response_id")
+        qid_generated = payload.get("questionnaire_id")
+        eq_payload['response_id'] = rid_generated
+        eq_payload['questionnaire_id'] = qid_generated
+
+        return eq_payload
+
     @unittest_run_loop
     async def test_build_en(self):
         eq_payload = self.eq_payload.copy()
@@ -86,6 +95,7 @@ class TestEq(RHTestCase):
                                 case_id=self.case_id,
                                 tx_id=self.jti)
 
+        await self.patch_response_id(payload, eq_payload)
         mocked_uuid4.assert_called()
         mocked_time.assert_called()
         self.assertEqual(payload, eq_payload)
@@ -120,6 +130,7 @@ class TestEq(RHTestCase):
                                 case_id=self.case_id,
                                 tx_id=self.jti)
 
+        await self.patch_response_id(payload, eq_payload)
         mocked_uuid4.assert_called()
         mocked_time.assert_called()
         self.assertEqual(payload, eq_payload)
@@ -154,6 +165,7 @@ class TestEq(RHTestCase):
                                 case_id=self.case_id,
                                 tx_id=self.jti)
 
+        await self.patch_response_id(payload, eq_payload)
         mocked_uuid4.assert_called()
         mocked_time.assert_called()
         self.assertEqual(payload, eq_payload)
@@ -189,6 +201,7 @@ class TestEq(RHTestCase):
                                 case_id=self.case_id,
                                 tx_id=self.jti)
 
+        await self.patch_response_id(payload, eq_payload)
         mocked_uuid4.assert_called()
         mocked_time.assert_called()
         self.assertEqual(payload, eq_payload)
@@ -224,6 +237,7 @@ class TestEq(RHTestCase):
                                 case_id=self.case_id,
                                 tx_id=self.jti)
 
+        await self.patch_response_id(payload, eq_payload)
         mocked_uuid4.assert_called()
         mocked_time.assert_called()
         self.assertEqual(payload, eq_payload)
@@ -259,6 +273,7 @@ class TestEq(RHTestCase):
                                 case_id=self.case_id,
                                 tx_id=self.jti)
 
+        await self.patch_response_id(payload, eq_payload)
         mocked_uuid4.assert_called()
         mocked_time.assert_called()
         self.assertEqual(payload, eq_payload)
@@ -272,6 +287,39 @@ class TestEq(RHTestCase):
             await eq.EqPayloadConstructor(self.uac_json_e, None, self.app,
                                           None).build()
         self.assertIn('Attributes is empty', ex.exception.message)
+
+    @unittest_run_loop
+    async def generate_and_encrypt_response_id_success(self):
+        from app import eq
+
+        eq_payload_1 = eq.EqPayloadConstructor.build()
+        eq_payload_1_response_id = eq_payload_1.get("response_id")
+        self.assertIsNotNone(eq_payload_1_response_id)
+
+    @unittest_run_loop
+    async def generate_and_encrypt_response_id_unique_response_ids_and_unique_questionnaire_ids(self):
+        from app import eq
+
+        eq_payload_1 = eq.EqPayloadConstructor.build()
+        eq_payload_1_response_id = eq_payload_1.get("response_id")
+        eq_payload_1_questionnaire_id = eq_payload_1.get("questionnaire_id")
+
+        eq_payload_2 = eq.EqPayloadConstructor.build()
+        eq_payload_2_response_id = eq_payload_2.get("response_id")
+        eq_payload_2_questionnaire_id = eq_payload_2.get("questionnaire_id")
+
+        self.assertNotEqual(eq_payload_1_response_id, eq_payload_2_response_id)
+        self.assertNotEqual(eq_payload_1_questionnaire_id, eq_payload_2_questionnaire_id)
+
+    @unittest_run_loop
+    async def generate_and_encrypt_response_id_equals_questionnaire_id(self):
+        from app import eq
+
+        eq_payload = eq.EqPayloadConstructor.build()
+        actual_response_id = eq_payload.get("response_id")
+        actual_questionnaire_id = eq_payload.get("questionnaire_id")
+
+        self.assertEqual(actual_response_id, actual_questionnaire_id)
 
     def test_build_display_address_en(self):
         eq_payload = self.eq_payload.copy()


### PR DESCRIPTION
# Motivation and Context

Encrypting the response Id which is also the questionnaire Id, to promote a more robust security model

# What has changed

- Implemented new method to encrypt the response Id (and also the questionnaire Id)
- Created 3 additional unittests within app/eq.py
- Fixed other tests within app/eq.py as they were not utilising the encrypted response Id / questionnaire Id
- Fixed payload within the post_surveylaunched method

# How to test?

To test, execute:

python -m unittest tests/unit/test_eq.py 

# Links

https://collaborate2.ons.gov.uk/jira/browse/CR-1206

https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=CATD&title=Census+Respondent+Home#CensusRespondentHome-ResponseIdgeneration

<img width="1767" alt="Screenshot 2020-11-08 at 16 13 40" src="https://user-images.githubusercontent.com/72972620/98470429-6de2c800-21dd-11eb-9fb3-70d0368bc3f1.png">
