### PR TITLE
CR-1206 hash eq response_id using salt

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -75,6 +75,7 @@ class BaseConfig:
     AD_LOOK_UP_SVC_AUTH = (env('AD_LOOK_UP_SVC_USERNAME'), env('AD_LOOK_UP_SVC_PASSWORD'))
     AD_LOOK_UP_SVC_APIKEY = env('AD_LOOK_UP_SVC_APIKEY')
     AD_LOOK_UP_SVC_APPID = env('AD_LOOK_UP_SVC_APPID')
+    RESPONSE_ID_SALT = env('RESPONSE_ID_SALT', default='s3cr3tS4lt')
 
 
 class ProductionConfig(BaseConfig):
@@ -130,6 +131,7 @@ class DevelopmentConfig:
                            env.str('AD_LOOK_UP_SVC_PASSWORD', default='secret'))
     AD_LOOK_UP_SVC_APIKEY = env.str('AD_LOOK_UP_SVC_APIKEY', default='apikey')
     AD_LOOK_UP_SVC_APPID = env.str('AD_LOOK_UP_SVC_APPID', default='appid')
+    RESPONSE_ID_SALT = env('RESPONSE_ID_SALT', default='s3cr3tS4lt')
 
 
 class TestingConfig:
@@ -171,3 +173,4 @@ class TestingConfig:
     AD_LOOK_UP_SVC_AUTH = ('admin', 'secret')
     AD_LOOK_UP_SVC_APIKEY = 'apikey'
     AD_LOOK_UP_SVC_APPID = 'appid'
+    RESPONSE_ID_SALT = 's3cr3tS4lt'

--- a/app/config.py
+++ b/app/config.py
@@ -75,7 +75,7 @@ class BaseConfig:
     AD_LOOK_UP_SVC_AUTH = (env('AD_LOOK_UP_SVC_USERNAME'), env('AD_LOOK_UP_SVC_PASSWORD'))
     AD_LOOK_UP_SVC_APIKEY = env('AD_LOOK_UP_SVC_APIKEY')
     AD_LOOK_UP_SVC_APPID = env('AD_LOOK_UP_SVC_APPID')
-    EQ_RESPONSE_ID_SALT = env('EQ_RESPONSE_ID_SALT', default='s3cr3tS4lt')
+    EQ_SALT = env('EQ_SALT', default='s3cr3tS4lt')
 
 
 class ProductionConfig(BaseConfig):
@@ -131,7 +131,7 @@ class DevelopmentConfig:
                            env.str('AD_LOOK_UP_SVC_PASSWORD', default='secret'))
     AD_LOOK_UP_SVC_APIKEY = env.str('AD_LOOK_UP_SVC_APIKEY', default='apikey')
     AD_LOOK_UP_SVC_APPID = env.str('AD_LOOK_UP_SVC_APPID', default='appid')
-    EQ_RESPONSE_ID_SALT = env('EQ_RESPONSE_ID_SALT', default='s3cr3tS4lt')
+    EQ_SALT = env('EQ_SALT', default='s3cr3tS4lt')
 
 
 class TestingConfig:
@@ -173,4 +173,4 @@ class TestingConfig:
     AD_LOOK_UP_SVC_AUTH = ('admin', 'secret')
     AD_LOOK_UP_SVC_APIKEY = 'apikey'
     AD_LOOK_UP_SVC_APPID = 'appid'
-    EQ_RESPONSE_ID_SALT = 's3cr3tS4lt'
+    EQ_SALT = 's3cr3tS4lt'

--- a/app/config.py
+++ b/app/config.py
@@ -75,7 +75,7 @@ class BaseConfig:
     AD_LOOK_UP_SVC_AUTH = (env('AD_LOOK_UP_SVC_USERNAME'), env('AD_LOOK_UP_SVC_PASSWORD'))
     AD_LOOK_UP_SVC_APIKEY = env('AD_LOOK_UP_SVC_APIKEY')
     AD_LOOK_UP_SVC_APPID = env('AD_LOOK_UP_SVC_APPID')
-    RESPONSE_ID_SALT = env('RESPONSE_ID_SALT', default='s3cr3tS4lt')
+    EQ_RESPONSE_ID_SALT = env('EQ_RESPONSE_ID_SALT', default='s3cr3tS4lt')
 
 
 class ProductionConfig(BaseConfig):
@@ -131,7 +131,7 @@ class DevelopmentConfig:
                            env.str('AD_LOOK_UP_SVC_PASSWORD', default='secret'))
     AD_LOOK_UP_SVC_APIKEY = env.str('AD_LOOK_UP_SVC_APIKEY', default='apikey')
     AD_LOOK_UP_SVC_APPID = env.str('AD_LOOK_UP_SVC_APPID', default='appid')
-    RESPONSE_ID_SALT = env('RESPONSE_ID_SALT', default='s3cr3tS4lt')
+    EQ_RESPONSE_ID_SALT = env('EQ_RESPONSE_ID_SALT', default='s3cr3tS4lt')
 
 
 class TestingConfig:
@@ -173,4 +173,4 @@ class TestingConfig:
     AD_LOOK_UP_SVC_AUTH = ('admin', 'secret')
     AD_LOOK_UP_SVC_APIKEY = 'apikey'
     AD_LOOK_UP_SVC_APPID = 'appid'
-    RESPONSE_ID_SALT = 's3cr3tS4lt'
+    EQ_RESPONSE_ID_SALT = 's3cr3tS4lt'

--- a/app/eq.py
+++ b/app/eq.py
@@ -28,7 +28,7 @@ class EqPayloadConstructor(object):
 
         self._sample_attributes = attributes
 
-        salt = app['RESPONSE_ID_SALT']
+        salt = app['EQ_RESPONSE_ID_SALT']
         domain_url_protocol = app['DOMAIN_URL_PROTOCOL']
         domain_url = app['DOMAIN_URL_EN']
         url_path_prefix = app['URL_PATH_PREFIX']

--- a/app/eq.py
+++ b/app/eq.py
@@ -28,7 +28,7 @@ class EqPayloadConstructor(object):
 
         self._sample_attributes = attributes
 
-        salt = app['EQ_RESPONSE_ID_SALT']
+        salt = app['EQ_SALT']
         domain_url_protocol = app['DOMAIN_URL_PROTOCOL']
         domain_url = app['DOMAIN_URL_EN']
         url_path_prefix = app['URL_PATH_PREFIX']

--- a/app/eq.py
+++ b/app/eq.py
@@ -1,4 +1,5 @@
 import time
+import hashlib
 from collections import namedtuple
 from uuid import uuid4
 from aiohttp.web import Application
@@ -27,6 +28,7 @@ class EqPayloadConstructor(object):
 
         self._sample_attributes = attributes
 
+        salt = app['RESPONSE_ID_SALT']
         domain_url_protocol = app['DOMAIN_URL_PROTOCOL']
         domain_url = app['DOMAIN_URL_EN']
         url_path_prefix = app['URL_PATH_PREFIX']
@@ -61,14 +63,11 @@ class EqPayloadConstructor(object):
             raise InvalidEqPayLoad('No collection id in supplied case JSON')
 
         try:
-            self._response_id = case['questionnaireId']
-        except KeyError:
-            raise InvalidEqPayLoad('No questionnaireId in supplied case JSON')
-
-        try:
             self._questionnaire_id = case['questionnaireId']
         except KeyError:
             raise InvalidEqPayLoad('No questionnaireId in supplied case JSON')
+
+        self._response_id = self.hash_qid(self._questionnaire_id, salt)
 
         try:
             self._uprn = case['address']['uprn']
@@ -125,8 +124,11 @@ class EqPayloadConstructor(object):
             'form_type': self._form_type,
             'survey': 'CENSUS'  # hardcoded for rehearsal
         }
-
         return self._payload
+
+    def hash_qid(self, qid, salt):
+        hashed = hashlib.sha256(salt.encode() + qid.encode()).hexdigest()
+        return qid + hashed[0:16]
 
     @staticmethod
     def build_display_address(sample_attributes):

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -585,7 +585,7 @@ class RHTestCase(AioHTTPTestCase):
         self.uac = 'w4nwwpphjjptp7fn'
         self.uacHash = self.uac_json_e['uacHash']
         self.uprn = self.uac_json_e['address']['uprn']
-        self.response_id = self.uac_json_e['questionnaireId']
+        self.response_id = '111000000092a445af12905967d'
         self.questionnaire_id = self.uac_json_e['questionnaireId']
         self.case_type = self.uac_json_e['caseType']
         self.channel = 'rh'


### PR DESCRIPTION
# Motivation and Context
CR-1206 changes to encrypt the EQ payload response_id based on the questionnaire id.  This will match the encryption
done by the services.

existing unit tests will check expected result.