### PR TITLE
Cr 1499 fulfilment session invalidate

### DIFF
--- a/app/request_handlers.py
+++ b/app/request_handlers.py
@@ -10,6 +10,7 @@ from . import (NO_SELECTION_CHECK_MSG,
 
 from .flash import flash
 from .exceptions import SessionTimeout, TooManyRequests
+from .security import invalidate
 from .utils import View, ProcessMobileNumber, InvalidDataError, InvalidDataErrorWelsh, \
     FlashMessage, RHService, ProcessName, ProcessNumberOfPeople
 
@@ -971,6 +972,8 @@ class RequestCodeSentByText(RequestCommon):
         attributes['request_type'] = request_type
         attributes['page_url'] = View.gen_page_url(request)
 
+        await invalidate(request)
+
         return attributes
 
 
@@ -1004,6 +1007,8 @@ class RequestCodeSentByPost(RequestCommon):
             else:
                 page_title = 'Household access code will be sent by post'
             locale = 'en'
+
+        await invalidate(request)
 
         return {
                 'page_title': page_title,
@@ -1175,6 +1180,8 @@ class RequestQuestionnaireSent(RequestCommon):
                 page_title = 'Household paper questionnaire will be sent'
             locale = 'en'
 
+        await invalidate(request)
+
         return {
                 'page_title': page_title,
                 'display_region': display_region,
@@ -1213,6 +1220,8 @@ class RequestContinuationSent(RequestCommon):
         self.log_entry(request, display_region + '/request/' + request_type + '/sent')
 
         attributes = await self.get_check_attributes(request, request_type)
+
+        await invalidate(request)
 
         return {
                 'page_title': page_title,
@@ -1259,6 +1268,8 @@ class RequestLargePrintSentPost(RequestCommon):
             else:
                 page_title = 'Large-print household paper questionnaire will be sent'
             locale = 'en'
+
+        await invalidate(request)
 
         return {
                 'page_title': page_title,


### PR DESCRIPTION
# Motivation and Context
Invalidates the user session when a fulfilment is successfully completed

# What has changed
Added the 'invalidate' call to the render of the 'success' pages in all fulfilment journeys to kill off the users session. This prevents the session continuing if they wish to make further requests

No Cucumber updates required

# How to test?
Make a fulfilment request, and ensure that the user session is removed from the browser when reaching the 'success' screen

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1499

# Screenshots (if appropriate):