### PR TITLE
Cr 1425 updates to enter address

### DIFF
--- a/app/common_handlers.py
+++ b/app/common_handlers.py
@@ -286,7 +286,12 @@ class CommonEnterAddress(CommonCommon):
 
         except (InvalidDataError, InvalidDataErrorWelsh) as exc:
             logger.info('invalid postcode', client_ip=request['client_ip'])
-            flash_message = FlashMessage.generate_flash_message(str(exc), 'ERROR', 'POSTCODE_ENTER_ERROR', 'postcode')
+            if exc.message_type == 'empty':
+                flash_message = FlashMessage.generate_flash_message(str(exc), 'ERROR', 'POSTCODE_ENTER_ERROR',
+                                                                    'error_postcode_empty')
+            else:
+                flash_message = FlashMessage.generate_flash_message(str(exc), 'ERROR', 'POSTCODE_ENTER_ERROR',
+                                                                    'error_postcode_invalid')
             flash(request, flash_message)
             raise HTTPFound(
                 request.app.router['CommonEnterAddress:get'].url_for(

--- a/app/templates/common-enter-address.html
+++ b/app/templates/common-enter-address.html
@@ -3,8 +3,10 @@
 {%- set messages_dict=dict(get_flashed_messages()|groupby('level')) -%}
 {%- set field_messages_dict=dict(messages_dict['ERROR']|groupby('field')) -%}
 
-{%- if 'postcode' in field_messages_dict -%}
-    {%- set error_postcode = { 'text': _('Enter a valid UK postcode') } -%}
+{%- if 'error_postcode_empty' in field_messages_dict -%}
+    {%- set error_postcode = { 'id':'error-postcode', 'text': _('Enter a postcode') } -%}
+{%- elif 'error_postcode_invalid' in field_messages_dict -%}
+    {%- set error_postcode = { 'id':'error-postcode', 'text': _('Enter a valid UK postcode') } -%}
 {%- endif -%}
 
 {%- from 'components/question/_macro.njk' import onsQuestion -%}
@@ -25,14 +27,14 @@
     {%- set question_description = _('<p>This will enable us to associate your code to your address</p>') -%}
 {%- elif sub_user_journey == 'change-address' -%}
     {%- set question_description = '' -%}
-{%- elif individual == True -%}
+{%- elif (individual == True) -%}
     {%- set question_description = _('<p>To request an individual access code, we need your address</p>') -%}
 {%- elif sub_user_journey == 'access-code' -%}
-    {%- set question_description = _('<p>To request an access code, we need your address. A new access code will start a new census.</p>') -%}
+    {%- set question_description = _('<p>To request an access code, we need your address</p>') -%}
 {%- elif sub_user_journey == 'paper-form' -%}
-    {%- set question_description = _('<p>To send a paper questionnaire, we need your address</p>') -%}
+    {%- set question_description = _('<p>To send a paper census questionnaire, we need your address</p>') -%}
 {%- else -%}
-    {%- set question_description = _('<p>We need to know the address for which you are answering.</p>') -%}
+    {%- set question_description = _('<p>We need to know the address for which you are answering</p>') -%}
 {%- endif -%}
 
 {%- block main -%}
@@ -59,7 +61,7 @@
                 'id': 'postcode',
                 'type': 'postcode',
                 'autocomplete': 'postcode',
-                'classes': 'input--w-8',
+                'classes': 'input--w-6',
                 'label': {
                     'text': _('UK postcode')
                 },
@@ -70,15 +72,23 @@
 
     {%- endcall -%}
 
-    {%- set content -%}
-        {%- autoescape false -%}
-            <p>{{ _('If you live somewhere that is mobile, such as a canal boat or motorhome, %(open)scontact us to request an access code%(close)s', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
-        {%- endautoescape -%}
-    {%- endset -%}
+    {%- if sub_user_journey == 'paper-form' -%}
+        {%- set content -%}
+            {%- autoescape false -%}
+                <p>{{ _('If you live somewhere that is mobile, such as a canal boat or motorhome, %(open)scontact us to request aa paper census questionnaire%(close)s.', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
+            {%- endautoescape -%}
+        {%- endset -%}
+    {%- else -%}
+        {%- set content -%}
+            {%- autoescape false -%}
+                <p>{{ _('If you live somewhere that is mobile, such as a canal boat or motorhome, %(open)scontact us to request an access code%(close)s.', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
+            {%- endautoescape -%}
+        {%- endset -%}
+    {%- endif -%}
 
     {%- call onsCollapsible({
             'id': 'collapsible',
-            'title': _("I don't live at a fixed address"),
+            'title': _("I don’t live at a fixed address"),
             'titleTag': 'h2',
             'classes': 'u-mt-m',
             'button': {

--- a/app/templates/common-enter-address.html
+++ b/app/templates/common-enter-address.html
@@ -75,7 +75,7 @@
     {%- if sub_user_journey == 'paper-form' -%}
         {%- set content -%}
             {%- autoescape false -%}
-                <p>{{ _('If you live somewhere that is mobile, such as a canal boat or motorhome, %(open)scontact us to request aa paper census questionnaire%(close)s.', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
+                <p>{{ _('If you live somewhere that is mobile, such as a canal boat or motorhome, %(open)scontact us to request a paper census questionnaire%(close)s.', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
             {%- endautoescape -%}
         {%- endset -%}
     {%- else -%}

--- a/app/utils.py
+++ b/app/utils.py
@@ -162,18 +162,21 @@ class ProcessPostcode:
 
         if not postcode.isalnum():
             if locale == 'cy':
+                # TODO: Add Welsh Translation
                 raise InvalidDataErrorWelsh("Enter a valid UK postcode")
             else:
                 raise InvalidDataError('Enter a valid UK postcode')
 
         if len(postcode) < 5:
             if locale == 'cy':
+                # TODO: Add Welsh Translation
                 raise InvalidDataErrorWelsh("Enter a valid UK postcode")
             else:
                 raise InvalidDataError('Enter a valid UK postcode')
 
         if len(postcode) > 7:
             if locale == 'cy':
+                # TODO: Add Welsh Translation
                 raise InvalidDataErrorWelsh("Enter a valid UK postcode")
             else:
                 raise InvalidDataError('Enter a valid UK postcode')

--- a/app/utils.py
+++ b/app/utils.py
@@ -155,33 +155,35 @@ class ProcessPostcode:
 
         if len(postcode) == 0:
             if locale == 'cy':
-                raise InvalidDataErrorWelsh("Nid ydych wedi nodi cod post")
+                # TODO: Add Welsh Translation
+                raise InvalidDataErrorWelsh("Enter a postcode", 'empty')
             else:
-                raise InvalidDataError('You have not entered a postcode')
+                raise InvalidDataError('Enter a postcode', 'empty')
 
         if not postcode.isalnum():
             if locale == 'cy':
-                raise InvalidDataErrorWelsh("Ni ddylai'r cod post gynnwys symbolau")
+                raise InvalidDataErrorWelsh("Enter a valid UK postcode")
             else:
-                raise InvalidDataError('The postcode must not contain symbols')
+                raise InvalidDataError('Enter a valid UK postcode')
 
         if len(postcode) < 5:
             if locale == 'cy':
-                raise InvalidDataErrorWelsh("Nid yw'r cod post yn cynnwys digon o nodau")
+                raise InvalidDataErrorWelsh("Enter a valid UK postcode")
             else:
-                raise InvalidDataError('The postcode does not contain enough characters')
+                raise InvalidDataError('Enter a valid UK postcode')
 
         if len(postcode) > 7:
             if locale == 'cy':
-                raise InvalidDataErrorWelsh("Mae'r cod post yn cynnwys gormod o nodau")
+                raise InvalidDataErrorWelsh("Enter a valid UK postcode")
             else:
-                raise InvalidDataError('The postcode contains too many characters')
+                raise InvalidDataError('Enter a valid UK postcode')
 
         if not ProcessPostcode.postcode_validation_pattern.fullmatch(postcode):
             if locale == 'cy':
-                raise InvalidDataErrorWelsh("Nid yw'r cod post yn god post dilys yn y Deyrnas Unedig")
+                # TODO: Add Welsh Translation
+                raise InvalidDataErrorWelsh("Enter a valid UK postcode")
             else:
-                raise InvalidDataError('The postcode is not a valid UK postcode')
+                raise InvalidDataError('Enter a valid UK postcode')
 
         postcode_formatted = postcode[:-3] + ' ' + postcode[-3:]
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -422,11 +422,13 @@ class RHTestCase(AioHTTPTestCase):
         # TODO: add welsh translation
         self.content_common_address_in_scotland_cy = 'This address is not part of the census for England and Wales'
 
-        self.content_common_enter_address_error_en = 'The postcode is not a valid UK postcode'
-        self.content_common_enter_address_error_cy = "Nid yw\\\'r cod post yn god post dilys yn y Deyrnas Unedig"
+        self.content_common_enter_address_error_en = 'Enter a valid UK postcode'
+        # TODO Add Welsh Translation
+        self.content_common_enter_address_error_cy = "Enter a valid UK postcode"
 
-        self.content_common_enter_address_error_empty_en = 'You have not entered a postcode'
-        self.content_common_enter_address_error_empty_cy = "Nid ydych wedi nodi cod post"
+        self.content_common_enter_address_error_empty_en = 'Enter a postcode'
+        # TODO Add Welsh Translation
+        self.content_common_enter_address_error_empty_cy = "Enter a postcode"
 
         self.content_common_select_address_title_en = 'Select your address'
         self.content_common_select_address_error_en = 'Select an address'
@@ -1059,13 +1061,13 @@ class RHTestCase(AioHTTPTestCase):
 
         self.content_request_enter_address_title_en = 'What is your postcode?'
         self.content_request_access_code_enter_address_secondary_en = \
-            'To request an access code, we need your address. A new access code will start a new census.'
+            'To request an access code, we need your address'
         self.content_request_individual_code_enter_address_secondary_en = \
             'To request an individual access code, we need your address'
         self.content_request_enter_address_title_cy = 'Beth yw eich cod post?'
         # TODO: add welsh translation
         self.content_request_access_code_enter_address_secondary_cy = \
-            'To request an access code, we need your address. A new access code will start a new census.'
+            'To request an access code, we need your address'
         self.content_request_individual_code_enter_address_secondary_cy = \
             'To request an individual access code, we need your address'
 
@@ -1964,10 +1966,10 @@ class RHTestCase(AioHTTPTestCase):
         # Content
 
         self.content_request_form_enter_address_secondary_en = \
-            'To send a paper questionnaire, we need your address'
+            'To send a paper census questionnaire, we need your address'
         # TODO: add welsh translation
         self.content_request_form_enter_address_secondary_cy = \
-            'To send a paper questionnaire, we need your address'
+            'To send a paper census questionnaire, we need your address'
 
         self.content_request_form_sent_post_title_en = \
             'A paper questionnaire will be sent to Bob Bobbington at 1 Gate Reach, Exeter'
@@ -2144,14 +2146,15 @@ class RHTestCase(AioHTTPTestCase):
         self.content_support_centre_enter_postcode_title_en = 'Find a support centre'
         self.content_support_centre_enter_postcode_secondary_en = \
             'To find your nearest support centre, we need your postcode.'
-        self.content_support_centre_enter_postcode_error_empty_en = 'You have not entered a postcode'
-        self.content_support_centre_enter_postcode_error_invalid_en = 'The postcode is not a valid UK postcode'
+        self.content_support_centre_enter_postcode_error_empty_en = 'Enter a postcode'
+        self.content_support_centre_enter_postcode_error_invalid_en = 'Enter a valid UK postcode'
         self.content_support_centre_enter_postcode_title_cy = "Chwilio am ganolfan gymorth"
         self.content_support_centre_enter_postcode_secondary_cy = \
             "Er mwyn chwilio am eich canolfan gymorth agosaf, bydd angen i ni gael eich cod post."
-        self.content_support_centre_enter_postcode_error_empty_cy = 'Nid ydych wedi nodi cod post'
-        self.content_support_centre_enter_postcode_error_invalid_cy = \
-            "Nid yw\\\'r cod post yn god post dilys yn y Deyrnas Unedig"
+        # TODO Add Welsh Translation
+        self.content_support_centre_enter_postcode_error_empty_cy = 'Enter a postcode'
+        # TODO Add Welsh Translation
+        self.content_support_centre_enter_postcode_error_invalid_cy = "Enter a valid UK postcode"
 
         self.content_support_centre_list_of_centres_result_one_google_url = \
             'https://www.google.com/maps/search/?api=1&query=53.380582,-1.466986'

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -22,7 +22,7 @@ class TestUtils(RHTestCase):
             ProcessPostcode.validate_postcode(postcode, locale)
         # Then an InvalidDataError is raised
         self.assertEqual(
-            'You have not entered a postcode',
+            'Enter a postcode',
             str(cm.exception)
         )
         # With the correct message
@@ -36,7 +36,7 @@ class TestUtils(RHTestCase):
             ProcessPostcode.validate_postcode(postcode, locale)
         # Then an InvalidDataError is raised
         self.assertEqual(
-            'The postcode must not contain symbols',
+            'Enter a valid UK postcode',
             str(cm.exception)
         )
         # With the correct message
@@ -50,7 +50,7 @@ class TestUtils(RHTestCase):
             ProcessPostcode.validate_postcode(postcode, locale)
         # Then an InvalidDataError is raised
         self.assertEqual(
-            'The postcode does not contain enough characters',
+            'Enter a valid UK postcode',
             str(cm.exception)
         )
         # With the correct message
@@ -64,7 +64,7 @@ class TestUtils(RHTestCase):
             ProcessPostcode.validate_postcode(postcode, locale)
         # Then an InvalidDataError is raised
         self.assertEqual(
-            'The postcode contains too many characters',
+            'Enter a valid UK postcode',
             str(cm.exception)
         )
         # With the correct message
@@ -78,7 +78,7 @@ class TestUtils(RHTestCase):
             ProcessPostcode.validate_postcode(postcode, locale)
         # Then an InvalidDataError is raised
         self.assertEqual(
-            'The postcode is not a valid UK postcode',
+            'Enter a valid UK postcode',
             str(cm.exception)
         )
         # With the correct message
@@ -99,8 +99,9 @@ class TestUtils(RHTestCase):
         with self.assertRaises(InvalidDataErrorWelsh) as cm:
             ProcessPostcode.validate_postcode(postcode, locale)
         # Then an InvalidDataError is raised
+        # TODO Add Welsh Translation
         self.assertEqual(
-            'Nid ydych wedi nodi cod post',
+            'Enter a postcode',
             str(cm.exception)
         )
         # With the correct message
@@ -113,8 +114,9 @@ class TestUtils(RHTestCase):
         with self.assertRaises(InvalidDataErrorWelsh) as cm:
             ProcessPostcode.validate_postcode(postcode, locale)
         # Then an InvalidDataError is raised
+        # TODO Add Welsh Translation
         self.assertEqual(
-            "Ni ddylai'r cod post gynnwys symbolau",
+            'Enter a valid UK postcode',
             str(cm.exception)
         )
         # With the correct message
@@ -127,8 +129,9 @@ class TestUtils(RHTestCase):
         with self.assertRaises(InvalidDataErrorWelsh) as cm:
             ProcessPostcode.validate_postcode(postcode, locale)
         # Then an InvalidDataError is raised
+        # TODO Add Welsh Translation
         self.assertEqual(
-            "Nid yw'r cod post yn cynnwys digon o nodau",
+            'Enter a valid UK postcode',
             str(cm.exception)
         )
         # With the correct message
@@ -141,8 +144,9 @@ class TestUtils(RHTestCase):
         with self.assertRaises(InvalidDataErrorWelsh) as cm:
             ProcessPostcode.validate_postcode(postcode, locale)
         # Then an InvalidDataError is raised
+        # TODO Add Welsh Translation
         self.assertEqual(
-            "Mae'r cod post yn cynnwys gormod o nodau",
+            'Enter a valid UK postcode',
             str(cm.exception)
         )
         # With the correct message
@@ -155,8 +159,9 @@ class TestUtils(RHTestCase):
         with self.assertRaises(InvalidDataErrorWelsh) as cm:
             ProcessPostcode.validate_postcode(postcode, locale)
         # Then an InvalidDataError is raised
+        # TODO Add Welsh Translation
         self.assertEqual(
-            "Nid yw'r cod post yn god post dilys yn y Deyrnas Unedig",
+            'Enter a valid UK postcode',
             str(cm.exception)
         )
         # With the correct message


### PR DESCRIPTION
# Motivation and Context
Text and error messaging updates to 'enter-address'

# What has changed
Updates to text on page
Updates to error message text, and call in the page
Updates to text in unit tests

Requires matching Cucumber update for error message text change

# How to test?
Check '/en/requests/access-code/enter-address/', '/en/requests/paper-form/enter-address/' and language/region variants for revised text, including tripping errors for empty string and invalid postcode

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1425
https://github.com/ONSdigital/census-rh-cucumber/pull/107

# Screenshots (if appropriate):