### PR TITLE
CR-1436 change text in web-form-success.html

### DIFF
--- a/app/templates/web-form-success.html
+++ b/app/templates/web-form-success.html
@@ -67,6 +67,6 @@
         })
     }}
 
-    <p>{{_('We will aim to respond to your query in 2 working days')}}</p>
+    <p>{{_('We will respond to you within 2 working days')}}</p>
 
 {%- endblock -%}

--- a/app/templates/web-form-success.html
+++ b/app/templates/web-form-success.html
@@ -54,7 +54,7 @@
 
     {%- set panel_content -%}
         <h1 class="u-fs-xxl">{{ _('Thank you for contacting us') }}</h1>
-        <p>{{ _('You message has been sent') }}</p>
+        <p>{{ _('Your message has been sent') }}</p>
     {%- endset -%}
 
     {{

--- a/app/templates/web-form-success.html
+++ b/app/templates/web-form-success.html
@@ -67,6 +67,6 @@
         })
     }}
 
-    <p>{{_('We will respond to your message within 48 working hours')}}</p>
+    <p>{{_('We will aim to respond to your query in 2 working days')}}</p>
 
 {%- endblock -%}

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2337,9 +2337,9 @@ class RHTestCase(AioHTTPTestCase):
 
         self.content_web_form_success_title_en = 'Thank you for contacting us'
         self.content_web_form_success_confirmation_en = 'You message has been sent'
-        self.content_web_form_success_secondary_en = 'We will respond to your message within 48 working hours'
+        self.content_web_form_success_secondary_en = 'We will aim to respond to your query in 2 working days'
         self.content_web_form_success_title_cy = 'Thank you for contacting us'
         self.content_web_form_success_confirmation_cy = 'You message has been sent'
-        self.content_web_form_success_secondary_cy = 'We will respond to your message within 48 working hours'
+        self.content_web_form_success_secondary_cy = 'We will aim to respond to your query in 2 working days'
 
         # yapf: enable

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2336,10 +2336,10 @@ class RHTestCase(AioHTTPTestCase):
         self.content_web_form_warning_cy = 'Do not include any personal information, for example, your access code'
 
         self.content_web_form_success_title_en = 'Thank you for contacting us'
-        self.content_web_form_success_confirmation_en = 'You message has been sent'
+        self.content_web_form_success_confirmation_en = 'Your message has been sent'
         self.content_web_form_success_secondary_en = 'We will respond to you within 2 working days'
         self.content_web_form_success_title_cy = 'Thank you for contacting us'
-        self.content_web_form_success_confirmation_cy = 'You message has been sent'
+        self.content_web_form_success_confirmation_cy = 'Your message has been sent'
         self.content_web_form_success_secondary_cy = 'We will respond to you within 2 working days'
 
         # yapf: enable

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2337,9 +2337,9 @@ class RHTestCase(AioHTTPTestCase):
 
         self.content_web_form_success_title_en = 'Thank you for contacting us'
         self.content_web_form_success_confirmation_en = 'You message has been sent'
-        self.content_web_form_success_secondary_en = 'We will aim to respond to your query in 2 working days'
+        self.content_web_form_success_secondary_en = 'We will respond to you within 2 working days'
         self.content_web_form_success_title_cy = 'Thank you for contacting us'
         self.content_web_form_success_confirmation_cy = 'You message has been sent'
-        self.content_web_form_success_secondary_cy = 'We will aim to respond to your query in 2 working days'
+        self.content_web_form_success_secondary_cy = 'We will respond to you within 2 working days'
 
         # yapf: enable


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Different text is required in the web-form success page.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

Instead of "We will respond to your message within 48 working hours"

it is now "We will respond to you within 2 working days"

# How to test?
<!--- Describe in detail how you tested your changes. -->

Run this branch of RHUI locally and then look at the following pages to see that they contain the new text:

http://localhost:9092/en/web-form/success/
http://localhost:9092/cy/web-form/success/
http://localhost:9092/ni/web-form/success/