### PR TITLE
Cr 1467 select address 403 fix

### DIFF
--- a/app/common_handlers.py
+++ b/app/common_handlers.py
@@ -1,5 +1,4 @@
 import aiohttp_jinja2
-import json
 
 from aiohttp.web import HTTPFound, RouteTableDef
 from structlog import get_logger
@@ -371,6 +370,7 @@ class CommonSelectAddress(CommonCommon):
         address_content['sub_user_journey'] = sub_user_journey
         address_content['locale'] = locale
         address_content['page_url'] = View.gen_page_url(request)
+        address_content['contact_us_link'] = View.get_campaign_site_link(request, display_region, 'contact-us')
 
         return address_content
 
@@ -399,7 +399,7 @@ class CommonSelectAddress(CommonCommon):
         data = await request.post()
 
         try:
-            form_return = json.loads(data['form-select-address'])
+            selected_uprn = data['form-pick-address']
         except KeyError:
             logger.info('no address selected', client_ip=request['client_ip'])
             if display_region == 'cy':
@@ -413,9 +413,10 @@ class CommonSelectAddress(CommonCommon):
             address_content['sub_user_journey'] = sub_user_journey
             address_content['locale'] = locale
             address_content['page_url'] = View.gen_page_url(request)
+            address_content['contact_us_link'] = View.get_campaign_site_link(request, display_region, 'contact-us')
             return address_content
 
-        if form_return['uprn'] == 'xxxx':
+        if selected_uprn == 'xxxx':
             raise HTTPFound(
                 request.app.router['CommonCallContactCentre:get'].url_for(
                     display_region=display_region,
@@ -423,8 +424,7 @@ class CommonSelectAddress(CommonCommon):
                     error='address-not-found'))
         else:
             session = await get_session(request)
-            session['attributes']['address'] = form_return['address']
-            session['attributes']['uprn'] = form_return['uprn']
+            session['attributes']['uprn'] = selected_uprn
             session.changed()
             logger.info('session updated', client_ip=request['client_ip'])
 

--- a/app/templates/common-select-address.html
+++ b/app/templates/common-select-address.html
@@ -1,13 +1,5 @@
 {% extends 'base-' + display_region + '.html' %}
 
-{% if display_region == 'ni' %}
-    {% set contact_us_link = domain_url_en + '/contact-us/' %}
-{% elif display_region == 'cy' %}
-    {% set contact_us_link = domain_url_cy + '/cysylltu-a-ni/' %}
-{% else %}
-    {% set contact_us_link = domain_url_en + '/contact-us/' %}
-{% endif %}
-
 {% set request_code_link = url('CommonEnterAddress:get', display_region=display_region, user_journey=user_journey, sub_user_journey=sub_user_journey) %}
 
 {% set messages_dict=dict(get_flashed_messages()|groupby('level')) %}
@@ -24,7 +16,11 @@
     }
 } %}
 
-{% set question_description = _('<p class="u-fs-r--b">%(total)s addresses found for postcode %(pcode)s</p>', total=total_matches|string, pcode=postcode) %}
+{%- if total_matches == 1: -%}
+    {%- set question_description = _('<p class="u-fs-r--b">%(total)s address found for postcode %(pcode)s</p>', total=total_matches|string, pcode=postcode) -%}
+{%- else: -%}
+    {%- set question_description = _('<p class="u-fs-r--b">%(total)s addresses found for postcode %(pcode)s</p>', total=total_matches|string, pcode=postcode) -%}
+{%- endif -%}
 
 {%- if 'error-no-address-selected' in field_messages_dict -%}
     {%- set error_select_address = {'id': 'error-no-address-selected', 'text': _('Select an address')} -%}
@@ -53,7 +49,7 @@
 
             {{
                 onsRadios({
-                    'name': 'form-select-address',
+                    'name': 'form-pick-address',
                     'or': 'Or',
                     'radios': addresses,
                     'error': error_select_address

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,5 @@
 import string
 import re
-import json
 import math
 
 from aiohttp.client_exceptions import (ClientResponseError)
@@ -171,7 +170,6 @@ class View:
                 raise TooManyRequestsEQLaunch()
             else:
                 raise ex
-
 
         logger.info('redirecting to eq', client_ip=request['client_ip'])
         eq_url = app['EQ_URL']

--- a/app/utils.py
+++ b/app/utils.py
@@ -413,24 +413,15 @@ class AddressIndex(View):
 
         for singleAddress in postcode_return['response']['addresses']:
             address_options.append({
-                'value':
-                json.dumps({
-                    'uprn': singleAddress['uprn'],
-                    'address': singleAddress['formattedAddress']
-                }),
+                'value': singleAddress['uprn'],
                 'label': {
                     'text': singleAddress['formattedAddress']
                 },
-                'id':
-                singleAddress['uprn']
+                'id': singleAddress['uprn']
             })
 
         address_options.append({
-            'value':
-            json.dumps({
-                'uprn': 'xxxx',
-                'address': cannot_find_text
-            }),
+            'value': 'xxxx',
             'label': {
                 'text': cannot_find_text
             },

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -273,28 +273,12 @@ class RHTestCase(AioHTTPTestCase):
         self.content_common_invalid_mobile_error_cy = \
             'Enter a UK mobile number in a valid format, for example, 07700 900345 or +44 7700 900345'
 
-        self.post_common_select_address_form_data_valid = \
-            '{"uprn": "10023122451", "address": "1 Gate Reach, Exeter, EX2 6GA"}'
-
-        self.post_common_select_address_form_data_not_listed_en = \
-            '{"uprn": "xxxx", "address": "I cannot find my address"}'
-
-        self.post_common_select_address_form_data_not_listed_cy = \
-            '{"uprn": "xxxx", "address": "I cannot find my address"}'
-
         self.common_select_address_input_valid = {
-            'form-select-address': self.post_common_select_address_form_data_valid,
-            'action[save_continue]': '',
+            'form-pick-address': '10023122451', 'action[save_continue]': '',
         }
 
-        self.common_select_address_input_not_listed_en = {
-            'form-select-address': self.post_common_select_address_form_data_not_listed_en,
-            'action[save_continue]': '',
-        }
-
-        self.common_select_address_input_not_listed_cy = {
-            'form-select-address': self.post_common_select_address_form_data_not_listed_cy,
-            'action[save_continue]': '',
+        self.common_select_address_input_not_listed = {
+            'form-pick-address': 'xxxx', 'action[save_continue]': '',
         }
 
         self.common_confirm_address_input_yes = {

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -657,7 +657,7 @@ class TestHelpers(RHTestCase):
 
     async def check_post_select_address_address_not_found(self, url, display_region):
         with self.assertLogs('respondent-home', 'INFO') as cm:
-            response = await self.client.request('POST', url, data=self.common_select_address_input_not_listed_en)
+            response = await self.client.request('POST', url, data=self.common_select_address_input_not_listed)
 
             self.assertLogEvent(cm, self.build_url_log_entry('select-address', display_region, 'POST'))
             self.assertLogEvent(cm, self.build_url_log_entry('call-contact-centre/address-not-found',

--- a/tests/unit/test_start_handlers_change_address.py
+++ b/tests/unit/test_start_handlers_change_address.py
@@ -2335,7 +2335,7 @@ class TestStartHandlersChangeAddress(TestHelpers):
             response = await self.client.request(
                     'POST',
                     self.post_start_change_address_select_address_en,
-                    data=self.common_select_address_input_not_listed_en)
+                    data=self.common_select_address_input_not_listed)
             self.assertLogEvent(cm, "received POST on endpoint 'en/start/change-address/select-address'")
             self.assertLogEvent(cm, "received GET on endpoint 'en/start/call-contact-centre/address-not-found'")
 
@@ -2389,7 +2389,7 @@ class TestStartHandlersChangeAddress(TestHelpers):
             response = await self.client.request(
                     'POST',
                     self.post_start_change_address_select_address_cy,
-                    data=self.common_select_address_input_not_listed_cy)
+                    data=self.common_select_address_input_not_listed)
             self.assertLogEvent(cm, "received POST on endpoint 'cy/start/change-address/select-address'")
             self.assertLogEvent(cm, "received GET on endpoint 'cy/start/call-contact-centre/address-not-found'")
 
@@ -2442,7 +2442,7 @@ class TestStartHandlersChangeAddress(TestHelpers):
             response = await self.client.request(
                     'POST',
                     self.post_start_change_address_select_address_ni,
-                    data=self.common_select_address_input_not_listed_en)
+                    data=self.common_select_address_input_not_listed)
             self.assertLogEvent(cm, "received POST on endpoint 'ni/start/change-address/select-address'")
             self.assertLogEvent(cm, "received GET on endpoint 'ni/start/call-contact-centre/address-not-found'")
 

--- a/tests/unit/test_start_handlers_unlinked.py
+++ b/tests/unit/test_start_handlers_unlinked.py
@@ -2086,7 +2086,7 @@ class TestStartHandlersUnlinked(TestHelpers):
             response = await self.client.request(
                     'POST',
                     self.post_start_unlinked_select_address_en,
-                    data=self.common_select_address_input_not_listed_en)
+                    data=self.common_select_address_input_not_listed)
             self.assertLogEvent(cm, "received POST on endpoint 'en/start/unlinked/select-address'")
             self.assertLogEvent(cm, "received GET on endpoint 'en/start/call-contact-centre/address-not-found'")
 
@@ -2131,7 +2131,7 @@ class TestStartHandlersUnlinked(TestHelpers):
             response = await self.client.request(
                     'POST',
                     self.post_start_unlinked_select_address_cy,
-                    data=self.common_select_address_input_not_listed_cy)
+                    data=self.common_select_address_input_not_listed)
             self.assertLogEvent(cm, "received POST on endpoint 'cy/start/unlinked/select-address'")
             self.assertLogEvent(cm, "received GET on endpoint 'cy/start/call-contact-centre/address-not-found'")
 
@@ -2175,7 +2175,7 @@ class TestStartHandlersUnlinked(TestHelpers):
             response = await self.client.request(
                     'POST',
                     self.post_start_unlinked_select_address_ni,
-                    data=self.common_select_address_input_not_listed_en)
+                    data=self.common_select_address_input_not_listed)
             self.assertLogEvent(cm, "received POST on endpoint 'ni/start/unlinked/select-address'")
             self.assertLogEvent(cm, "received GET on endpoint 'ni/start/call-contact-centre/address-not-found'")
 


### PR DESCRIPTION
# Motivation and Context
Changes how 'select-address' page is built to stop WAF rules being violated

# What has changed
Changed radio 'name' to remove problem term 'select'
Removed redundant JSON from radio 'value', so that the field only contains the UPRN value
Added text variant for only 1 address match
Updated effected unit tests

Requires matching RHCuc update due to field name change

# How to test?
Tested in dev

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1467
https://github.com/ONSdigital/census-rh-cucumber/pull/113

# Screenshots (if appropriate):