### PR TITLE
CR-1521 Update GTM tags and envars

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -55,9 +55,8 @@ class BaseConfig:
 
     URL_PATH_PREFIX = env('URL_PATH_PREFIX', default='')
 
+    GTM_CONTAINER_ID = env('GTM_CONTAINER_ID', default='')
     GTM_AUTH = env('GTM_AUTH', default='')
-    GTM_PREVIEW = env('GTM_PREVIEW', default='')
-    GTM_COOKIES_WIN = env('GTM_COOKIES_WIN', default='')
 
     REDIS_SERVER = env('REDIS_SERVER', default='localhost')
 
@@ -106,9 +105,8 @@ class DevelopmentConfig:
 
     URL_PATH_PREFIX = env('URL_PATH_PREFIX', default='')
 
-    GTM_AUTH = env.str('GTM_AUTH', default='QZTzNzZrlo_z0DCT4veo1A')
-    GTM_PREVIEW = env.str('GTM_PREVIEW', default='env-13')
-    GTM_COOKIES_WIN = env.str('GTM_COOKIES_WIN', default='x')
+    GTM_CONTAINER_ID = env.str('GTM_CONTAINER_ID', default='GTM-MRQGCXS')
+    GTM_AUTH = env.str('GTM_AUTH', default='SMijm6Rii1nctiBFRb1Rdw')
 
     REDIS_SERVER = env('REDIS_SERVER', default='localhost')
 
@@ -153,9 +151,8 @@ class TestingConfig:
 
     URL_PATH_PREFIX = ''
 
-    GTM_AUTH = 'QZTzNzZrlo_z0DCT4veo1A'
-    GTM_PREVIEW = 'env-13'
-    GTM_COOKIES_WIN = 'x'
+    GTM_CONTAINER_ID = 'GTM-MRQGCXS'
+    GTM_AUTH = 'SMijm6Rii1nctiBFRb1Rdw'
 
     REDIS_SERVER = ''
 

--- a/app/google_analytics.py
+++ b/app/google_analytics.py
@@ -1,4 +1,2 @@
 async def ga_ua_id_processor(request):
-    return {'gtm_auth': request.app['GTM_AUTH'],
-            'gtm_preview': request.app['GTM_PREVIEW'],
-            'gtm_cookies_win': request.app['GTM_COOKIES_WIN']}
+    return {'gtm_cont_id': request.app['GTM_CONTAINER_ID'], 'gtm_auth': request.app['GTM_AUTH']}

--- a/app/templates/base-cy.html
+++ b/app/templates/base-cy.html
@@ -109,7 +109,7 @@
 {%- block head -%}
 
     <!-- Google Analytics -->
-    {%- if gtm_auth and gtm_preview and gtm_cookies_win -%}
+    {%- if gtm_cont_id and gtm_auth -%}
         {%- include 'partials/gtm.html' with context -%}
     {%- endif -%}
     <!-- End Google Analytics -->
@@ -118,7 +118,7 @@
 
 {%- block bodyStart -%}
 
-    {%- if gtm_auth and gtm_preview and gtm_cookies_win -%}
+    {%- if gtm_cont_id and gtm_auth -%}
         {%- include 'partials/gtm-no-script.html' with context -%}
     {%- endif -%}
 

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -106,7 +106,7 @@
 {%- block head -%}
 
     <!-- Google Analytics -->
-    {%- if gtm_auth and gtm_preview and gtm_cookies_win -%}
+    {%- if gtm_cont_id and gtm_auth -%}
         {%- include 'partials/gtm.html' with context -%}
     {%- endif -%}
     <!-- End Google Analytics -->
@@ -115,7 +115,7 @@
 
 {%- block bodyStart -%}
 
-    {%- if gtm_auth and gtm_preview and gtm_cookies_win -%}
+    {%- if gtm_cont_id and gtm_auth -%}
         {%- include 'partials/gtm-no-script.html' with context -%}
     {%- endif -%}
 

--- a/app/templates/base-ni.html
+++ b/app/templates/base-ni.html
@@ -87,7 +87,7 @@
 {%- block head -%}
 
     <!-- Google Analytics -->
-    {%- if gtm_auth and gtm_preview and gtm_cookies_win -%}
+    {%- if gtm_cont_id and gtm_auth -%}
         {%- include 'partials/gtm.html' with context -%}
     {%- endif -%}
     <!-- End Google Analytics -->
@@ -96,7 +96,7 @@
 
 {%- block bodyStart -%}
 
-    {%- if gtm_auth and gtm_preview and gtm_cookies_win -%}
+    {%- if gtm_cont_id and gtm_auth -%}
         {%- include 'partials/gtm-no-script.html' with context -%}
     {%- endif -%}
 

--- a/app/templates/base-webchat-cy.html
+++ b/app/templates/base-webchat-cy.html
@@ -49,7 +49,7 @@
 {% block head %}
 
     <!-- Google Analytics -->
-    {% if gtm_auth and gtm_preview and gtm_cookies_win %}
+    {% if gtm_cont_id and gtm_auth %}
         {% include 'partials/gtm.html' with context %}
     {% endif %}
     <!-- End Google Analytics -->
@@ -58,7 +58,7 @@
 
 {% block bodyStart %}
 
-    {% if gtm_auth and gtm_preview and gtm_cookies_win %}
+    {% if gtm_cont_id and gtm_auth %}
         {% include 'partials/gtm-no-script.html' with context %}
     {% endif %}
 

--- a/app/templates/base-webchat-en.html
+++ b/app/templates/base-webchat-en.html
@@ -48,7 +48,7 @@
 {% block head %}
 
     <!-- Google Analytics -->
-    {% if gtm_auth and gtm_preview and gtm_cookies_win %}
+    {% if gtm_cont_id and gtm_auth %}
         {% include 'partials/gtm.html' with context %}
     {% endif %}
     <!-- End Google Analytics -->
@@ -57,7 +57,7 @@
 
 {% block bodyStart %}
 
-    {% if gtm_auth and gtm_preview and gtm_cookies_win %}
+    {% if gtm_cont_id and gtm_auth %}
         {% include 'partials/gtm-no-script.html' with context %}
     {% endif %}
 

--- a/app/templates/base-webchat-ni.html
+++ b/app/templates/base-webchat-ni.html
@@ -25,7 +25,7 @@
 {% block head %}
 
     <!-- Google Analytics -->
-    {% if gtm_auth and gtm_preview and gtm_cookies_win %}
+    {% if gtm_cont_id and gtm_auth %}
         {% include 'partials/gtm.html' with context %}
     {% endif %}
     <!-- End Google Analytics -->
@@ -34,7 +34,7 @@
 
 {% block bodyStart %}
 
-    {% if gtm_auth and gtm_preview and gtm_cookies_win %}
+    {% if gtm_cont_id and gtm_auth %}
         {% include 'partials/gtm-no-script.html' with context %}
     {% endif %}
 

--- a/app/templates/partials/gtm-no-script.html
+++ b/app/templates/partials/gtm-no-script.html
@@ -1,4 +1,4 @@
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TLWR59T&gtm_auth={{ gtm_auth }}&gtm_preview={{ gtm_preview }}&gtm_cookies_win={{ gtm_cookies_win }}"
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_cont_id }}&gtm_auth={{ gtm_auth }}&gtm_cookies_win=x"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->

--- a/app/templates/partials/gtm.html
+++ b/app/templates/partials/gtm.html
@@ -5,8 +5,8 @@
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth={{ gtm_auth }}&gtm_preview={{ gtm_preview }}&gtm_cookies_win={{ gtm_cookies_win }}';f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','GTM-TLWR59T');
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth={{ gtm_auth }}&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','{{ gtm_cont_id }}');
     }
 </script>
 <!-- End Google Tag Manager -->

--- a/tests/unit/test_google_analytics.py
+++ b/tests/unit/test_google_analytics.py
@@ -7,44 +7,69 @@ from . import RHTestCase
 class TestGoogleAnalytics(RHTestCase):
     @unittest_run_loop
     async def test_google_analytics_context(self):
+        self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
         self.app['GTM_AUTH'] = '12345'
-        self.app['GTM_PREVIEW'] = 'env-5'
-        self.app['GTM_COOKIES_WIN'] = 'x'
         request = make_mocked_request('GET', '/', app=self.app)
         context = await ga_ua_id_processor(request)
+        self.assertEqual(context['gtm_cont_id'], 'GTM-XXXXXXX')
         self.assertEqual(context['gtm_auth'], '12345')
-        self.assertEqual(context['gtm_preview'], 'env-5')
-        self.assertEqual(context['gtm_cookies_win'], 'x')
 
     @unittest_run_loop
     async def test_google_analytics_script_rendered_base_en(self):
+        self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
         self.app['GTM_AUTH'] = '12345'
-        self.app['GTM_PREVIEW'] = 'env-5'
-        self.app['GTM_COOKIES_WIN'] = 'x'
         response = await self.client.request('GET', self.get_start_en)
         self.assertEqual(response.status, 200)
-        self.assertIn(f"gtm_auth=12345&gtm_preview=env-5&gtm_cookies_win=x".encode(), await
-                      response.content.read())
+        response = await response.content.read()
+        self.assertIn(f"(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(), response)
+        self.assertIn(f"gtm_auth=12345&gtm_cookies_win=x".encode(), response)
 
     @unittest_run_loop
     async def test_google_analytics_script_rendered_base_cy(self):
+        self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
         self.app['GTM_AUTH'] = '12345'
-        self.app['GTM_PREVIEW'] = 'env-5'
-        self.app['GTM_COOKIES_WIN'] = 'x'
         response = await self.client.request('GET', self.get_start_cy)
         self.assertEqual(response.status, 200)
-        self.assertIn(f"gtm_auth=12345&gtm_preview=env-5&gtm_cookies_win=x".encode(), await
-                      response.content.read())
+        response = await response.content.read()
+        self.assertIn(f"(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(), response)
+        self.assertIn(f"gtm_auth=12345&gtm_cookies_win=x".encode(), response)
 
     @unittest_run_loop
     async def test_google_analytics_script_rendered_base_ni(self):
+        self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
         self.app['GTM_AUTH'] = '12345'
-        self.app['GTM_PREVIEW'] = 'env-5'
-        self.app['GTM_COOKIES_WIN'] = 'x'
         response = await self.client.request('GET', self.get_start_ni)
         self.assertEqual(response.status, 200)
-        self.assertIn(f"gtm_auth=12345&gtm_preview=env-5&gtm_cookies_win=x".encode(), await
-                      response.content.read())
+        response = await response.content.read()
+        self.assertIn(f"(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(), response)
+        self.assertIn(f"gtm_auth=12345&gtm_cookies_win=x".encode(), response)
+
+    @unittest_run_loop
+    async def test_google_analytics_script_not_rendered_missing_container_id_base_en(self):
+        self.app['GTM_CONTAINER_ID'] = ''
+
+        response = await self.client.request('GET', self.get_start_en)
+        self.assertEqual(response.status, 200)
+        self.assertNotIn(f"(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(),
+                         await response.content.read())
+
+    @unittest_run_loop
+    async def test_google_analytics_script_not_rendered_missing_container_id_base_cy(self):
+        self.app['GTM_CONTAINER_ID'] = ''
+
+        response = await self.client.request('GET', self.get_start_cy)
+        self.assertEqual(response.status, 200)
+        self.assertNotIn(f"(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(),
+                         await response.content.read())
+
+    @unittest_run_loop
+    async def test_google_analytics_script_not_rendered_missing_container_id_base_ni(self):
+        self.app['GTM_CONTAINER_ID'] = ''
+
+        response = await self.client.request('GET', self.get_start_ni)
+        self.assertEqual(response.status, 200)
+        self.assertNotIn(f"(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(),
+                         await response.content.read())
 
     @unittest_run_loop
     async def test_google_analytics_script_not_rendered_base_en(self):
@@ -52,8 +77,7 @@ class TestGoogleAnalytics(RHTestCase):
 
         response = await self.client.request('GET', self.get_start_en)
         self.assertEqual(response.status, 200)
-        self.assertNotIn(f"ga('gtm_auth', '', 'auto');".encode(), await
-                         response.content.read())
+        self.assertNotIn(f"gtm_auth=12345&gtm_cookies_win=x".encode(), await response.content.read())
 
     @unittest_run_loop
     async def test_google_analytics_script_not_rendered_base_cy(self):
@@ -61,8 +85,7 @@ class TestGoogleAnalytics(RHTestCase):
 
         response = await self.client.request('GET', self.get_start_cy)
         self.assertEqual(response.status, 200)
-        self.assertNotIn(f"ga('gtm_auth', '', 'auto');".encode(), await
-                         response.content.read())
+        self.assertNotIn(f"gtm_auth=12345&gtm_cookies_win=x".encode(), await response.content.read())
 
     @unittest_run_loop
     async def test_google_analytics_script_not_rendered_base_ni(self):
@@ -70,38 +93,64 @@ class TestGoogleAnalytics(RHTestCase):
 
         response = await self.client.request('GET', self.get_start_ni)
         self.assertEqual(response.status, 200)
-        self.assertNotIn(f"ga('gtm_auth', '', 'auto');".encode(), await
-                         response.content.read())
+        self.assertNotIn(f"gtm_auth=12345&gtm_cookies_win=x".encode(), await response.content.read())
 
     @unittest_run_loop
     async def test_google_analytics_script_rendered_base_webchat_en(self):
+        self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
         self.app['GTM_AUTH'] = '12345'
-        self.app['GTM_PREVIEW'] = 'env-5'
-        self.app['GTM_COOKIES_WIN'] = 'x'
         response = await self.client.request('GET', self.get_webchat_en)
         self.assertEqual(response.status, 200)
-        self.assertIn(f"gtm_auth=12345&gtm_preview=env-5&gtm_cookies_win=x".encode(), await
-                      response.content.read())
+        response = await response.content.read()
+        self.assertIn(f"(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(), response)
+        self.assertIn(f"gtm_auth=12345&gtm_cookies_win=x".encode(), response)
 
     @unittest_run_loop
     async def test_google_analytics_script_rendered_base_webchat_cy(self):
+        self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
         self.app['GTM_AUTH'] = '12345'
-        self.app['GTM_PREVIEW'] = 'env-5'
-        self.app['GTM_COOKIES_WIN'] = 'x'
         response = await self.client.request('GET', self.get_webchat_cy)
         self.assertEqual(response.status, 200)
-        self.assertIn(f"gtm_auth=12345&gtm_preview=env-5&gtm_cookies_win=x".encode(), await
-                      response.content.read())
+        response = await response.content.read()
+        self.assertIn(f"(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(), response)
+        self.assertIn(f"gtm_auth=12345&gtm_cookies_win=x".encode(), response)
 
     @unittest_run_loop
     async def test_google_analytics_script_rendered_base_webchat_ni(self):
+        self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
         self.app['GTM_AUTH'] = '12345'
-        self.app['GTM_PREVIEW'] = 'env-5'
-        self.app['GTM_COOKIES_WIN'] = 'x'
         response = await self.client.request('GET', self.get_webchat_ni)
         self.assertEqual(response.status, 200)
-        self.assertIn(f"gtm_auth=12345&gtm_preview=env-5&gtm_cookies_win=x".encode(), await
-                      response.content.read())
+        response = await response.content.read()
+        self.assertIn(f"(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(), response)
+        self.assertIn(f"gtm_auth=12345&gtm_cookies_win=x".encode(), response)
+
+    @unittest_run_loop
+    async def test_google_analytics_script_not_rendered_missing_container_id_base_webchat_en(self):
+        self.app['GTM_CONTAINER_ID'] = ''
+
+        response = await self.client.request('GET', self.get_webchat_en)
+        self.assertEqual(response.status, 200)
+        self.assertNotIn(f"(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(),
+                         await response.content.read())
+
+    @unittest_run_loop
+    async def test_google_analytics_script_not_rendered_missing_container_id_base_webchat_cy(self):
+        self.app['GTM_CONTAINER_ID'] = ''
+
+        response = await self.client.request('GET', self.get_webchat_cy)
+        self.assertEqual(response.status, 200)
+        self.assertNotIn(f"(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(),
+                         await response.content.read())
+
+    @unittest_run_loop
+    async def test_google_analytics_script_not_rendered_missing_container_id_base_webchat_ni(self):
+        self.app['GTM_CONTAINER_ID'] = ''
+
+        response = await self.client.request('GET', self.get_webchat_ni)
+        self.assertEqual(response.status, 200)
+        self.assertNotIn(f"(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(),
+                         await response.content.read())
 
     @unittest_run_loop
     async def test_google_analytics_script_not_rendered_base_webchat_en(self):
@@ -109,8 +158,7 @@ class TestGoogleAnalytics(RHTestCase):
 
         response = await self.client.request('GET', self.get_webchat_en)
         self.assertEqual(response.status, 200)
-        self.assertNotIn(f"ga('gtm_auth', '', 'auto');".encode(), await
-                         response.content.read())
+        self.assertNotIn(f"gtm_auth=12345&gtm_cookies_win=x".encode(), await response.content.read())
 
     @unittest_run_loop
     async def test_google_analytics_script_not_rendered_base_webchat_cy(self):
@@ -118,8 +166,7 @@ class TestGoogleAnalytics(RHTestCase):
 
         response = await self.client.request('GET', self.get_webchat_cy)
         self.assertEqual(response.status, 200)
-        self.assertNotIn(f"ga('gtm_auth', '', 'auto');".encode(), await
-                         response.content.read())
+        self.assertNotIn(f"gtm_auth=12345&gtm_cookies_win=x".encode(), await response.content.read())
 
     @unittest_run_loop
     async def test_google_analytics_script_not_rendered_base_webchat_ni(self):
@@ -127,5 +174,4 @@ class TestGoogleAnalytics(RHTestCase):
 
         response = await self.client.request('GET', self.get_webchat_ni)
         self.assertEqual(response.status, 200)
-        self.assertNotIn(f"ga('gtm_auth', '', 'auto');".encode(), await
-                         response.content.read())
+        self.assertNotIn(f"gtm_auth=12345&gtm_cookies_win=x".encode(), await response.content.read())


### PR DESCRIPTION
Complete

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Update to use the changed environment variables for the GTM tagging

# What has changed
Removal of gtm_preview (not required) and gtm_cookies_win (not changing so hardcoded), and addition of GTM_CONTAINER_ID
Update and addition to unit tests

No Cucumber updates required (has been tested)

# How to test?
Run and ensure GTM code is present in pages

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1521
https://collaborate2.ons.gov.uk/jira/browse/CR-1396
