### PR TITLE
Cr 1427 Change the Text that's Displayed on the NOT FOUND - 404 error page

### DIFF
--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -13,9 +13,9 @@
     <h1>{{ _('Page not found') }}</h1>
 
     <p>{{ _('If you entered a web address, check it is correct.') }}</p>
-    <p>{{ _('If you pasted the web address, check that you copied the entire address.') }}</p>
+    <p>{{ _('If you pasted the web address, check you copied the whole address.') }}</p>
     {% autoescape false %}
-    <p>{{ _('If you still encounter problems please %(open)scontact us%(close)s. We apologise for any inconvenience this may have caused.', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
+    <p>{{ _('If the web address is correct or you selected a link or button, %(open)scontact us%(close)s for more help.', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
     {% endautoescape %}
 
 {% endblock %}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Different text is required in the 404 NOT FOUND error page.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

Instead of "If you pasted the web address, check that you copied the entire address."

it is now "If you pasted the web address, check you copied the whole address."

And instead of "If you still encounter problems please contact us. We apologise for any inconvenience this may have caused."

it is now "If the web address is correct or you selected a link or button, contact us for more help."

# How to test?
<!--- Describe in detail how you tested your changes. -->

Run this branch of RHUI locally and then look at the following page, or any other page that won't be found, to see that it contains the new text:

http://localhost:9092/en/start/hello
