### PR TITLE
CR-1478 Web Form Rate Limiting

### DIFF
--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -8,7 +8,7 @@ from aiohttp.client_exceptions import (ClientResponseError,
 from .exceptions import (ExerciseClosedError, InactiveCaseError,
                          InvalidEqPayLoad,
                          SessionTimeout,
-                         TooManyRequests)
+                         TooManyRequests, TooManyRequestsWebForm)
 from structlog import get_logger
 
 from .utils import View
@@ -48,6 +48,8 @@ def create_error_middleware(overrides):
             return await session_timeout(request, ex.user_journey, ex.sub_user_journey)
         except TooManyRequests as ex:
             return await too_many_requests(request, ex.sub_user_journey)
+        except TooManyRequestsWebForm:
+            return await too_many_requests_web_form(request)
         except InactiveCaseError as ex:
             return await inactive_case(request, ex.case_type)
         except ExerciseClosedError as ex:
@@ -126,6 +128,11 @@ async def too_many_requests(request, sub_user_journey: str):
     attributes = check_display_region(request)
     attributes['sub_user_journey'] = sub_user_journey
     return jinja.render_template('request-too-many-requests.html', request, attributes, status=429)
+
+
+async def too_many_requests_web_form(request):
+    attributes = check_display_region(request)
+    return jinja.render_template('web-form-too-many-requests.html', request, attributes, status=429)
 
 
 async def session_timeout(request, user_journey: str, sub_user_journey: str):

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -24,10 +24,14 @@ class SessionTimeout(Exception):
 
 
 class TooManyRequests(Exception):
-    """Raised when users session expires in journeys requiring sessions"""
+    """Raised when request fulfilment returns a 429"""
     def __init__(self, sub_user_journey):
         super().__init__()
         self.sub_user_journey = sub_user_journey
+
+
+class TooManyRequestsWebForm(Exception):
+    """Raised when web form returns a 429 error"""
 
 
 class ExerciseClosedError(Exception):

--- a/app/templates/web-form-too-many-requests.html
+++ b/app/templates/web-form-too-many-requests.html
@@ -1,0 +1,55 @@
+{%- extends 'base-' + display_region + '.html' -%}
+
+{% from "components/breadcrumb/_macro.njk" import onsBreadcrumb %}
+
+{%- if display_region == 'ni' -%}
+    {%- set contact_us_link = domain_url_ni + '/contact-us/' -%}
+{%- elif display_region == 'cy' -%}
+    {%- set contact_us_link = domain_url_cy + '/cysylltu-a-ni/' -%}
+{%- else -%}
+    {%- set contact_us_link = domain_url_en + '/contact-us/' -%}
+{%- endif -%}
+
+{% if display_region == 'ni' %}
+    {% set breadcrumb_items = [
+                {
+                    "url": domain_url_ni,
+                    "text": 'Home'
+                }
+            ]
+    %}
+{% elif display_region == 'cy' %}
+    {% set breadcrumb_items = [
+                {
+                    "url": domain_url_cy,
+                    "text": 'Hafan'
+                }
+            ]
+    %}
+{% else %}
+    {% set breadcrumb_items = [
+                {
+                    "url": domain_url_en,
+                    "text": 'Home'
+                }
+            ]
+    %}
+{% endif %}
+
+{% block preMain %}
+    {{
+        onsBreadcrumb({
+            "ariaLabel": 'Breadcrumb',
+            "itemsList": breadcrumb_items
+        })
+    }}
+{% endblock %}
+
+{%- block main -%}
+
+    <h1>{{ _('You have reached the maximum number web form submissions') }}</h1>
+    {%- autoescape false -%}
+        <p>{{ _('If you need further assistance, please %(open)scontact us%(close)s', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
+    {%- endautoescape -%}
+
+{%- endblock -%}

--- a/app/utils.py
+++ b/app/utils.py
@@ -525,7 +525,8 @@ class RHService(View):
             'language': form_data['language'],
             'name': form_data['name'],
             'description': form_data['description'],
-            'email': form_data['email']
+            'email': form_data['email'],
+            'clientIP': View.single_client_ip(request)
         }
         rhsvc_url = request.app['RHSVC_URL']
         return await View._make_request(request,

--- a/app/web_form_handlers.py
+++ b/app/web_form_handlers.py
@@ -3,6 +3,7 @@ import re
 
 from aiohttp.client_exceptions import (ClientResponseError)
 from aiohttp.web import HTTPFound, RouteTableDef
+from .exceptions import TooManyRequestsWebForm
 from structlog import get_logger
 
 from . import (WEBFORM_MISSING_COUNTRY_MSG,
@@ -145,7 +146,10 @@ class WebForm(View):
             try:
                 await RHService.post_webform(request, form_data)
             except ClientResponseError as ex:
-                raise ex
+                if ex.status == 429:
+                    raise TooManyRequestsWebForm()
+                else:
+                    raise ex
 
             raise HTTPFound(
                 request.app.router['WebFormSuccess:get'].url_for(display_region=display_region))

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2343,15 +2343,24 @@ class RHTestCase(AioHTTPTestCase):
 
         self.content_web_form_title_en = 'Web form'
         self.content_web_form_warning_en = 'Do not include any personal information, for example, your access code'
+        # TODO Add Welsh Translation
         self.content_web_form_title_cy = 'Web form'
+        # TODO Add Welsh Translation
         self.content_web_form_warning_cy = 'Do not include any personal information, for example, your access code'
 
         self.content_web_form_success_title_en = 'Thank you for contacting us'
         self.content_web_form_success_confirmation_en = 'Your message has been sent'
         self.content_web_form_success_secondary_en = 'We will respond to you within 2 working days'
+        # TODO Add Welsh Translation
         self.content_web_form_success_title_cy = 'Thank you for contacting us'
+        # TODO Add Welsh Translation
         self.content_web_form_success_confirmation_cy = 'Your message has been sent'
+        # TODO Add Welsh Translation
         self.content_web_form_success_secondary_cy = 'We will respond to you within 2 working days'
+
+        self.content_web_form_error_429_title_en = 'You have reached the maximum number web form submissions'
+        # TODO Add Welsh Translation
+        self.content_web_form_error_429_title_cy = 'You have reached the maximum number web form submissions'
 
         # Transient
 


### PR DESCRIPTION
Updates to add clientIP and 429 errors to web form

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Updates needed for rate limiting of web form

# What has changed
Added clientIP to RHSvc call
Added handling of a 429 response from RHSvc

Note text has not been finalised
No Cucumber updates required

# How to test?
Unit tests have been added, but cannot be tested with RHSvc until RHSvc changes are implemented

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1478

# Screenshots (if appropriate):