### PR TITLE
CR-1403 Region redirect urls bug

### DIFF
--- a/app/common_handlers.py
+++ b/app/common_handlers.py
@@ -117,7 +117,8 @@ class CommonAddressInNorthernIreland(CommonCommon):
             'page_title': page_title,
             'display_region': display_region,
             'locale': locale,
-            'page_url': View.gen_page_url(request)
+            'page_url': View.gen_page_url(request),
+            'contact_us_link': View.get_campaign_site_link(request, display_region, 'contact-us')
         }
 
 
@@ -140,7 +141,8 @@ class CommonAddressInEngland(CommonCommon):
 
         return {
             'page_title': page_title,
-            'locale': locale
+            'locale': locale,
+            'contact_us_link': View.get_campaign_site_link(request, display_region, 'contact-us')
         }
 
 
@@ -163,7 +165,8 @@ class CommonAddressInWales(CommonCommon):
 
         return {
             'page_title': page_title,
-            'locale': locale
+            'locale': locale,
+            'contact_us_link': View.get_campaign_site_link(request, display_region, 'contact-us')
         }
 
 

--- a/app/start_handlers.py
+++ b/app/start_handlers.py
@@ -222,7 +222,8 @@ class StartCodeForNorthernIreland(StartCommon):
             'display_region': display_region,
             'locale': locale,
             'page_title': page_title,
-            'page_url': View.gen_page_url(request)
+            'page_url': View.gen_page_url(request),
+            'contact_us_link': View.get_campaign_site_link(request, display_region, 'contact-us')
         }
 
 
@@ -242,7 +243,8 @@ class StartCodeForEngland(StartCommon):
         return {
             'display_region': display_region,
             'locale': locale,
-            'page_title': page_title
+            'page_title': page_title,
+            'contact_us_link': View.get_campaign_site_link(request, display_region, 'contact-us')
         }
 
 
@@ -261,7 +263,8 @@ class StartCodeForWales(StartCommon):
 
         return {
             'locale': locale,
-            'page_title': page_title
+            'page_title': page_title,
+            'contact_us_link': View.get_campaign_site_link(request, display_region, 'contact-us')
         }
 
 

--- a/app/templates/common-address-in-england.html
+++ b/app/templates/common-address-in-england.html
@@ -1,13 +1,13 @@
 {%- extends 'base-ni.html' -%}
-
+{%- set census_home_link = domain_url_en -%}
 {%- block main -%}
 
     <h1 class="u-mt-l">This address is not part of the census for Northern Ireland</h1>
 
     <p>You have selected an address in England.</p>
 
-    <p>The Office for National Statistics (ONS) runs the census in England and Wales. Visit the <a href="https://www.census.gov.uk/">Office for National Statistics census website</a> to find out how to take part in the census for England and Wales.</p>
+    <p>The Office for National Statistics (ONS) runs the census in England and Wales. Visit the <a href="{{ census_home_link }}">Office for National Statistics census website</a> to find out how to take part in the census for England and Wales.</p>
 
-    <p>Alternatively, you can <a href="/ni/contact-us/">contact us for help</a>.</p>
+    <p>Alternatively, you can <a href="{{ contact_us_link }}">contact us for help</a>.</p>
 
 {%- endblock -%}

--- a/app/templates/common-address-in-england.html
+++ b/app/templates/common-address-in-england.html
@@ -8,6 +8,6 @@
 
     <p>The Office for National Statistics (ONS) runs the census in England and Wales. Visit the <a href="{{ census_home_link }}">Office for National Statistics census website</a> to find out how to take part in the census for England and Wales.</p>
 
-    <p>Alternatively, you can <a href="{{ contact_us_link }}">contact us for help</a>.</p>
+    <p>Alternatively, you can <a href="{{ contact_us_link }}">contact us</a> for help.</p>
 
 {%- endblock -%}

--- a/app/templates/common-address-in-northern-ireland.html
+++ b/app/templates/common-address-in-northern-ireland.html
@@ -9,7 +9,7 @@
     {%- autoescape false -%}
         <p>{{ _('The Northern Ireland Statistics and Research Agency (NISRA) runs the census in Northern Ireland. Visit the %(open)sNISRA census website%(close)s to find out how to take part in the census for Northern Ireland.', open='<a href="%s">' % census_home_link, close='</a>')|safe }}</p>
 
-        <p>{{ _('Alternatively, you can %(open)scontact us for help%(close)s.', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
+        <p>{{ _('Alternatively, you can %(open)scontact us%(close)s for help.', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
     {%- endautoescape -%}
 
 {%- endblock -%}

--- a/app/templates/common-address-in-northern-ireland.html
+++ b/app/templates/common-address-in-northern-ireland.html
@@ -1,13 +1,15 @@
 {%- extends 'base-' + display_region + '.html' -%}
-
+{%- set census_home_link = domain_url_ni -%}
 {%- block main -%}
 
     <h1 class="u-mt-l">{{ _('This address is not part of the census for England and Wales') }}</h1>
 
     <p>{{ _('You have selected an address in Northern Ireland.') }}</p>
 
-    <p>{{ _('The Northern Ireland Statistics and Research Agency (NISRA) runs the census in Northern Ireland. Visit the <a href="https://www.census.gov.uk/ni/">NISRA census website</a> to find out how to take part in the census for Northern Ireland.') }}</p>
+    {%- autoescape false -%}
+        <p>{{ _('The Northern Ireland Statistics and Research Agency (NISRA) runs the census in Northern Ireland. Visit the %(open)sNISRA census website%(close)s to find out how to take part in the census for Northern Ireland.', open='<a href="%s">' % census_home_link, close='</a>')|safe }}</p>
 
-    <p>{{ _('Alternatively, you can <a href="/contact-us/">contact us for help</a>.') }}</p>
+        <p>{{ _('Alternatively, you can %(open)scontact us for help%(close)s.', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
+    {%- endautoescape -%}
 
 {%- endblock -%}

--- a/app/templates/common-address-in-wales.html
+++ b/app/templates/common-address-in-wales.html
@@ -8,6 +8,6 @@
 
     <p>The Office for National Statistics (ONS) runs the census in England and Wales. Visit the <a href="{{ census_home_link }}">Office for National Statistics census website</a> to find out how to take part in the census for England and Wales.</p>
 
-    <p>Alternatively, you can <a href="{{ contact_us_link }}">contact us for help</a>.</p>
+    <p>Alternatively, you can <a href="{{ contact_us_link }}">contact us</a> for help.</p>
 
 {%- endblock -%}

--- a/app/templates/common-address-in-wales.html
+++ b/app/templates/common-address-in-wales.html
@@ -1,13 +1,13 @@
 {%- extends 'base-ni.html' -%}
-
+{%- set census_home_link = domain_url_en -%}
 {%- block main -%}
 
     <h1 class="u-mt-l">This address is not part of the census for Northern Ireland</h1>
 
     <p>You have selected an address in Wales.</p>
 
-    <p>The Office for National Statistics (ONS) runs the census in England and Wales. Visit the <a href="https://www.census.gov.uk/">Office for National Statistics census website</a> to find out how to take part in the census for England and Wales.</p>
+    <p>The Office for National Statistics (ONS) runs the census in England and Wales. Visit the <a href="{{ census_home_link }}">Office for National Statistics census website</a> to find out how to take part in the census for England and Wales.</p>
 
-    <p>Alternatively, you can <a href="/ni/contact-us/">contact us for help</a>.</p>
+    <p>Alternatively, you can <a href="{{ contact_us_link }}">contact us for help</a>.</p>
 
 {%- endblock -%}

--- a/app/templates/start-code-for-england.html
+++ b/app/templates/start-code-for-england.html
@@ -1,13 +1,13 @@
 {%- extends 'base-ni.html' -%}
-
+{%- set census_home_link = domain_url_en -%}
 {%- block main -%}
 
     <h1 class="u-mt-l">This access code is not part of the census for Northern Ireland</h1>
 
     <p>You have entered an access code for the census in England.</p>
 
-    <p>The Office for National Statistics (ONS) runs the census in England and Wales. Visit the <a href="https://www.census.gov.uk/">Office for National Statistics census website</a> to find out how to take part in the census for England and Wales.</p>
+    <p>The Office for National Statistics (ONS) runs the census in England and Wales. Visit the <a href="{{ census_home_link }}">Office for National Statistics census website</a> to find out how to take part in the census for England and Wales.</p>
 
-    <p>Alternatively, you can <a href="/ni/contact-us/">contact us for help</a>.</p>
+    <p>Alternatively, you can <a href="{{ contact_us_link }}">contact us for help</a>.</p>
 
 {%- endblock -%}

--- a/app/templates/start-code-for-england.html
+++ b/app/templates/start-code-for-england.html
@@ -8,6 +8,6 @@
 
     <p>The Office for National Statistics (ONS) runs the census in England and Wales. Visit the <a href="{{ census_home_link }}">Office for National Statistics census website</a> to find out how to take part in the census for England and Wales.</p>
 
-    <p>Alternatively, you can <a href="{{ contact_us_link }}">contact us for help</a>.</p>
+    <p>Alternatively, you can <a href="{{ contact_us_link }}">contact us</a> for help.</p>
 
 {%- endblock -%}

--- a/app/templates/start-code-for-northern-ireland.html
+++ b/app/templates/start-code-for-northern-ireland.html
@@ -1,13 +1,15 @@
 {%- extends 'base-' + display_region + '.html' -%}
-
+{%- set census_home_link = domain_url_ni -%}
 {%- block main -%}
 
     <h1 class="u-mt-l">{{ _('This access code is not part of the census for England and Wales') }}</h1>
 
     <p>{{ _('You have entered an access code for the census in Northern Ireland.') }}</p>
 
-    <p>{{ _('The Northern Ireland Statistics and Research Agency (NISRA) runs the census in Northern Ireland. Visit the <a href="https://www.census.gov.uk/ni/">NISRA census website</a> to find out how to take part in the census for Northern Ireland.') }}</p>
+    {%- autoescape false -%}
+        <p>{{ _('The Northern Ireland Statistics and Research Agency (NISRA) runs the census in Northern Ireland. Visit the %(open)sNISRA census website%(close)s to find out how to take part in the census for Northern Ireland.', open='<a href="%s">' % census_home_link, close='</a>')|safe }}</p>
 
-    <p>{{ _('Alternatively, you can <a href="/contact-us/">contact us for help</a>.') }}</p>
+        <p>{{ _('Alternatively, you can %(open)scontact us for help%(close)s.', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
+    {%- endautoescape -%}
 
 {%- endblock -%}

--- a/app/templates/start-code-for-northern-ireland.html
+++ b/app/templates/start-code-for-northern-ireland.html
@@ -9,7 +9,7 @@
     {%- autoescape false -%}
         <p>{{ _('The Northern Ireland Statistics and Research Agency (NISRA) runs the census in Northern Ireland. Visit the %(open)sNISRA census website%(close)s to find out how to take part in the census for Northern Ireland.', open='<a href="%s">' % census_home_link, close='</a>')|safe }}</p>
 
-        <p>{{ _('Alternatively, you can %(open)scontact us for help%(close)s.', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
+        <p>{{ _('Alternatively, you can %(open)scontact us%(close)s for help.', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
     {%- endautoescape -%}
 
 {%- endblock -%}

--- a/app/templates/start-code-for-wales.html
+++ b/app/templates/start-code-for-wales.html
@@ -1,13 +1,13 @@
 {%- extends 'base-ni.html' -%}
-
+{%- set census_home_link = domain_url_en -%}
 {%- block main -%}
 
     <h1 class="u-mt-l">This access code is not part of the census for Northern Ireland</h1>
 
     <p>You have entered an access code for the census in Wales.</p>
 
-    <p>The Office for National Statistics (ONS) runs the census in England and Wales. Visit the <a href="https://www.census.gov.uk/">Office for National Statistics census website</a> to find out how to take part in the census for England and Wales.</p>
+    <p>The Office for National Statistics (ONS) runs the census in England and Wales. Visit the <a href="{{ census_home_link }}">Office for National Statistics census website</a> to find out how to take part in the census for England and Wales.</p>
 
-    <p>Alternatively, you can <a href="/ni/contact-us/">contact us for help</a>.</p>
+    <p>Alternatively, you can <a href="{{ contact_us_link }}">contact us for help</a>.</p>
 
 {%- endblock -%}

--- a/app/templates/start-code-for-wales.html
+++ b/app/templates/start-code-for-wales.html
@@ -8,6 +8,6 @@
 
     <p>The Office for National Statistics (ONS) runs the census in England and Wales. Visit the <a href="{{ census_home_link }}">Office for National Statistics census website</a> to find out how to take part in the census for England and Wales.</p>
 
-    <p>Alternatively, you can <a href="{{ contact_us_link }}">contact us for help</a>.</p>
+    <p>Alternatively, you can <a href="{{ contact_us_link }}">contact us</a> for help.</p>
 
 {%- endblock -%}


### PR DESCRIPTION
Fixed home links going to the external census websites

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Bug fix to resolve the website homepage links in the 'wrong site' pages go to the external sites only.

# What has changed
Update to use 'local' links instead of absolute external ones
Added use of new central contact us links to changed pages

# How to test?
Trigger 'wrong site' pages (NI uAC on /en etc), and confirm homepage link stays on the same site instance

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1403