### PR TITLE
CR-1426 Update 'address-not-found'

### DIFF
--- a/app/templates/common-contact-centre.html
+++ b/app/templates/common-contact-centre.html
@@ -1,45 +1,55 @@
-{% extends 'base-' + display_region + '.html' %}
+{%- extends 'base-' + display_region + '.html' -%}
 
-{% if display_region == 'ni' %}
-    {% set contact_us_link = domain_url_ni + '/contact-us/' %}
-{% elif display_region == 'cy' %}
-    {% set contact_us_link = domain_url_cy + '/cysylltu-a-ni/' %}
-{% else %}
-    {% set contact_us_link = domain_url_en + '/contact-us/' %}
-{% endif %}
+{%- if display_region == 'ni' -%}
+    {%- set contact_us_link = domain_url_ni + '/contact-us/' -%}
+{%- elif display_region == 'cy' -%}
+    {%- set contact_us_link = domain_url_cy + '/cysylltu-a-ni/' -%}
+{%- else -%}
+    {%- set contact_us_link = domain_url_en + '/contact-us/' -%}
+{%- endif -%}
 
-{% block main %}
+{%- block main -%}
 
-    {% if error == 'address-linking' %}
+    {%- if error == 'address-linking' -%}
 
         <h1 class="u-mt-l">{{ _('You need to call the Census customer contact centre') }}</h1>
 
         <p>{{ _('There is an issue linking your address via the website.') }}</p>
 
-    {% elif error == 'change-address' %}
+        {%- autoescape false -%}
+            <p>{{ _('You can call us free on %(telephone_number)s or %(open)schoose another way to contact us%(close)s.', telephone_number=call_centre_number, open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
+        {%- endautoescape -%}
+
+    {%- elif error == 'change-address' -%}
 
         <h1 class="u-mt-l">{{ _('You need to call the Census customer contact centre') }}</h1>
 
         <p>{{ _('There is an issue changing your address via the website.') }}</p>
 
-    {% elif error == 'address-not-found' %}
+        {%- autoescape false -%}
+            <p>{{ _('You can call us free on %(telephone_number)s or %(open)schoose another way to contact us%(close)s.', telephone_number=call_centre_number, open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
+        {%- endautoescape -%}
+
+    {%- elif error == 'address-not-found' -%}
 
         <h1 class="u-mt-l">{{ _('Register an address') }}</h1>
 
-        <p>{{ _('If you can’t find your address or part of your address has changed, it may not be registered on our system.') }}</p>
+        <p>{{ _('If you can’t find your address, it may not be registered on our system.') }}</p>
 
-        <p>{{ _('To register your address, we need you to get in touch.') }}</p>
+        {%- autoescape false -%}
+            <p>{{ _('To register your address, we need you to get in touch. You can call us free on %(telephone_number)s or %(open)schoose another way to contact us%(close)s.', telephone_number=call_centre_number, open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
+        {%- endautoescape -%}
 
-    {% elif error == 'unable-to-match-address' %}
+    {%- elif error == 'unable-to-match-address' -%}
 
         <h1 class="u-mt-l">{{ _('You need to call the Census customer contact centre') }}</h1>
 
         <p>{{ _('There is an issue processing your address via the website.') }}</p>
 
-    {% endif %}
+        {%- autoescape false -%}
+            <p>{{ _('You can call us free on %(telephone_number)s or %(open)schoose another way to contact us%(close)s.', telephone_number=call_centre_number, open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
+        {%- endautoescape -%}
 
-    {% autoescape false %}
-        <p>{{ _('You can call us free on %(telephone_number)s or %(open)schoose another way to contact us%(close)s.', telephone_number=call_centre_number, open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
-    {% endautoescape %}
+    {%- endif -%}
 
-{% endblock %}
+{%- endblock -%}

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -477,12 +477,10 @@ class RHTestCase(AioHTTPTestCase):
         self.content_common_call_contact_centre_address_not_found_title_cy = \
             'Register an address'
         self.content_common_call_contact_centre_address_not_found_text_en = \
-            'If you can\\xe2\\x80\\x99t find your address or part of your address has changed, ' \
-            'it may not be registered on our system.'
+            'If you can\\xe2\\x80\\x99t find your address, it may not be registered on our system.'
         # TODO: add welsh translation
         self.content_common_call_contact_centre_address_not_found_text_cy = \
-            'If you can\\xe2\\x80\\x99t find your address or part of your address has changed, ' \
-            'it may not be registered on our system.'
+            'If you can\\xe2\\x80\\x99t find your address, it may not be registered on our system.'
         self.content_common_call_contact_centre_address_linking_en = \
             'There is an issue linking your address via the website.'
         # TODO: add welsh translation


### PR DESCRIPTION
Text update and matching unit tests update

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Text changes to Call contact centre - Address not found (Register an address)

# What has changed
Text change and unit test update

No Cucumber update required

# How to test?
Trigger an address lookup with a valid postcode, but select 'I cannot find my address' on the address selection screen

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1426

# Screenshots (if appropriate):