### PR TITLE
Cr 1584 update post option text

### DIFF
--- a/app/templates/request-code-select-how-to-receive.html
+++ b/app/templates/request-code-select-how-to-receive.html
@@ -20,6 +20,12 @@
     {%- set error_radio = {'id': 'no-selection', 'text': _('Select an answer')} -%}
 {%- endif -%}
 
+{%- if case_type == 'CE' -%}
+    {%- set post_description = _('We can only send access codes to the registered address') -%}
+{%- else -%}
+    {%- set post_description = _('We can only send access codes to the registered household address') -%}
+{%- endif -%}
+
 {%- set form_options = [
         {
             'id': 'sms',
@@ -33,7 +39,7 @@
             'id': 'post',
             'label': {
                 'text': _('Post'),
-                'description': _('We can only send access codes to the registered household address')
+                'description': post_description
             },
             'value': 'post'
         }

--- a/app/templates/request-code-select-how-to-receive.html
+++ b/app/templates/request-code-select-how-to-receive.html
@@ -21,9 +21,17 @@
 {%- endif -%}
 
 {%- if case_type == 'CE' -%}
-    {%- set post_description = _('We can only send access codes to the registered address') -%}
+    {%- if (individual == True) -%}
+        {%- set post_description = _('An unbranded envelope can be addressed to you at the registered address') -%}
+    {%- else -%}
+        {%- set post_description = _('We can only send access codes to the registered address') -%}
+    {%- endif -%}
 {%- else -%}
-    {%- set post_description = _('We can only send access codes to the registered household address') -%}
+    {%- if (individual == True) -%}
+        {%- set post_description = _('An unbranded envelope can be addressed to you at the registered household address') -%}
+    {%- else -%}
+        {%- set post_description = _('We can only send access codes to the registered household address') -%}
+    {%- endif -%}
 {%- endif -%}
 
 {%- set form_options = [

--- a/app/templates/request-questionnaire-individual.html
+++ b/app/templates/request-questionnaire-individual.html
@@ -30,7 +30,7 @@
 
     {{
         onsButton({
-            'text': _('Continue'),
+            'text': _('Start'),
             'classes': 'u-mb-m u-mt-l',
             'icon': {
                 'iconType': 'chevron',

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1129,8 +1129,12 @@ class RHTestCase(AioHTTPTestCase):
         self.content_request_code_select_how_to_receive_option_post_en = 'Post'
         self.content_request_code_select_how_to_receive_option_post_hint_en = \
             'We can only send access codes to the registered household address'
+        self.content_request_code_select_how_to_receive_option_post_hint_individual_en = \
+            'An unbranded envelope can be addressed to you at the registered household address'
         self.content_request_code_select_how_to_receive_option_post_hint_ce_en = \
             'We can only send access codes to the registered address'
+        self.content_request_code_select_how_to_receive_option_post_hint_ce_individual_en = \
+            'An unbranded envelope can be addressed to you at the registered address'
 
         self.content_request_code_select_how_to_receive_individual_response_question_cy = \
             "Angen ateb ar wahân i aelodau eich cartref?"
@@ -1142,8 +1146,14 @@ class RHTestCase(AioHTTPTestCase):
         self.content_request_code_select_how_to_receive_option_post_hint_cy = \
             "Dim ond i gyfeiriad cofrestredig y cartref y gallwn anfon codau mynediad"
         # TODO Add Welsh Translation
+        self.content_request_code_select_how_to_receive_option_post_hint_individual_cy = \
+            'An unbranded envelope can be addressed to you at the registered household address'
+        # TODO Add Welsh Translation
         self.content_request_code_select_how_to_receive_option_post_hint_ce_cy = \
             "We can only send access codes to the registered address"
+        # TODO Add Welsh Translation
+        self.content_request_code_select_how_to_receive_option_post_hint_ce_individual_cy = \
+            'An unbranded envelope can be addressed to you at the registered address'
 
         self.content_request_code_select_how_to_receive_household_page_title_en = \
             '<title>Select how to receive household access code - Census 2021</title>'

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1127,6 +1127,10 @@ class RHTestCase(AioHTTPTestCase):
         self.content_request_code_select_how_to_receive_secondary_en = 'Select how to send access code'
         self.content_request_code_select_how_to_receive_option_text_en = 'Text message'
         self.content_request_code_select_how_to_receive_option_post_en = 'Post'
+        self.content_request_code_select_how_to_receive_option_post_hint_en = \
+            'We can only send access codes to the registered household address'
+        self.content_request_code_select_how_to_receive_option_post_hint_ce_en = \
+            'We can only send access codes to the registered address'
 
         self.content_request_code_select_how_to_receive_individual_response_question_cy = \
             "Angen ateb ar wahân i aelodau eich cartref?"
@@ -1135,6 +1139,11 @@ class RHTestCase(AioHTTPTestCase):
         self.content_request_code_select_how_to_receive_secondary_cy = "Dewiswch sut i anfon y cod mynediad"
         self.content_request_code_select_how_to_receive_option_text_cy = "Neges destun"
         self.content_request_code_select_how_to_receive_option_post_cy = "Post"
+        self.content_request_code_select_how_to_receive_option_post_hint_cy = \
+            "Dim ond i gyfeiriad cofrestredig y cartref y gallwn anfon codau mynediad"
+        # TODO Add Welsh Translation
+        self.content_request_code_select_how_to_receive_option_post_hint_ce_cy = \
+            "We can only send access codes to the registered address"
 
         self.content_request_code_select_how_to_receive_household_page_title_en = \
             '<title>Select how to receive household access code - Census 2021</title>'

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -199,9 +199,17 @@ class TestHelpers(RHTestCase):
             self.assertIn(self.content_request_code_select_how_to_receive_option_text_cy, contents)
             self.assertIn(self.content_request_code_select_how_to_receive_option_post_cy, contents)
             if address_type == 'CE':
-                self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_ce_cy, contents)
+                if user_type == 'individual':
+                    self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_ce_individual_cy,
+                                  contents)
+                else:
+                    self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_ce_cy, contents)
             else:
-                self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_cy, contents)
+                if user_type == 'individual':
+                    self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_individual_cy,
+                                  contents)
+                else:
+                    self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_cy, contents)
         else:
             if check_error:
                 self.assertIn(self.content_request_code_select_how_to_receive_error_en, contents)
@@ -229,9 +237,17 @@ class TestHelpers(RHTestCase):
             self.assertIn(self.content_request_code_select_how_to_receive_option_text_en, contents)
             self.assertIn(self.content_request_code_select_how_to_receive_option_post_en, contents)
             if address_type == 'CE':
-                self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_ce_en, contents)
+                if user_type == 'individual':
+                    self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_ce_individual_en,
+                                  contents)
+                else:
+                    self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_ce_en, contents)
             else:
-                self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_en, contents)
+                if user_type == 'individual':
+                    self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_individual_en,
+                                  contents)
+                else:
+                    self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_en, contents)
 
     def check_text_resident_or_manager(self, display_region, contents, check_error=False):
         if display_region == 'cy':

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -171,7 +171,7 @@ class TestHelpers(RHTestCase):
                 self.assertNotIn(self.content_common_ce_room_number_change_link_en, contents)
                 self.assertNotIn(self.content_common_ce_room_number_add_link_en, contents)
 
-    def check_text_select_how_to_receive(self, display_region, contents, user_type, check_error=False):
+    def check_text_select_how_to_receive(self, display_region, contents, user_type, address_type, check_error=False):
         if display_region == 'cy':
             if check_error:
                 self.assertIn(self.content_request_code_select_how_to_receive_error_cy, contents)
@@ -198,6 +198,10 @@ class TestHelpers(RHTestCase):
             self.assertIn(self.content_request_code_select_how_to_receive_secondary_cy, contents)
             self.assertIn(self.content_request_code_select_how_to_receive_option_text_cy, contents)
             self.assertIn(self.content_request_code_select_how_to_receive_option_post_cy, contents)
+            if address_type == 'CE':
+                self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_ce_cy, contents)
+            else:
+                self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_cy, contents)
         else:
             if check_error:
                 self.assertIn(self.content_request_code_select_how_to_receive_error_en, contents)
@@ -224,6 +228,10 @@ class TestHelpers(RHTestCase):
             self.assertIn(self.content_request_code_select_how_to_receive_secondary_en, contents)
             self.assertIn(self.content_request_code_select_how_to_receive_option_text_en, contents)
             self.assertIn(self.content_request_code_select_how_to_receive_option_post_en, contents)
+            if address_type == 'CE':
+                self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_ce_en, contents)
+            else:
+                self.assertIn(self.content_request_code_select_how_to_receive_option_post_hint_en, contents)
 
     def check_text_resident_or_manager(self, display_region, contents, check_error=False):
         if display_region == 'cy':
@@ -734,7 +742,7 @@ class TestHelpers(RHTestCase):
                 self.assertIn(self.content_request_code_household_title_en, contents)
 
     async def check_post_confirm_address_input_yes_code_individual(self, url, display_region,
-                                                                   case_by_uprn_return, user_type):
+                                                                   case_by_uprn_return, user_type, address_type):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.utils.RHService.get_case_by_uprn') as mocked_get_case_by_uprn:
 
@@ -747,7 +755,7 @@ class TestHelpers(RHTestCase):
             self.assertIn(self.get_logo(display_region), contents)
             if not display_region == 'ni':
                 self.assertIn(self.build_translation_link('select-how-to-receive', display_region), contents)
-            self.check_text_select_how_to_receive(display_region, contents, user_type)
+            self.check_text_select_how_to_receive(display_region, contents, user_type, address_type)
 
     async def check_post_confirm_address_input_yes_code_new_case(self, url, display_region,
                                                                  create_case_return):
@@ -779,7 +787,7 @@ class TestHelpers(RHTestCase):
                 self.assertIn(self.content_request_code_household_title_en, contents)
 
     async def check_post_confirm_address_input_yes_code_new_case_individual(
-            self, url, display_region, create_case_return, user_type):
+            self, url, display_region, create_case_return, user_type, address_type):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
                 'app.utils.RHService.post_case_create') as mocked_post_case_create, aioresponses(
             passthrough=[str(self.server._root)]
@@ -801,7 +809,7 @@ class TestHelpers(RHTestCase):
             self.assertIn(self.get_logo(display_region), contents)
             if not display_region == 'ni':
                 self.assertIn(self.build_translation_link('select-how-to-receive', display_region), contents)
-            self.check_text_select_how_to_receive(display_region, contents, user_type)
+            self.check_text_select_how_to_receive(display_region, contents, user_type, address_type)
 
     async def check_post_confirm_address_input_yes_form(self, url, display_region, case_by_uprn_return):
         with self.assertLogs('respondent-home', 'INFO') as cm, mock.patch(
@@ -1137,7 +1145,7 @@ class TestHelpers(RHTestCase):
             self.assertIn(self.get_logo(display_region), contents)
             self.check_text_error_500(display_region, contents)
 
-    async def check_post_household_information_code(self, url, display_region, user_type):
+    async def check_post_household_information_code(self, url, display_region, user_type, address_type):
         with self.assertLogs('respondent-home', 'INFO') as cm:
             response = await self.client.request('POST', url)
             self.assertLogEvent(cm, self.build_url_log_entry('household', display_region, 'POST', True))
@@ -1146,7 +1154,7 @@ class TestHelpers(RHTestCase):
             self.assertIn(self.get_logo(display_region), contents)
             if not display_region == 'ni':
                 self.assertIn(self.build_translation_link('select-how-to-receive', display_region), contents)
-            self.check_text_select_how_to_receive(display_region, contents, user_type)
+            self.check_text_select_how_to_receive(display_region, contents, user_type, address_type)
 
     async def check_post_household_information_form(self, url, display_region):
         with self.assertLogs('respondent-home', 'INFO') as cm:
@@ -1250,7 +1258,7 @@ class TestHelpers(RHTestCase):
             if not display_region == 'ni':
                 self.assertIn(self.build_translation_link('access-code/select-how-to-receive', display_region, False),
                               contents)
-            self.check_text_select_how_to_receive(display_region, contents, 'manager')
+            self.check_text_select_how_to_receive(display_region, contents, 'manager', 'CE')
 
     async def check_post_select_how_to_receive_input_sms(self, url, display_region, override_sub_user_journey=None):
         with self.assertLogs('respondent-home', 'INFO') as cm:
@@ -1302,7 +1310,7 @@ class TestHelpers(RHTestCase):
                 self.assertIn(self.content_request_common_enter_name_title_en, contents)
 
     async def check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self, url, display_region, data, user_type):
+            self, url, display_region, data, user_type, address_type):
         with self.assertLogs('respondent-home', 'INFO') as cm:
 
             response = await self.client.request('POST', url, data=data)
@@ -1312,7 +1320,7 @@ class TestHelpers(RHTestCase):
             self.assertIn(self.get_logo(display_region), contents)
             if not display_region == 'ni':
                 self.assertIn(self.build_translation_link('select-how-to-receive', display_region), contents)
-            self.check_text_select_how_to_receive(display_region, contents, user_type, check_error=True)
+            self.check_text_select_how_to_receive(display_region, contents, user_type, address_type, check_error=True)
 
     async def check_post_resident_or_manager(self, url, display_region, data, user_type):
         with self.assertLogs('respondent-home', 'INFO') as cm:
@@ -1325,7 +1333,7 @@ class TestHelpers(RHTestCase):
             self.assertIn(self.get_logo(display_region), contents)
             if not display_region == 'ni':
                 self.assertIn(self.build_translation_link('select-how-to-receive', display_region), contents)
-            self.check_text_select_how_to_receive(display_region, contents, user_type)
+            self.check_text_select_how_to_receive(display_region, contents, user_type, 'CE')
 
     async def check_post_resident_or_manager_code_manager_ni(self, url, data):
         with self.assertLogs('respondent-home', 'INFO') as cm:
@@ -2116,7 +2124,7 @@ class TestHelpers(RHTestCase):
                         self.assertIn(self.content_request_code_sent_by_post_page_title_household_en, contents)
                         self.assertIn(self.content_request_code_sent_post_secondary_household_en, contents)
 
-    async def check_post_confirm_send_by_post_input_no(self, url, display_region, user_type):
+    async def check_post_confirm_send_by_post_input_no(self, url, display_region, user_type, address_type):
         with self.assertLogs('respondent-home', 'INFO') as cm:
 
             response = await self.client.request('POST', url, data=self.request_common_confirm_send_by_post_data_no)
@@ -2128,7 +2136,7 @@ class TestHelpers(RHTestCase):
             self.assertIn(self.get_logo(display_region), contents)
             if not display_region == 'ni':
                 self.assertIn(self.build_translation_link('select-how-to-receive', display_region), contents)
-            self.check_text_select_how_to_receive(display_region, contents, user_type, check_error=False)
+            self.check_text_select_how_to_receive(display_region, contents, user_type, address_type, check_error=False)
 
     async def check_post_confirm_send_by_post_input_no_form(self, url, display_region):
         with self.assertLogs('respondent-home', 'INFO') as cm:
@@ -2320,7 +2328,7 @@ class TestHelpers(RHTestCase):
                 self.assertIn(self.content_request_individual_questionnaire_title_en, contents)
                 self.assertIn(self.content_request_individual_questionnaire_secondary_en, contents)
 
-    async def check_post_request_individual_code_journey_switch(self, url, display_region):
+    async def check_post_request_individual_code_journey_switch(self, url, display_region, address_type):
         with self.assertLogs('respondent-home', 'INFO') as cm:
             response = await self.client.request('POST', url)
             self.assertLogEvent(cm, self.build_url_log_entry('individual', display_region, 'POST', True))
@@ -2332,7 +2340,7 @@ class TestHelpers(RHTestCase):
             self.assertIn(self.get_logo(display_region), contents)
             if not display_region == 'ni':
                 self.assertIn(self.build_translation_link('select-how-to-receive', display_region, True), contents)
-            self.check_text_select_how_to_receive(display_region, contents, 'individual')
+            self.check_text_select_how_to_receive(display_region, contents, 'individual', address_type)
 
     async def add_room_number(self, url_get, url_post, display_region, user_type, return_page, no_data=False,
                               data_over_length=False, check_for_value=False):

--- a/tests/unit/test_request_handlers_access_code.py
+++ b/tests/unit/test_request_handlers_access_code.py
@@ -16,7 +16,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -31,7 +31,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -46,7 +46,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'household')
@@ -61,7 +61,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'household')
@@ -76,7 +76,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -91,7 +91,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -106,7 +106,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'household')
@@ -121,7 +121,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'household')
@@ -246,7 +246,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'individual')
@@ -259,7 +259,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'individual')
@@ -272,7 +272,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'individual')
@@ -285,7 +285,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'individual')
@@ -568,7 +568,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_new_case_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
 
     @unittest_run_loop
     async def test_get_request_access_code_confirm_address_new_case_ce_r_ew_w(self):
@@ -576,7 +576,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_new_case_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
 
     @unittest_run_loop
     async def test_get_request_access_code_confirm_address_new_case_ce_r_cy(self):
@@ -584,7 +584,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_new_case_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
 
     @unittest_run_loop
     async def test_get_request_access_code_confirm_address_new_case_ce_r_ni(self):
@@ -592,7 +592,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_new_case_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
 
     @unittest_run_loop
     async def test_get_request_access_code_confirm_address_new_case_error_ew(self):
@@ -796,9 +796,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 'household')
+            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty,
+            'household', 'HH')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_hh_ew_w(self):
@@ -808,9 +809,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 'household')
+            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty,
+            'household', 'HH')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_hh_cy(self):
@@ -820,9 +822,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_cy, 'cy', self.common_form_data_empty, 'household')
+            self.post_request_access_code_select_how_to_receive_cy, 'cy', self.common_form_data_empty,
+            'household', 'HH')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_hh_ni(self):
@@ -832,9 +835,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_ni, 'ni', self.common_form_data_empty, 'household')
+            self.post_request_access_code_select_how_to_receive_ni, 'ni', self.common_form_data_empty,
+            'household', 'HH')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_spg_ew_e(self):
@@ -844,9 +848,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 'household')
+            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty,
+            'household', 'SPG')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_spg_ew_w(self):
@@ -856,9 +861,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 'household')
+            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty,
+            'household', 'SPG')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_spg_cy(self):
@@ -868,9 +874,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_cy, 'cy', self.common_form_data_empty, 'household')
+            self.post_request_access_code_select_how_to_receive_cy, 'cy', self.common_form_data_empty,
+            'household', 'SPG')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_spg_ni(self):
@@ -880,9 +887,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_ni, 'ni', self.common_form_data_empty, 'household')
+            self.post_request_access_code_select_how_to_receive_ni, 'ni', self.common_form_data_empty,
+            'household', 'SPG')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_select_manager_ce_m_ew_e(self):
@@ -895,7 +903,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.post_request_access_code_resident_or_manager_en, 'en',
             self.common_resident_or_manager_input_manager, 'manager')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 'manager')
+            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 'manager', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_select_manager_ce_m_ew_w(self):
@@ -908,7 +916,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.post_request_access_code_resident_or_manager_en, 'en',
             self.common_resident_or_manager_input_manager, 'manager')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 'manager')
+            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 'manager', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_select_manager_ce_m_cy(self):
@@ -921,7 +929,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.post_request_access_code_resident_or_manager_cy, 'cy',
             self.common_resident_or_manager_input_manager, 'manager')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_cy, 'cy', self.common_form_data_empty, 'manager')
+            self.post_request_access_code_select_how_to_receive_cy, 'cy', self.common_form_data_empty, 'manager', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_select_resident_ce_m_ew_e(self):
@@ -934,7 +942,8 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.post_request_access_code_resident_or_manager_en, 'en',
             self.common_resident_or_manager_input_resident, 'individual')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 'individual')
+            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty,
+            'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_select_resident_ce_m_ew_w(self):
@@ -947,7 +956,8 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.post_request_access_code_resident_or_manager_en, 'en',
             self.common_resident_or_manager_input_resident, 'individual')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 'individual')
+            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty,
+            'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_select_resident_ce_m_cy(self):
@@ -960,7 +970,8 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.post_request_access_code_resident_or_manager_cy, 'cy',
             self.common_resident_or_manager_input_resident, 'individual')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_cy, 'cy', self.common_form_data_empty, 'individual')
+            self.post_request_access_code_select_how_to_receive_cy, 'cy', self.common_form_data_empty,
+            'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_select_resident_ce_m_ni(self):
@@ -973,7 +984,8 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.post_request_access_code_resident_or_manager_ni, 'ni',
             self.common_resident_or_manager_input_resident, 'individual')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_ni, 'ni', self.common_form_data_empty, 'individual')
+            self.post_request_access_code_select_how_to_receive_ni, 'ni', self.common_form_data_empty,
+            'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_ce_r_ew_e(self):
@@ -981,9 +993,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 'individual')
+            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty,
+            'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_ce_r_ew_w(self):
@@ -991,9 +1004,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 'individual')
+            self.post_request_access_code_select_how_to_receive_en, 'en', self.common_form_data_empty,
+            'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_ce_r_cy(self):
@@ -1001,9 +1015,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_cy, 'cy', self.common_form_data_empty, 'individual')
+            self.post_request_access_code_select_how_to_receive_cy, 'cy', self.common_form_data_empty,
+            'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_no_selection_ce_r_ni(self):
@@ -1011,9 +1026,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_access_code_select_how_to_receive_ni, 'ni', self.common_form_data_empty, 'individual')
+            self.post_request_access_code_select_how_to_receive_ni, 'ni', self.common_form_data_empty,
+            'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_hh_ew_e(self):
@@ -1023,10 +1039,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_en, 'en',
-            self.request_code_select_how_to_receive_data_invalid, 'household')
+            self.request_code_select_how_to_receive_data_invalid, 'household', 'HH')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_hh_ew_w(self):
@@ -1036,10 +1052,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_en, 'en',
-            self.request_code_select_how_to_receive_data_invalid, 'household')
+            self.request_code_select_how_to_receive_data_invalid, 'household', 'HH')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_hh_cy(self):
@@ -1049,10 +1065,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_cy, 'cy',
-            self.request_code_select_how_to_receive_data_invalid, 'household')
+            self.request_code_select_how_to_receive_data_invalid, 'household', 'HH')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_hh_ni(self):
@@ -1062,10 +1078,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_ni, 'ni',
-            self.request_code_select_how_to_receive_data_invalid, 'household')
+            self.request_code_select_how_to_receive_data_invalid, 'household', 'HH')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_spg_ew_e(self):
@@ -1075,10 +1091,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_en, 'en',
-            self.request_code_select_how_to_receive_data_invalid, 'household')
+            self.request_code_select_how_to_receive_data_invalid, 'household', 'SPG')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_spg_ew_w(self):
@@ -1088,10 +1104,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_en, 'en',
-            self.request_code_select_how_to_receive_data_invalid, 'household')
+            self.request_code_select_how_to_receive_data_invalid, 'household', 'SPG')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_spg_cy(self):
@@ -1101,10 +1117,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_cy, 'cy',
-            self.request_code_select_how_to_receive_data_invalid, 'household')
+            self.request_code_select_how_to_receive_data_invalid, 'household', 'SPG')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_spg_ni(self):
@@ -1114,10 +1130,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_ni, 'ni',
-            self.request_code_select_how_to_receive_data_invalid, 'household')
+            self.request_code_select_how_to_receive_data_invalid, 'household', 'SPG')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_select_manager_ce_m_ew_e(self):
@@ -1131,7 +1147,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.common_resident_or_manager_input_manager, 'manager')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_en, 'en',
-            self.request_code_select_how_to_receive_data_invalid, 'manager')
+            self.request_code_select_how_to_receive_data_invalid, 'manager', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_select_manager_ce_m_ew_w(self):
@@ -1145,7 +1161,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.common_resident_or_manager_input_manager, 'manager')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_en, 'en',
-            self.request_code_select_how_to_receive_data_invalid, 'manager')
+            self.request_code_select_how_to_receive_data_invalid, 'manager', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_select_manager_ce_m_cy(self):
@@ -1159,7 +1175,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.common_resident_or_manager_input_manager, 'manager')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_cy, 'cy',
-            self.request_code_select_how_to_receive_data_invalid, 'manager')
+            self.request_code_select_how_to_receive_data_invalid, 'manager', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_select_resident_ce_m_ew_e(self):
@@ -1173,7 +1189,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.common_resident_or_manager_input_resident, 'individual')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_en, 'en',
-            self.request_code_select_how_to_receive_data_invalid, 'individual')
+            self.request_code_select_how_to_receive_data_invalid, 'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_select_resident_ce_m_ew_w(self):
@@ -1187,7 +1203,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.common_resident_or_manager_input_resident, 'individual')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_en, 'en',
-            self.request_code_select_how_to_receive_data_invalid, 'individual')
+            self.request_code_select_how_to_receive_data_invalid, 'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_select_resident_ce_m_cy(self):
@@ -1201,7 +1217,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.common_resident_or_manager_input_resident, 'individual')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_cy, 'cy',
-            self.request_code_select_how_to_receive_data_invalid, 'individual')
+            self.request_code_select_how_to_receive_data_invalid, 'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_select_resident_ce_m_ni(self):
@@ -1215,7 +1231,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.common_resident_or_manager_input_resident, 'individual')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_ni, 'ni',
-            self.request_code_select_how_to_receive_data_invalid, 'individual')
+            self.request_code_select_how_to_receive_data_invalid, 'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_ce_r_ew_e(self):
@@ -1223,10 +1239,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_en, 'en',
-            self.request_code_select_how_to_receive_data_invalid, 'individual')
+            self.request_code_select_how_to_receive_data_invalid, 'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_ce_r_ew_w(self):
@@ -1234,10 +1250,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_en, 'en',
-            self.request_code_select_how_to_receive_data_invalid, 'individual')
+            self.request_code_select_how_to_receive_data_invalid, 'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_ce_r_cy(self):
@@ -1245,10 +1261,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_cy, 'cy',
-            self.request_code_select_how_to_receive_data_invalid, 'individual')
+            self.request_code_select_how_to_receive_data_invalid, 'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_select_how_to_receive_input_invalid_ce_r_ni(self):
@@ -1256,10 +1272,10 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_access_code_select_how_to_receive_ni, 'ni',
-            self.request_code_select_how_to_receive_data_invalid, 'individual')
+            self.request_code_select_how_to_receive_data_invalid, 'individual', 'CE')
 
     @unittest_run_loop
     async def test_post_request_access_code_enter_mobile_invalid_hh_ew_e(self):
@@ -1269,7 +1285,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile_input_invalid(self.post_request_access_code_enter_mobile_en, 'en')
@@ -1282,7 +1298,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile_input_invalid(self.post_request_access_code_enter_mobile_en, 'en')
@@ -1295,7 +1311,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile_input_invalid(self.post_request_access_code_enter_mobile_cy, 'cy')
@@ -1308,7 +1324,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile_input_invalid(self.post_request_access_code_enter_mobile_ni, 'ni')
@@ -1321,7 +1337,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_enter_mobile_input_invalid(self.post_request_access_code_enter_mobile_en, 'en')
 
     @unittest_run_loop
@@ -1332,7 +1348,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_enter_mobile_input_invalid(self.post_request_access_code_enter_mobile_en, 'en')
 
     @unittest_run_loop
@@ -1343,7 +1359,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_enter_mobile_input_invalid(self.post_request_access_code_enter_mobile_cy, 'cy')
 
     @unittest_run_loop
@@ -1354,7 +1370,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_enter_mobile_input_invalid(self.post_request_access_code_enter_mobile_ni, 'ni')
 
     @unittest_run_loop
@@ -1399,7 +1415,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile_input_invalid(self.post_request_access_code_enter_mobile_en, 'en')
@@ -1410,7 +1426,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile_input_invalid(self.post_request_access_code_enter_mobile_en, 'en')
@@ -1421,7 +1437,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile_input_invalid(self.post_request_access_code_enter_mobile_cy, 'cy')
@@ -1432,7 +1448,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile_input_invalid(self.post_request_access_code_enter_mobile_ni, 'ni')
@@ -1445,7 +1461,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile_input_empty(self.post_request_access_code_enter_mobile_en, 'en')
@@ -1458,7 +1474,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile_input_empty(self.post_request_access_code_enter_mobile_en, 'en')
@@ -1471,7 +1487,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile_input_empty(self.post_request_access_code_enter_mobile_cy, 'cy')
@@ -1484,7 +1500,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile_input_empty(self.post_request_access_code_enter_mobile_ni, 'ni')
@@ -1497,7 +1513,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_enter_mobile_input_empty(self.post_request_access_code_enter_mobile_en, 'en')
 
     @unittest_run_loop
@@ -1508,7 +1524,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_enter_mobile_input_empty(self.post_request_access_code_enter_mobile_en, 'en')
 
     @unittest_run_loop
@@ -1519,7 +1535,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_enter_mobile_input_empty(self.post_request_access_code_enter_mobile_cy, 'cy')
 
     @unittest_run_loop
@@ -1530,7 +1546,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_enter_mobile_input_empty(self.post_request_access_code_enter_mobile_ni, 'ni')
 
     @unittest_run_loop
@@ -1575,7 +1591,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile_input_empty(self.post_request_access_code_enter_mobile_en, 'en')
@@ -1586,7 +1602,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile_input_empty(self.post_request_access_code_enter_mobile_en, 'en')
@@ -1597,7 +1613,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile_input_empty(self.post_request_access_code_enter_mobile_cy, 'cy')
@@ -1608,7 +1624,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile_input_empty(self.post_request_access_code_enter_mobile_ni, 'ni')
@@ -1621,7 +1637,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -1635,7 +1651,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -1649,7 +1665,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'household')
@@ -1663,7 +1679,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'household')
@@ -1677,7 +1693,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -1691,7 +1707,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -1705,7 +1721,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'household')
@@ -1719,7 +1735,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'household')
@@ -1776,7 +1792,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'individual')
@@ -1788,7 +1804,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'individual')
@@ -1800,7 +1816,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'individual')
@@ -1812,7 +1828,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'individual')
@@ -1826,7 +1842,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -1842,7 +1858,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -1858,7 +1874,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'household')
@@ -1874,7 +1890,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'household')
@@ -1890,7 +1906,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -1906,7 +1922,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -1922,7 +1938,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'household')
@@ -1938,7 +1954,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'household')
@@ -2003,7 +2019,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'individual')
@@ -2017,7 +2033,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'individual')
@@ -2031,7 +2047,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'individual')
@@ -2045,7 +2061,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'individual')
@@ -2061,7 +2077,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2077,7 +2093,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2093,7 +2109,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'household')
@@ -2109,7 +2125,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'household')
@@ -2125,7 +2141,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2141,7 +2157,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2157,7 +2173,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'household')
@@ -2173,7 +2189,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'household')
@@ -2238,7 +2254,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'individual')
@@ -2252,7 +2268,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'individual')
@@ -2266,7 +2282,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'individual')
@@ -2280,7 +2296,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'individual')
@@ -2296,7 +2312,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2311,7 +2327,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2326,7 +2342,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'household')
@@ -2341,7 +2357,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'household')
@@ -2356,7 +2372,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2371,7 +2387,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2386,7 +2402,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'household')
@@ -2401,7 +2417,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'household')
@@ -2526,7 +2542,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'individual')
@@ -2539,7 +2555,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'individual')
@@ -2552,7 +2568,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'individual')
@@ -2565,7 +2581,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'individual')
@@ -2580,7 +2596,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2595,7 +2611,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2610,7 +2626,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'household')
@@ -2625,7 +2641,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'household')
@@ -2640,7 +2656,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2655,7 +2671,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2670,7 +2686,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'household')
@@ -2685,7 +2701,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'household')
@@ -2810,7 +2826,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'individual')
@@ -2823,7 +2839,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'individual')
@@ -2836,7 +2852,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'individual')
@@ -2849,7 +2865,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'individual')
@@ -2864,7 +2880,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2879,7 +2895,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2894,7 +2910,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'household')
@@ -2909,7 +2925,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'household')
@@ -2924,7 +2940,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2939,7 +2955,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'household')
@@ -2954,7 +2970,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'household')
@@ -2969,7 +2985,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'household')
@@ -3096,7 +3112,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'individual')
@@ -3109,7 +3125,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_en, 'en', 'individual')
@@ -3122,7 +3138,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_cy, 'cy', 'individual')
@@ -3135,7 +3151,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_access_code_enter_mobile_ni, 'ni', 'individual')
@@ -3150,7 +3166,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3164,7 +3180,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3178,7 +3194,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
@@ -3192,7 +3208,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
@@ -3206,7 +3222,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3220,7 +3236,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3234,7 +3250,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
@@ -3248,7 +3264,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
@@ -3365,7 +3381,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3377,7 +3393,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3389,7 +3405,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
@@ -3401,7 +3417,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
@@ -3415,7 +3431,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3429,7 +3445,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3443,7 +3459,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
@@ -3457,7 +3473,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
@@ -3471,7 +3487,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3485,7 +3501,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3499,7 +3515,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
@@ -3513,7 +3529,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
@@ -3630,7 +3646,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3642,7 +3658,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3654,7 +3670,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
@@ -3666,7 +3682,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
@@ -3680,7 +3696,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3694,7 +3710,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3708,7 +3724,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
@@ -3722,7 +3738,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
@@ -3736,7 +3752,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3750,7 +3766,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3764,7 +3780,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
@@ -3778,7 +3794,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
@@ -3895,7 +3911,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3907,7 +3923,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
@@ -3919,7 +3935,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
@@ -3931,7 +3947,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
@@ -3945,7 +3961,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'HH')
@@ -3960,7 +3976,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'HH')
@@ -3975,7 +3991,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'household', 'HH')
@@ -3990,7 +4006,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'household', 'HH')
@@ -4005,7 +4021,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'SPG')
@@ -4021,7 +4037,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'SPG')
@@ -4037,7 +4053,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'household', 'SPG')
@@ -4053,7 +4069,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'household', 'SPG')
@@ -4183,7 +4199,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
@@ -4197,7 +4213,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
@@ -4211,7 +4227,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'individual', 'CE')
@@ -4225,7 +4241,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'individual', 'CE')
@@ -4241,7 +4257,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'HH')
@@ -4257,7 +4273,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'HH')
@@ -4273,7 +4289,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'household', 'HH')
@@ -4289,7 +4305,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'household', 'HH')
@@ -4305,7 +4321,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'SPG')
@@ -4321,7 +4337,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'SPG')
@@ -4337,7 +4353,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'household', 'SPG')
@@ -4353,7 +4369,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'household', 'SPG')
@@ -4486,7 +4502,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
@@ -4500,7 +4516,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
@@ -4514,7 +4530,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'individual', 'CE')
@@ -4528,7 +4544,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'individual', 'CE')
@@ -4544,12 +4560,12 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'HH')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_en, 'en', 'household')
+            self.post_request_access_code_confirm_send_by_post_en, 'en', 'household', 'HH')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_hh_ew_w(self):
@@ -4559,12 +4575,12 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'HH')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_en, 'en', 'household')
+            self.post_request_access_code_confirm_send_by_post_en, 'en', 'household', 'HH')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_hh_cy(self):
@@ -4574,12 +4590,12 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'household', 'HH')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_cy, 'cy', 'household')
+            self.post_request_access_code_confirm_send_by_post_cy, 'cy', 'household', 'HH')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_hh_ni(self):
@@ -4589,12 +4605,12 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'household', 'HH')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_ni, 'ni', 'household')
+            self.post_request_access_code_confirm_send_by_post_ni, 'ni', 'household', 'HH')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_spg_ew_e(self):
@@ -4604,12 +4620,12 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'SPG')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_en, 'en', 'household')
+            self.post_request_access_code_confirm_send_by_post_en, 'en', 'household', 'SPG')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_spg_ew_w(self):
@@ -4619,12 +4635,12 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'SPG')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_en, 'en', 'household')
+            self.post_request_access_code_confirm_send_by_post_en, 'en', 'household', 'SPG')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_spg_cy(self):
@@ -4634,12 +4650,12 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'household', 'SPG')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_cy, 'cy', 'household')
+            self.post_request_access_code_confirm_send_by_post_cy, 'cy', 'household', 'SPG')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_spg_ni(self):
@@ -4649,12 +4665,12 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'household', 'SPG')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_ni, 'ni', 'household')
+            self.post_request_access_code_confirm_send_by_post_ni, 'ni', 'household', 'SPG')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_select_manager_ce_m_ew_e(self):
@@ -4670,7 +4686,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'manager', 'CE')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_en, 'en', 'manager')
+            self.post_request_access_code_confirm_send_by_post_en, 'en', 'manager', 'CE')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_select_manager_ce_m_ew_w(self):
@@ -4686,7 +4702,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'manager', 'CE')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_en, 'en', 'manager')
+            self.post_request_access_code_confirm_send_by_post_en, 'en', 'manager', 'CE')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_select_manager_ce_m_cy(self):
@@ -4702,7 +4718,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'manager', 'CE')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_cy, 'cy', 'manager')
+            self.post_request_access_code_confirm_send_by_post_cy, 'cy', 'manager', 'CE')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_select_resident_ce_m_ew_e(self):
@@ -4718,7 +4734,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_en, 'en', 'individual')
+            self.post_request_access_code_confirm_send_by_post_en, 'en', 'individual', 'CE')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_select_resident_ce_m_ew_w(self):
@@ -4734,7 +4750,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_en, 'en', 'individual')
+            self.post_request_access_code_confirm_send_by_post_en, 'en', 'individual', 'CE')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_select_resident_ce_m_cy(self):
@@ -4750,7 +4766,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'individual', 'CE')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_cy, 'cy', 'individual')
+            self.post_request_access_code_confirm_send_by_post_cy, 'cy', 'individual', 'CE')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_select_resident_ce_m_ni(self):
@@ -4766,7 +4782,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'individual', 'CE')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_ni, 'ni', 'individual')
+            self.post_request_access_code_confirm_send_by_post_ni, 'ni', 'individual', 'CE')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_ce_r_ew_e(self):
@@ -4774,12 +4790,12 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_en, 'en', 'individual')
+            self.post_request_access_code_confirm_send_by_post_en, 'en', 'individual', 'CE')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_ce_r_ew_w(self):
@@ -4787,12 +4803,12 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_en, 'en', 'individual')
+            self.post_request_access_code_confirm_send_by_post_en, 'en', 'individual', 'CE')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_ce_r_cy(self):
@@ -4800,12 +4816,12 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'individual', 'CE')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_cy, 'cy', 'individual')
+            self.post_request_access_code_confirm_send_by_post_cy, 'cy', 'individual', 'CE')
 
     @unittest_run_loop
     async def test_request_access_code_post_confirm_send_by_post_option_no_ce_r_ni(self):
@@ -4813,12 +4829,12 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'individual', 'CE')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_access_code_confirm_send_by_post_ni, 'ni', 'individual')
+            self.post_request_access_code_confirm_send_by_post_ni, 'ni', 'individual', 'CE')
 
     @unittest_run_loop
     async def test_request_access_code_post_code_sent_post_hh_ew_e(self):
@@ -4828,7 +4844,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'HH')
@@ -4843,7 +4859,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'HH')
@@ -4858,7 +4874,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'household', 'HH')
@@ -4873,7 +4889,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'household', 'HH')
@@ -4888,7 +4904,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'SPG')
@@ -4903,7 +4919,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'SPG')
@@ -4918,7 +4934,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'household', 'SPG')
@@ -4933,7 +4949,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'household', 'SPG')
@@ -5058,7 +5074,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
@@ -5071,7 +5087,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
@@ -5084,7 +5100,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'individual', 'CE')
@@ -5097,7 +5113,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'individual', 'CE')
@@ -5112,7 +5128,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'HH')
@@ -5127,7 +5143,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'HH')
@@ -5142,7 +5158,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'household', 'HH')
@@ -5157,7 +5173,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'household', 'HH')
@@ -5172,7 +5188,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'SPG')
@@ -5187,7 +5203,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'SPG')
@@ -5202,7 +5218,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'household', 'SPG')
@@ -5217,7 +5233,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'household', 'SPG')
@@ -5342,7 +5358,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
@@ -5355,7 +5371,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
@@ -5368,7 +5384,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'individual', 'CE')
@@ -5381,7 +5397,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'individual', 'CE')
@@ -5396,7 +5412,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'HH')
@@ -5411,7 +5427,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'HH')
@@ -5426,7 +5442,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'household', 'HH')
@@ -5441,7 +5457,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'household', 'HH')
@@ -5456,7 +5472,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'SPG')
@@ -5471,7 +5487,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'SPG')
@@ -5486,7 +5502,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'household', 'SPG')
@@ -5501,7 +5517,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'household', 'SPG')
@@ -5630,7 +5646,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
@@ -5643,7 +5659,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
@@ -5656,7 +5672,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'individual', 'CE')
@@ -5669,7 +5685,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'individual', 'CE')
@@ -5684,7 +5700,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'HH')
@@ -5699,7 +5715,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'HH')
@@ -5714,7 +5730,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'household', 'HH')
@@ -5729,7 +5745,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'household', 'HH')
@@ -5744,7 +5760,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'SPG')
@@ -5759,7 +5775,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_en, 'en', 'household')
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'household', 'SPG')
@@ -5774,7 +5790,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_cy, 'cy', 'household')
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'household', 'SPG')
@@ -5789,7 +5805,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_post_household_information_code(
-            self.post_request_access_code_household_ni, 'ni', 'household')
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'household', 'SPG')
@@ -5921,7 +5937,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
@@ -5934,7 +5950,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
@@ -5947,7 +5963,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'individual', 'CE')
@@ -5960,7 +5976,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'individual', 'CE')
@@ -5975,7 +5991,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_get_request_individual_code(self.get_request_individual_code_en, 'en')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en', override_sub_user_journey='access-code')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual',
@@ -5992,7 +6008,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_get_request_individual_code(self.get_request_individual_code_en, 'en')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en', override_sub_user_journey='access-code')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual',
@@ -6009,7 +6025,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_get_request_individual_code(self.get_request_individual_code_cy, 'cy')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_cy, 'cy')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_cy, 'cy', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy', override_sub_user_journey='access-code')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_cy, 'cy', 'individual',
@@ -6026,7 +6042,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_get_request_individual_code(self.get_request_individual_code_ni, 'ni')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_ni, 'ni')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_ni, 'ni', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni', override_sub_user_journey='access-code')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_ni, 'ni', 'individual',
@@ -6043,7 +6059,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_get_request_individual_code(self.get_request_individual_code_en, 'en')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en', override_sub_user_journey='access-code')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual',
@@ -6060,7 +6076,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_get_request_individual_code(self.get_request_individual_code_en, 'en')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en', override_sub_user_journey='access-code')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual',
@@ -6077,7 +6093,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_get_request_individual_code(self.get_request_individual_code_cy, 'cy')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_cy, 'cy')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_cy, 'cy', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy', override_sub_user_journey='access-code')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_cy, 'cy', 'individual',
@@ -6094,7 +6110,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_get_request_individual_code(self.get_request_individual_code_ni, 'ni')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_ni, 'ni')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_ni, 'ni', 'SPG')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni', override_sub_user_journey='access-code')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_ni, 'ni', 'individual',
@@ -6111,7 +6127,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
         await self.check_get_request_individual_code(self.get_request_individual_code_en, 'en')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en', override_sub_user_journey='access-code')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH',
@@ -6128,7 +6144,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
         await self.check_get_request_individual_code(self.get_request_individual_code_en, 'en')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en', override_sub_user_journey='access-code')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH',
@@ -6145,7 +6161,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
         await self.check_get_request_individual_code(self.get_request_individual_code_cy, 'cy')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_cy, 'cy')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_cy, 'cy', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy', override_sub_user_journey='access-code')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_cy, 'cy', 'individual', 'HH',
@@ -6162,7 +6178,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
         await self.check_get_request_individual_code(self.get_request_individual_code_ni, 'ni')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_ni, 'ni')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_ni, 'ni', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni', override_sub_user_journey='access-code')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_ni, 'ni', 'individual', 'HH',
@@ -6179,7 +6195,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
         await self.check_get_request_individual_code(self.get_request_individual_code_en, 'en')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en', override_sub_user_journey='access-code')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'SPG',
@@ -6196,7 +6212,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
         await self.check_get_request_individual_code(self.get_request_individual_code_en, 'en')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_en, 'en', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en', override_sub_user_journey='access-code')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'SPG',
@@ -6213,7 +6229,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
         await self.check_get_request_individual_code(self.get_request_individual_code_cy, 'cy')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_cy, 'cy')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_cy, 'cy', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy', override_sub_user_journey='access-code')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_cy, 'cy', 'individual', 'SPG',
@@ -6230,7 +6246,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_confirm_address_input_yes_code(
             self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
         await self.check_get_request_individual_code(self.get_request_individual_code_ni, 'ni')
-        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_ni, 'ni')
+        await self.check_post_request_individual_code_journey_switch(self.post_request_individual_code_ni, 'ni', 'SPG')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni', override_sub_user_journey='access-code')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_ni, 'ni', 'individual', 'SPG',
@@ -6395,7 +6411,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
                                    self.post_request_access_code_enter_room_number_en,
                                    'en', 'individual', 'ConfirmAddress')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE',
@@ -6413,7 +6429,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
                                    self.post_request_access_code_enter_room_number_en,
                                    'en', 'individual', 'ConfirmAddress')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE',
@@ -6431,7 +6447,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
                                    self.post_request_access_code_enter_room_number_cy,
                                    'cy', 'individual', 'ConfirmAddress')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'individual', 'CE',
@@ -6449,7 +6465,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
                                    self.post_request_access_code_enter_room_number_ni,
                                    'ni', 'individual', 'ConfirmAddress')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'individual', 'CE',
@@ -6604,7 +6620,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
@@ -6621,7 +6637,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE')
@@ -6638,7 +6654,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'individual', 'CE')
@@ -6655,7 +6671,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'individual', 'CE')
@@ -6792,7 +6808,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE',
@@ -6810,7 +6826,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_en, 'en', 'individual', 'CE',
@@ -6828,7 +6844,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual')
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_cy, 'cy', 'individual', 'CE',
@@ -6846,7 +6862,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_access_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_access_code_enter_name_ni, 'ni', 'individual', 'CE',
@@ -6910,7 +6926,7 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.check_post_select_address(
             self.post_request_access_code_select_address_ni, 'ni', 'CE', self.ai_uprn_result_northern_ireland_ce)
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual')
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
 
     @unittest_run_loop
     async def test_get_request_access_code_address_not_in_northern_ireland_region_e_ni(self):

--- a/tests/unit/test_request_handlers_individual_code.py
+++ b/tests/unit/test_request_handlers_individual_code.py
@@ -29,7 +29,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual')
@@ -43,7 +44,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual')
@@ -57,7 +59,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_cy, 'cy', 'individual')
@@ -71,7 +74,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_ni, 'ni', 'individual')
@@ -277,7 +281,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 
+            'individual', 'HH')
 
     @unittest_run_loop
     async def test_get_request_individual_code_confirm_address_new_case_ew_w(self):
@@ -286,7 +291,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
 
     @unittest_run_loop
     async def test_get_request_individual_code_confirm_address_new_case_cy(self):
@@ -295,7 +301,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
 
     @unittest_run_loop
     async def test_get_request_individual_code_confirm_address_new_case_ni(self):
@@ -304,7 +311,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 
+            'individual', 'HH')
 
     @unittest_run_loop
     async def test_get_request_individual_code_confirm_address_new_case_error_ew(self):
@@ -442,9 +450,11 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_individual_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 'individual')
+            self.post_request_individual_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 
+            'individual', 'HH')
 
     @unittest_run_loop
     async def test_post_request_individual_code_select_how_to_receive_no_selection_ew_w(self):
@@ -453,9 +463,11 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_individual_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 'individual')
+            self.post_request_individual_code_select_how_to_receive_en, 'en', self.common_form_data_empty, 
+            'individual', 'HH')
 
     @unittest_run_loop
     async def test_post_request_individual_code_select_how_to_receive_no_selection_cy(self):
@@ -464,9 +476,11 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_individual_code_select_how_to_receive_cy, 'cy', self.common_form_data_empty, 'individual')
+            self.post_request_individual_code_select_how_to_receive_cy, 'cy', self.common_form_data_empty, 
+            'individual', 'HH')
 
     @unittest_run_loop
     async def test_post_request_individual_code_select_how_to_receive_no_selection_ni(self):
@@ -475,9 +489,11 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
-            self.post_request_individual_code_select_how_to_receive_ni, 'ni', self.common_form_data_empty, 'individual')
+            self.post_request_individual_code_select_how_to_receive_ni, 'ni', self.common_form_data_empty, 
+            'individual', 'HH')
 
     @unittest_run_loop
     async def test_post_request_individual_code_select_how_to_receive_input_invalid_ew_e(self):
@@ -486,10 +502,11 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_individual_code_select_how_to_receive_en, 'en',
-            self.request_code_select_how_to_receive_data_invalid, 'individual')
+            self.request_code_select_how_to_receive_data_invalid, 'individual', 'HH')
 
     @unittest_run_loop
     async def test_post_request_individual_code_select_how_to_receive_input_invalid_ew_w(self):
@@ -498,10 +515,11 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_individual_code_select_how_to_receive_en, 'en',
-            self.request_code_select_how_to_receive_data_invalid, 'individual')
+            self.request_code_select_how_to_receive_data_invalid, 'individual', 'HH')
 
     @unittest_run_loop
     async def test_post_request_individual_code_select_how_to_receive_input_invalid_cy(self):
@@ -510,10 +528,11 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy',
-            self.request_code_select_how_to_receive_data_invalid, 'individual')
+            self.request_code_select_how_to_receive_data_invalid, 'individual', 'HH')
 
     @unittest_run_loop
     async def test_post_request_individual_code_select_how_to_receive_input_invalid_ni(self):
@@ -522,10 +541,11 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_invalid_or_no_selection(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni',
-            self.request_code_select_how_to_receive_data_invalid, 'individual')
+            self.request_code_select_how_to_receive_data_invalid, 'individual', 'HH')
 
     @unittest_run_loop
     async def test_post_request_individual_code_enter_mobile_invalid_ew_e(self):
@@ -534,7 +554,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile_input_invalid(self.post_request_individual_code_enter_mobile_en, 'en')
@@ -546,7 +567,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile_input_invalid(self.post_request_individual_code_enter_mobile_en, 'en')
@@ -558,7 +580,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile_input_invalid(self.post_request_individual_code_enter_mobile_cy, 'cy')
@@ -570,7 +593,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile_input_invalid(self.post_request_individual_code_enter_mobile_ni, 'ni')
@@ -582,7 +606,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual')
@@ -596,7 +621,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual')
@@ -610,7 +636,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_cy, 'cy', 'individual')
@@ -624,7 +651,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_ni, 'ni', 'individual')
@@ -638,7 +666,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual')
@@ -653,7 +682,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual')
@@ -668,7 +698,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_cy, 'cy', 'individual')
@@ -683,7 +714,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_ni, 'ni', 'individual')
@@ -698,7 +730,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual')
@@ -713,7 +746,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual')
@@ -728,7 +762,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_cy, 'cy', 'individual')
@@ -743,7 +778,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_ni, 'ni', 'individual')
@@ -758,7 +794,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual')
@@ -772,7 +809,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual')
@@ -786,7 +824,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_cy, 'cy', 'individual')
@@ -800,7 +839,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_ni, 'ni', 'individual')
@@ -814,7 +854,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual')
@@ -828,7 +869,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual')
@@ -842,7 +884,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_cy, 'cy', 'individual')
@@ -856,7 +899,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_ni, 'ni', 'individual')
@@ -870,7 +914,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual')
@@ -884,7 +929,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_en, 'en', 'individual')
@@ -898,7 +944,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_cy, 'cy', 'individual')
@@ -912,7 +959,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_sms(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_mobile(self.post_request_individual_code_enter_mobile_ni, 'ni', 'individual')
@@ -926,7 +974,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_en, 'en',
@@ -939,7 +988,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_en, 'en',
@@ -952,7 +1002,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_cy, 'cy',
@@ -965,7 +1016,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_ni, 'ni',
@@ -978,7 +1030,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_en, 'en',
@@ -991,7 +1044,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_en, 'en',
@@ -1004,7 +1058,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_cy, 'cy',
@@ -1017,7 +1072,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_ni, 'ni',
@@ -1030,7 +1086,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_en, 'en',
@@ -1043,7 +1100,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_en, 'en',
@@ -1056,7 +1114,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_cy, 'cy',
@@ -1069,7 +1128,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_ni, 'ni',
@@ -1082,7 +1142,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH')
@@ -1097,7 +1158,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH')
@@ -1112,7 +1174,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_cy, 'cy', 'individual', 'HH')
@@ -1127,7 +1190,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_ni, 'ni', 'individual', 'HH')
@@ -1142,7 +1206,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH')
@@ -1157,7 +1222,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH')
@@ -1172,7 +1238,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_cy, 'cy', 'individual', 'HH')
@@ -1187,7 +1254,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_ni, 'ni', 'individual', 'HH')
@@ -1202,12 +1270,13 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_individual_code_confirm_send_by_post_en, 'en', 'individual')
+            self.post_request_individual_code_confirm_send_by_post_en, 'en', 'individual', 'HH')
 
     @unittest_run_loop
     async def test_request_individual_code_post_confirm_send_by_post_option_no_hh_ew_w(self):
@@ -1216,12 +1285,13 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_individual_code_confirm_send_by_post_en, 'en', 'individual')
+            self.post_request_individual_code_confirm_send_by_post_en, 'en', 'individual', 'HH')
 
     @unittest_run_loop
     async def test_request_individual_code_post_confirm_send_by_post_option_no_hh_cy(self):
@@ -1230,12 +1300,13 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_cy, 'cy', 'individual', 'HH')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_individual_code_confirm_send_by_post_cy, 'cy', 'individual')
+            self.post_request_individual_code_confirm_send_by_post_cy, 'cy', 'individual', 'HH')
 
     @unittest_run_loop
     async def test_request_individual_code_post_confirm_send_by_post_option_no_hh_ni(self):
@@ -1244,12 +1315,13 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_ni, 'ni', 'individual', 'HH')
         await self.check_post_confirm_send_by_post_input_no(
-            self.post_request_individual_code_confirm_send_by_post_ni, 'ni', 'individual')
+            self.post_request_individual_code_confirm_send_by_post_ni, 'ni', 'individual', 'HH')
 
     @unittest_run_loop
     async def test_request_individual_code_post_code_sent_post_hh_ew_e(self):
@@ -1258,7 +1330,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH')
@@ -1272,7 +1345,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH')
@@ -1286,7 +1360,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_cy, 'cy', 'individual', 'HH')
@@ -1300,10 +1375,12 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_ni, 'ni', 'individual', 'HH')
@@ -1317,7 +1394,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH')
@@ -1331,7 +1409,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH')
@@ -1345,7 +1424,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_cy, 'cy', 'individual', 'HH')
@@ -1359,7 +1439,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_ni, 'ni', 'individual', 'HH')
@@ -1373,7 +1454,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH')
@@ -1387,7 +1469,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH')
@@ -1401,7 +1484,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_cy, 'cy', 'individual', 'HH')
@@ -1415,7 +1499,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_ni, 'ni', 'individual', 'HH')
@@ -1429,7 +1514,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH')
@@ -1443,7 +1529,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
         await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_en, 'en')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_en, 'en', 'individual', 'HH')
@@ -1457,7 +1544,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
         await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w, 'individual')
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_cy, 'cy')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_cy, 'cy', 'individual', 'HH')
@@ -1471,7 +1559,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
         await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
         await self.check_post_select_how_to_receive_input_post(
             self.post_request_individual_code_select_how_to_receive_ni, 'ni')
         await self.check_post_enter_name(self.post_request_individual_code_enter_name_ni, 'ni', 'individual', 'HH')
@@ -1506,7 +1595,8 @@ class TestRequestHandlersIndividualCode(TestHelpers):
         await self.check_post_select_address(
             self.post_request_individual_code_select_address_ni, 'ni', 'HH', self.ai_uprn_result_northern_ireland)
         await self.check_post_confirm_address_input_yes_code_individual(
-            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n, 'individual')
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
 
     @unittest_run_loop
     async def test_get_request_individual_code_address_not_in_northern_ireland_region_e_ni(self):


### PR DESCRIPTION
# Motivation and Context
Changes to 'select how to receive' hint text

# What has changed
Change of text for both CE and Individual journeys
Unit tests updates to pass through address_type for checking for correct text
Change of button text for individual questionnaires

No Cucumber updates required

# How to test?
Check 'Post' option hint text is different for household, CE and Individuals (both household and CE variants) in the access code journey

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1581
https://collaborate2.ons.gov.uk/jira/browse/CR-1584
