### PR TITLE
Cr 1210 nisra ce manager restrictions

### DIFF
--- a/app/common_handlers.py
+++ b/app/common_handlers.py
@@ -727,13 +727,21 @@ class CommonCEMangerQuestion(CommonCommon):
 
         elif resident_or_manager == 'manager':
             if sub_user_journey == 'paper-form':
-                raise HTTPFound(
-                    request.app.router['RequestFormManager:get'].url_for(
-                        request_type=sub_user_journey, display_region=display_region))
+                if display_region == 'ni':
+                    raise HTTPFound(
+                        request.app.router['RequestFormNIManager:get'].url_for())
+                else:
+                    raise HTTPFound(
+                        request.app.router['RequestFormManager:get'].url_for(
+                            request_type=sub_user_journey, display_region=display_region))
             else:
-                raise HTTPFound(
-                    request.app.router['RequestCodeSelectMethod:get'].url_for(
-                        request_type=sub_user_journey, display_region=display_region))
+                if display_region == 'ni':
+                    raise HTTPFound(
+                        request.app.router['RequestCodeNIManager:get'].url_for())
+                else:
+                    raise HTTPFound(
+                        request.app.router['RequestCodeSelectMethod:get'].url_for(
+                            request_type=sub_user_journey, display_region=display_region))
 
         else:
             # catch all just in case, should never get here

--- a/app/requests_handlers.py
+++ b/app/requests_handlers.py
@@ -943,3 +943,43 @@ class RequestLargePrintSentPost(RequestCommon):
                 'address_level': attributes['address_level'],
                 'roomNumber': room_number
             }
+
+
+@requests_routes.view(r'/ni/requests/access-code/ce-manager/')
+class RequestCodeNIManager(RequestCommon):
+    @aiohttp_jinja2.template('request-code-nisra-manager.html')
+    async def get(self, request):
+        self.setup_request(request)
+
+        display_region = 'ni'
+        page_title = 'You need to visit the Communal Establishment Portal'
+        locale = 'en'
+
+        self.log_entry(request, display_region + '/requests/access-code/ce-manager')
+
+        return {
+                'page_title': page_title,
+                'display_region': display_region,
+                'locale': locale,
+                'contact_us_link': View.get_campaign_site_link(request, display_region, 'contact-us')
+            }
+
+
+@requests_routes.view(r'/ni/requests/paper-form/ce-manager/')
+class RequestFormNIManager(RequestCommon):
+    @aiohttp_jinja2.template('request-form-nisra-manager.html')
+    async def get(self, request):
+        self.setup_request(request)
+
+        display_region = 'ni'
+        page_title = 'You need to visit the Communal Establishment Portal'
+        locale = 'en'
+
+        self.log_entry(request, display_region + '/requests/paper-form/ce-manager')
+
+        return {
+                'page_title': page_title,
+                'display_region': display_region,
+                'locale': locale,
+                'contact_us_link': View.get_campaign_site_link(request, display_region, 'contact-us')
+            }

--- a/app/templates/request-code-nisra-manager.html
+++ b/app/templates/request-code-nisra-manager.html
@@ -1,0 +1,10 @@
+{% extends 'base-ni.html' %}
+
+{% block main %}
+    <h1>You need to visit the Communal Establishment Portal</h1>
+
+    <p>Visit the <a href="https://nisra.gov.uk/census-ce/">Communal Establishment Portal website</a> to request a manager access code.</p>
+
+    <p>Alternatively you can <a href="{{ contact_us_link }}">contact us</a> for help.</p>
+
+{% endblock %}

--- a/app/templates/request-code-nisra-manager.html
+++ b/app/templates/request-code-nisra-manager.html
@@ -5,6 +5,6 @@
 
     <p>Visit the <a href="https://nisra.gov.uk/census-ce/">Communal Establishment Portal website</a> to request a manager access code.</p>
 
-    <p>Alternatively you can <a href="{{ contact_us_link }}">contact us</a> for help.</p>
+    <p>Alternatively, you can <a href="{{ contact_us_link }}">contact us</a> for help.</p>
 
 {% endblock %}

--- a/app/templates/request-form-nisra-manager.html
+++ b/app/templates/request-form-nisra-manager.html
@@ -3,8 +3,8 @@
 {% block main %}
     <h1>You need to visit the Communal Establishment Portal</h1>
 
-    <p>Visit the <a href="https://nisra.gov.uk/census-ce/">Communal Establishment Portal website</a> to request a manager paper questionnaire.</p>
+    <p>Visit the <a href="https://nisra.gov.uk/census-ce/">Communal Establishment Portal website</a> to request a communal establishment paper questionnaire for managers.</p>
 
-    <p>Alternatively you can <a href="{{ contact_us_link }}">contact us</a> for help.</p>
+    <p>Alternatively, you can <a href="{{ contact_us_link }}">contact us</a> for help.</p>
 
 {% endblock %}

--- a/app/templates/request-form-nisra-manager.html
+++ b/app/templates/request-form-nisra-manager.html
@@ -1,0 +1,10 @@
+{% extends 'base-ni.html' %}
+
+{% block main %}
+    <h1>You need to visit the Communal Establishment Portal</h1>
+
+    <p>Visit the <a href="https://nisra.gov.uk/census-ce/">Communal Establishment Portal website</a> to request a manager paper questionnaire.</p>
+
+    <p>Alternatively you can <a href="{{ contact_us_link }}">contact us</a> for help.</p>
+
+{% endblock %}

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -550,6 +550,8 @@ class RHTestCase(AioHTTPTestCase):
         # TODO: add welsh translation
         self.content_common_resident_or_manager_error_cy = 'Select an answer'
 
+        self.content_common_nisra_ce_manager_title = 'You need to visit the Communal Establishment Portal'
+
         self.content_common_save_and_exit_link_en = 'Exit'
         # TODO: add welsh translation
         self.content_common_save_and_exit_link_cy = 'Exit'

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -816,6 +816,28 @@ class TestHelpers(RHTestCase):
                 self.assertIn(self.build_translation_link('select-method', display_region), contents)
             self.check_text_select_method(display_region, contents, user_type)
 
+    async def check_post_resident_or_manager_code_manager_ni(self, url, data):
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            response = await self.client.request('POST', url, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('resident-or-manager', 'ni', 'POST'))
+            self.assertLogEvent(cm, self.build_url_log_entry('ce-manager', 'ni', 'GET'))
+
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.get_logo('ni'), contents)
+            self.assertIn(self.content_common_nisra_ce_manager_title, contents)
+
+    async def check_post_resident_or_manager_form_manager_ni(self, url, data):
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            response = await self.client.request('POST', url, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('resident-or-manager', 'ni', 'POST'))
+            self.assertLogEvent(cm, self.build_url_log_entry('ce-manager', 'ni', 'GET'))
+
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.get_logo('ni'), contents)
+            self.assertIn(self.content_common_nisra_ce_manager_title, contents)
+
     async def check_post_resident_or_manager_form_resident(self, url, display_region):
         with self.assertLogs('respondent-home', 'INFO') as cm:
             response = await self.client.request('POST', url, data=self.common_resident_or_manager_input_resident)

--- a/tests/unit/test_requests_handlers_access_code.py
+++ b/tests/unit/test_requests_handlers_access_code.py
@@ -150,21 +150,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
             self.post_request_access_code_confirm_mobile_cy, 'cy', 'CE', 'W', 'false')
 
     @unittest_run_loop
-    async def test_request_access_code_sms_happy_path_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_sms(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni')
-        await self.check_post_confirm_mobile(
-            self.post_request_access_code_confirm_mobile_ni, 'ni', 'CE', 'N', 'false')
-
-    @unittest_run_loop
     async def test_request_access_code_sms_happy_path_select_resident_ce_m_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
@@ -876,19 +861,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
             self.post_request_access_code_select_method_cy, 'cy', self.common_form_data_empty, 'manager')
 
     @unittest_run_loop
-    async def test_post_request_access_code_select_method_no_selection_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
-                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_invalid_or_no_selection(
-            self.post_request_access_code_select_method_ni, 'ni', self.common_form_data_empty, 'manager')
-
-    @unittest_run_loop
     async def test_post_request_access_code_select_method_no_selection_select_resident_ce_m_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
@@ -1111,20 +1083,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
             self.request_code_select_method_data_invalid, 'manager')
 
     @unittest_run_loop
-    async def test_post_request_access_code_select_method_input_invalid_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
-                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_invalid_or_no_selection(
-            self.post_request_access_code_select_method_ni, 'ni',
-            self.request_code_select_method_data_invalid, 'manager')
-
-    @unittest_run_loop
     async def test_post_request_access_code_select_method_input_invalid_select_resident_ce_m_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
@@ -1333,18 +1291,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
         await self.check_post_enter_mobile_input_invalid(self.post_request_access_code_enter_mobile_cy, 'cy')
 
     @unittest_run_loop
-    async def test_post_request_access_code_enter_mobile_invalid_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_enter_mobile_input_invalid(self.post_request_access_code_enter_mobile_cy, 'cy')
-
-    @unittest_run_loop
     async def test_post_request_access_code_enter_mobile_invalid_ce_r_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
@@ -1509,20 +1455,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
         await self.check_post_select_method_input_sms(self.post_request_access_code_select_method_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy')
         await self.check_post_confirm_mobile_input_no(self.post_request_access_code_confirm_mobile_cy, 'cy')
-
-    @unittest_run_loop
-    async def test_request_access_code_confirm_mobile_no_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_sms(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni')
-        await self.check_post_confirm_mobile_input_no(self.post_request_access_code_confirm_mobile_ni, 'ni')
 
     @unittest_run_loop
     async def test_request_access_code_confirm_mobile_no_ce_r_ew_e(self):
@@ -1708,21 +1640,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy')
         await self.check_post_confirm_mobile_input_invalid_or_no_selection(
             self.post_request_access_code_confirm_mobile_cy, 'cy', self.request_code_mobile_confirmation_data_empty)
-
-    @unittest_run_loop
-    async def test_request_access_code_confirm_mobile_empty_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_sms(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni')
-        await self.check_post_confirm_mobile_input_invalid_or_no_selection(
-            self.post_request_access_code_confirm_mobile_ni, 'ni', self.request_code_mobile_confirmation_data_empty)
 
     @unittest_run_loop
     async def test_request_access_code_confirm_mobile_empty_ce_r_ew_e(self):
@@ -1914,21 +1831,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
             self.post_request_access_code_confirm_mobile_cy, 'cy', self.request_code_mobile_confirmation_data_invalid)
 
     @unittest_run_loop
-    async def test_request_access_code_confirm_mobile_invalid_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_sms(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni')
-        await self.check_post_confirm_mobile_input_invalid_or_no_selection(
-            self.post_request_access_code_confirm_mobile_ni, 'ni', self.request_code_mobile_confirmation_data_invalid)
-
-    @unittest_run_loop
     async def test_request_access_code_confirm_mobile_invalid_ce_r_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
@@ -2116,21 +2018,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy')
         await self.check_post_confirm_mobile_error_from_get_fulfilment(
             self.post_request_access_code_confirm_mobile_cy, 'cy', 'CE', 'W', 'false')
-
-    @unittest_run_loop
-    async def test_request_access_code_confirm_mobile_get_fulfilment_error_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_sms(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni')
-        await self.check_post_confirm_mobile_error_from_get_fulfilment(
-            self.post_request_access_code_confirm_mobile_ni, 'ni', 'CE', 'N', 'false')
 
     @unittest_run_loop
     async def test_request_access_code_confirm_mobile_get_fulfilment_error_select_resident_ce_m_ew_e(self):
@@ -2382,21 +2269,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
             self.post_request_access_code_confirm_mobile_cy, 'cy')
 
     @unittest_run_loop
-    async def test_request_access_code_confirm_mobile_request_fulfilment_error_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_sms(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni')
-        await self.check_post_confirm_mobile_error_from_request_fulfilment(
-            self.post_request_access_code_confirm_mobile_ni, 'ni')
-
-    @unittest_run_loop
     async def test_request_access_code_confirm_mobile_request_fulfilment_error_select_resident_ce_m_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
@@ -2646,21 +2518,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
             self.post_request_access_code_confirm_mobile_cy, 'cy')
 
     @unittest_run_loop
-    async def test_request_access_code_confirm_mobile_request_fulfilment_error_429_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_sms(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni')
-        await self.check_post_confirm_mobile_error_429_from_request_fulfilment(
-            self.post_request_access_code_confirm_mobile_ni, 'ni')
-
-    @unittest_run_loop
     async def test_request_access_code_confirm_mobile_request_fulfilment_error_429_select_resident_ce_m_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
@@ -2899,20 +2756,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
                                                       self.common_form_data_empty, False, False)
 
     @unittest_run_loop
-    async def test_request_access_code_post_enter_name_empty_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
-                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_post(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
-                                                      self.common_form_data_empty, False, False)
-
-    @unittest_run_loop
     async def test_request_access_code_post_enter_name_empty_select_resident_ce_m_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
@@ -3143,20 +2986,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
                                                       self.request_common_enter_name_form_data_no_first, False, True)
 
     @unittest_run_loop
-    async def test_request_access_code_post_enter_name_no_first_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
-                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_post(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
-                                                      self.request_common_enter_name_form_data_no_first, False, True)
-
-    @unittest_run_loop
     async def test_request_access_code_post_enter_name_no_first_select_resident_ce_m_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
@@ -3384,20 +3213,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
             self.common_resident_or_manager_input_manager, 'manager')
         await self.check_post_select_method_input_post(self.post_request_access_code_select_method_cy, 'cy')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
-                                                      self.request_common_enter_name_form_data_no_last, True, False)
-
-    @unittest_run_loop
-    async def test_request_access_code_post_enter_name_no_last_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
-                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_post(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
                                                       self.request_common_enter_name_form_data_no_last, True, False)
 
     @unittest_run_loop
@@ -3644,21 +3459,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'manager', 'CE')
         await self.check_post_confirm_name_address_input_invalid_or_no_selection(
             self.post_request_access_code_confirm_name_address_cy, 'cy', self.common_form_data_empty, 'manager', 'CE')
-
-    @unittest_run_loop
-    async def test_request_access_code_post_confirm_name_address_empty_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
-                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_post(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'manager', 'CE')
-        await self.check_post_confirm_name_address_input_invalid_or_no_selection(
-            self.post_request_access_code_confirm_name_address_ni, 'ni', self.common_form_data_empty, 'manager', 'CE')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_name_address_empty_select_resident_ce_m_ew_e(self):
@@ -3929,22 +3729,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
             self.request_common_confirm_name_address_data_invalid, 'manager', 'CE')
 
     @unittest_run_loop
-    async def test_request_access_code_post_confirm_name_address_input_invalid_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
-                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_post(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'manager', 'CE')
-        await self.check_post_confirm_name_address_input_invalid_or_no_selection(
-            self.post_request_access_code_confirm_name_address_ni, 'ni',
-            self.request_common_confirm_name_address_data_invalid, 'manager', 'CE')
-
-    @unittest_run_loop
     async def test_request_access_code_post_confirm_name_address_input_invalid_select_resident_ce_m_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
@@ -4202,21 +3986,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
             self.post_request_access_code_confirm_name_address_cy, 'cy', 'manager')
 
     @unittest_run_loop
-    async def test_request_access_code_post_confirm_name_address_option_no_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
-                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_post(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'manager', 'CE')
-        await self.check_post_confirm_name_address_input_no(
-            self.post_request_access_code_confirm_name_address_ni, 'ni', 'manager')
-
-    @unittest_run_loop
     async def test_request_access_code_post_confirm_name_address_option_no_select_resident_ce_m_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
@@ -4464,21 +4233,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'manager', 'CE')
         await self.check_post_confirm_name_address_input_yes(
             self.post_request_access_code_confirm_name_address_cy, 'cy', 'CE', 'UAC', 'W', 'false')
-
-    @unittest_run_loop
-    async def test_request_access_code_post_code_sent_post_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
-                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_post(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'manager', 'CE')
-        await self.check_post_confirm_name_address_input_yes(
-            self.post_request_access_code_confirm_name_address_ni, 'ni', 'CE', 'UAC', 'N', 'false')
 
     @unittest_run_loop
     async def test_request_access_code_post_code_sent_post_select_resident_ce_m_ew_e(self):
@@ -4730,21 +4484,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
             self.post_request_access_code_confirm_name_address_cy, 'cy', 'CE', 'W', 'UAC', 'false')
 
     @unittest_run_loop
-    async def test_request_access_code_post_confirm_name_address_get_fulfilment_error_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
-                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_post(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'manager', 'CE')
-        await self.check_post_confirm_name_address_error_from_get_fulfilment(
-            self.post_request_access_code_confirm_name_address_ni, 'ni', 'CE', 'N', 'UAC', 'false')
-
-    @unittest_run_loop
     async def test_request_access_code_post_confirm_name_address_get_fulfilment_error_select_resident_ce_m_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
@@ -4994,21 +4733,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'manager', 'CE')
         await self.check_post_confirm_name_address_error_from_request_fulfilment(
             self.post_request_access_code_confirm_name_address_cy, 'cy')
-
-    @unittest_run_loop
-    async def test_request_access_code_post_confirm_name_address_request_fulfilment_error_select_manager_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
-                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_post(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'manager', 'CE')
-        await self.check_post_confirm_name_address_error_from_request_fulfilment(
-            self.post_request_access_code_confirm_name_address_ni, 'ni')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_name_address_request_fulfilment_error_select_resident_ce_m_ew_e(
@@ -5263,22 +4987,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'manager', 'CE')
         await self.check_post_confirm_name_address_error_429_from_request_fulfilment_uac(
             self.post_request_access_code_confirm_name_address_cy, 'cy')
-
-    @unittest_run_loop
-    async def test_request_access_code_post_confirm_name_address_request_fulfilment_error_429_select_manager_ce_m_ni(
-            self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
-                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_post(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'manager', 'CE')
-        await self.check_post_confirm_name_address_error_429_from_request_fulfilment_uac(
-            self.post_request_access_code_confirm_name_address_ni, 'ni')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_name_address_request_fulfilment_error_429_select_resident_ce_m_ew_e(
@@ -5585,26 +5293,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
             check_room_number=True)
 
     @unittest_run_loop
-    async def test_request_access_code_post_code_sent_post_select_manager_add_room_early_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.add_room_number(self.get_request_access_code_enter_room_number_ni,
-                                   self.post_request_access_code_enter_room_number_ni,
-                                   'ni', 'manager', 'ConfirmAddress')
-        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
-                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_post(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'manager', 'CE',
-                                         check_room_number=True)
-        await self.check_post_confirm_name_address_input_yes(
-            self.post_request_access_code_confirm_name_address_ni, 'ni', 'CE', 'UAC', 'N', 'false',
-            check_room_number=True)
-
-    @unittest_run_loop
     async def test_request_access_code_post_code_sent_post_select_resident_add_room_early_ce_m_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
@@ -5807,25 +5495,6 @@ class TestRequestsHandlersAccessCode(TestHelpers):
                                    'cy', 'manager', 'ConfirmNameAddress')
         await self.check_post_confirm_name_address_input_yes(
             self.post_request_access_code_confirm_name_address_cy, 'cy', 'CE', 'UAC', 'W', 'false',
-            check_room_number=True)
-
-    @unittest_run_loop
-    async def test_request_access_code_post_code_sent_post_select_manager_add_room_late_ce_m_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
-                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager(
-            self.post_request_access_code_resident_or_manager_ni, 'ni',
-            self.common_resident_or_manager_input_manager, 'manager')
-        await self.check_post_select_method_input_post(self.post_request_access_code_select_method_ni, 'ni')
-        await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'manager', 'CE')
-        await self.add_room_number(self.get_request_access_code_enter_room_number_ni,
-                                   self.post_request_access_code_enter_room_number_ni,
-                                   'ni', 'manager', 'ConfirmNameAddress')
-        await self.check_post_confirm_name_address_input_yes(
-            self.post_request_access_code_confirm_name_address_ni, 'ni', 'CE', 'UAC', 'N', 'false',
             check_room_number=True)
 
     @unittest_run_loop
@@ -6143,3 +5812,13 @@ class TestRequestsHandlersAccessCode(TestHelpers):
             self.post_request_access_code_select_address_ni, 'ni', 'HH', self.ai_uprn_result_wales)
         await self.check_post_confirm_address_address_in_wales(
             self.post_request_access_code_confirm_address_ni, 'ni')
+
+    @unittest_run_loop
+    async def test_request_access_code_happy_path_nisra_manager(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
+        await self.check_post_confirm_address_input_yes_ce(
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_m_n)
+        await self.check_post_resident_or_manager_code_manager_ni(
+            self.post_request_access_code_resident_or_manager_ni, self.common_resident_or_manager_input_manager)

--- a/tests/unit/test_requests_handlers_form.py
+++ b/tests/unit/test_requests_handlers_form.py
@@ -2535,8 +2535,8 @@ class TestRequestsHandlersPaperForm(TestHelpers):
         await self.check_post_select_address(self.post_request_paper_form_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_ce(
             self.post_request_paper_form_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager_form_manager(
-            self.post_request_paper_form_resident_or_manager_ni, 'ni')
+        await self.check_post_resident_or_manager_form_manager_ni(
+            self.post_request_paper_form_resident_or_manager_ni, self.common_resident_or_manager_input_manager)
 
     @unittest_run_loop
     async def test_request_paper_form_select_manager_uac_sms_ew_e(self):
@@ -2593,24 +2593,6 @@ class TestRequestsHandlersPaperForm(TestHelpers):
             override_sub_user_journey='access-code')
 
     @unittest_run_loop
-    async def test_request_paper_form_select_manager_uac_sms_ni(self):
-        await self.check_get_enter_address(self.get_request_paper_form_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_paper_form_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_paper_form_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(
-            self.post_request_paper_form_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager_form_manager(
-            self.post_request_paper_form_resident_or_manager_ni, 'ni')
-        await self.check_get_select_method_form_manager(self.get_request_access_code_select_method_ni, 'ni')
-        await self.check_post_select_method_input_sms(self.post_request_access_code_select_method_ni, 'ni',
-                                                      override_sub_user_journey='access-code')
-        await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni',
-                                           override_sub_user_journey='access-code')
-        await self.check_post_confirm_mobile(
-            self.post_request_access_code_confirm_mobile_ni, 'ni', 'CE', 'N', 'false',
-            override_sub_user_journey='access-code')
-
-    @unittest_run_loop
     async def test_request_paper_form_select_manager_uac_post_ew_e(self):
         await self.check_get_enter_address(self.get_request_paper_form_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_paper_form_enter_address_en, 'en')
@@ -2662,24 +2644,6 @@ class TestRequestsHandlersPaperForm(TestHelpers):
                                          'manager', 'CE', override_sub_user_journey='access-code')
         await self.check_post_confirm_name_address_input_yes(
             self.post_request_access_code_confirm_name_address_cy, 'cy', 'CE', 'UAC', 'W', 'false',
-            override_sub_user_journey='access-code')
-
-    @unittest_run_loop
-    async def test_request_paper_form_select_manager_uac_post_ni(self):
-        await self.check_get_enter_address(self.get_request_paper_form_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_paper_form_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_paper_form_select_address_ni, 'ni', 'CE')
-        await self.check_post_confirm_address_input_yes_ce(
-            self.post_request_paper_form_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_m_n)
-        await self.check_post_resident_or_manager_form_manager(
-            self.post_request_paper_form_resident_or_manager_ni, 'ni')
-        await self.check_get_select_method_form_manager(self.get_request_access_code_select_method_ni, 'ni')
-        await self.check_post_select_method_input_post(self.post_request_access_code_select_method_ni, 'ni',
-                                                       override_sub_user_journey='access-code')
-        await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni',
-                                         'manager', 'CE', override_sub_user_journey='access-code')
-        await self.check_post_confirm_name_address_input_yes(
-            self.post_request_access_code_confirm_name_address_ni, 'ni', 'CE', 'UAC', 'N', 'false',
             override_sub_user_journey='access-code')
 
     @unittest_run_loop


### PR DESCRIPTION
# Motivation and Context
Block all CE Manager fulfilment requests from a 'N' region address

# What has changed
If a user uses the /ni version, selects a NI CE address, and selects that they are a manager, they are shown a page telling them to use the NI Communal Portal.
This only effects 'declared' CE Managers on the /ni version.
It applies to both questionnaire and UAC fulfilments
N Region addresses selected on the /en or /cy sites will be shown the 'wrong site' page as normal

Change implements the above, and removes redundant ce-m-ni unit tests

No Cucumber changes required

# How to test?
Start a fulfilment request for an access code or a paper form
Use the ni site version
Select a NI CE address
Select Manager
Get new error page (one for UAC, one for questionnaire)

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1210

# Screenshots (if appropriate):