### PR TITLE
Cr 1496 client ip updates

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -52,7 +52,14 @@ class View:
     @staticmethod
     def single_client_ip(request):
         if request['client_ip']:
-            single_ip = request['client_ip'].split(',', 1)[0]
+            client_ip = request['client_ip']
+            for character in string.whitespace + OBSCURE_WHITESPACE:
+                client_ip = client_ip.replace(character, '')
+            ip_validation_pattern = re.compile(r'^[0-9.,\s]*$')
+            if ip_validation_pattern.fullmatch(client_ip):
+                single_ip = client_ip.split(',', -1)[-3]
+            else:
+                single_ip = ''
         elif request.headers.get('Origin', None) and 'localhost' in request.headers.get('Origin', None):
             single_ip = '127.0.0.1'
         else:

--- a/app/utils.py
+++ b/app/utils.py
@@ -53,12 +53,11 @@ class View:
     def single_client_ip(request):
         if request['client_ip']:
             client_ip = request['client_ip']
-            for character in string.whitespace + OBSCURE_WHITESPACE:
-                client_ip = client_ip.replace(character, '')
             ip_validation_pattern = re.compile(r'^[0-9.,\s]*$')
-            if ip_validation_pattern.fullmatch(client_ip):
-                single_ip = client_ip.split(',', -1)[-3]
+            if ip_validation_pattern.fullmatch(client_ip) and client_ip.count(',') > 1:
+                single_ip = client_ip.split(', ', -1)[-3]
             else:
+                logger.warn('clientIP failed validation. Provided IP - ' + client_ip)
                 single_ip = ''
         elif request.headers.get('Origin', None) and 'localhost' in request.headers.get('Origin', None):
             single_ip = '127.0.0.1'

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -329,3 +329,16 @@ class TestUtils(RHTestCase):
         self.after_census_day(2021, 3, 22)
         self.before_census_day(2021, 3, 21)
         self.before_census_day(2021, 3, 20)
+
+    def test_client_ip(self):
+        valid_request = {'client_ip': '192.168.0.0, 35.190.0.0, 35.191.10.0'}
+        spoofed_request = {'client_ip': '200.30.20.10, 192.168.0.0, 35.190.0.0, 35.191.10.0'}
+        invalid_request = {'client_ip': 'GHT.RGT.ED.WS, 192.168.0.0, 35.190.0.0, 35.191.10.0'}
+        built_valid = View.single_client_ip(valid_request)
+        built_invalid = View.single_client_ip(invalid_request)
+        built_spoofed = View.single_client_ip(spoofed_request)
+        expected_valid = '192.168.0.0'
+        expected_empty = ''
+        self.assertEqual(built_valid, expected_valid)
+        self.assertEqual(built_spoofed, expected_valid)
+        self.assertEqual(built_invalid, expected_empty)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -334,11 +334,10 @@ class TestUtils(RHTestCase):
         valid_request = {'client_ip': '192.168.0.0, 35.190.0.0, 35.191.10.0'}
         spoofed_request = {'client_ip': '200.30.20.10, 192.168.0.0, 35.190.0.0, 35.191.10.0'}
         invalid_request = {'client_ip': 'GHT.RGT.ED.WS, 192.168.0.0, 35.190.0.0, 35.191.10.0'}
-        built_valid = View.single_client_ip(valid_request)
-        built_invalid = View.single_client_ip(invalid_request)
-        built_spoofed = View.single_client_ip(spoofed_request)
+        single_ip_request = {'client_ip': '35.191.10.0'}
         expected_valid = '192.168.0.0'
         expected_empty = ''
-        self.assertEqual(built_valid, expected_valid)
-        self.assertEqual(built_spoofed, expected_valid)
-        self.assertEqual(built_invalid, expected_empty)
+        self.assertEqual(View.single_client_ip(valid_request), expected_valid)
+        self.assertEqual(View.single_client_ip(spoofed_request), expected_valid)
+        self.assertEqual(View.single_client_ip(invalid_request), expected_empty)
+        self.assertEqual(View.single_client_ip(single_ip_request), expected_empty)


### PR DESCRIPTION
# Motivation and Context
Change to generation of clientIP for rate limiting purposes

# What has changed
clientIP is now passed through a regex to check it only contains ip like content, and to take value third from right instead of the first value.
Added a unit test to check the validity tests

No Cucumber updates required

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1496

# Screenshots (if appropriate):