### PR TITLE
CR-1566 Radio Legends

### DIFF
--- a/app/templates/common-confirm-address.html
+++ b/app/templates/common-confirm-address.html
@@ -69,6 +69,8 @@
             onsRadios({
                 'name': 'form-confirm-address',
                 'radios': form_options,
+                'legend': _('Is this the correct address?'),
+                'legendClasses': 'u-vh',
                 'error': error_address
             })
         }}

--- a/app/templates/common-resident-or-manager.html
+++ b/app/templates/common-resident-or-manager.html
@@ -59,6 +59,8 @@
             onsRadios({
                 'name': 'form-resident-or-manager',
                 'radios': form_options,
+                'legend': _('Are you a resident or manager of this establishment?'),
+                'legendClasses': 'u-vh',
                 'error': error_resident_or_manager
             })
         }}

--- a/app/templates/common-select-address.html
+++ b/app/templates/common-select-address.html
@@ -52,6 +52,8 @@
                     'name': 'form-pick-address',
                     'or': 'Or',
                     'radios': addresses,
+                    'legend': _('Select your address'),
+                    'legendClasses': 'u-vh',
                     'error': error_select_address
                 })
             }}

--- a/app/templates/request-code-confirm-send-by-text.html
+++ b/app/templates/request-code-confirm-send-by-text.html
@@ -51,6 +51,8 @@
             onsRadios({
                 'name': 'request-mobile-confirmation',
                 'radios': form_options,
+                'legend': _('Is this mobile number correct?'),
+                'legendClasses': 'u-vh',
                 'error': error_mobile
             })
         }}

--- a/app/templates/request-code-household.html
+++ b/app/templates/request-code-household.html
@@ -15,7 +15,7 @@
 
 {%- block main -%}
 
-    <h1 class="u-mb-l u-fs-xxl">{{ _('Request a new household access code') }}</h1>
+    <h1 class="u-fs-xxl">{{ _('Request a new household access code') }}</h1>
 
     <p>{{ _('A household access code lets you start a new census for your household and the people who live there. You will lose any answers entered using a previous access code.') }}</p>
 

--- a/app/templates/request-common-confirm-send-by-post.html
+++ b/app/templates/request-common-confirm-send-by-post.html
@@ -118,6 +118,8 @@
             onsRadios({
                 'name': 'request-name-address-confirmation',
                 'radios': form_options,
+                'legend': question_title,
+                'legendClasses': 'u-vh',
                 'error': error_radio
             })
         }}

--- a/app/templates/start-confirm-address.html
+++ b/app/templates/start-confirm-address.html
@@ -69,6 +69,8 @@
         onsRadios({
             'name': 'address-check-answer',
             'radios': form_radio_options,
+            'legend': _('Is this the correct address?'),
+            'legendClasses': 'u-vh',
             'error': error_address
         })
     }}

--- a/app/templates/start-ni-language-options.html
+++ b/app/templates/start-ni-language-options.html
@@ -50,6 +50,8 @@
             onsRadios({
                 'name': 'language-option',
                 'radios': radio_options,
+                'legend': 'Would you like to complete the census in English?',
+                'legendClasses': 'u-vh',
                 'error': error_language_option
             })
         }}

--- a/app/templates/start-transient-accommodation-type.html
+++ b/app/templates/start-transient-accommodation-type.html
@@ -59,6 +59,8 @@
             onsRadios({
                 'name': 'accommodation-type',
                 'radios': radio_options,
+                'legend': _('Which of the following best describes your type of accommodation?'),
+                'legendClasses': 'u-vh',
                 'error': error_accommodation_type
             })
         }}


### PR DESCRIPTION
Adds 'legends' to radio buttons that didn't have it set already

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Calls to onsRadios macro should have 'legends' set

# What has changed
Set 'legends' on onsRadios where not set, also adding 'legendsClasses' hidden class
Removed class on household interstitial page h1

No Cucumber updates required

# How to test?
All updated radio fields should now have a 'legend' with a 'u-vh' class, so the legend is visible in the code, but not on the screen (so is read by screen readers).
Existing 'legends' are as before, with a visible legend

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1566