### PR TITLE
CR-1586 Make Room Number Optional

### DIFF
--- a/app/common_handlers.py
+++ b/app/common_handlers.py
@@ -909,7 +909,7 @@ class CommonEnterRoomNumber(CommonCommon):
 
         try:
             room_number = data['form-enter-room-number']
-            if (room_number == '') or (len(room_number) > 10):
+            if len(room_number) > 10:
                 raise KeyError
             session['attributes']['roomNumber'] = room_number
             session.changed()
@@ -943,14 +943,6 @@ class CommonEnterRoomNumber(CommonCommon):
                     flash(request, FlashMessage.generate_flash_message(
                         'You have entered too many characters. Enter up to 10 characters', 'ERROR',
                         'ROOM_NUMBER_ENTER_ERROR', 'error-room-number-len'))
-            else:
-                if display_region == 'cy':
-                    # TODO Add Welsh translation
-                    flash(request, FlashMessage.generate_flash_message('Enter your flat or room number', 'ERROR',
-                                                                       'ROOM_NUMBER_ENTER_ERROR', 'error-room-number'))
-                else:
-                    flash(request, FlashMessage.generate_flash_message('Enter your flat or room number', 'ERROR',
-                                                                       'ROOM_NUMBER_ENTER_ERROR', 'error-room-number'))
             raise HTTPFound(
                 request.app.router['CommonEnterRoomNumber:get'].url_for(
                     display_region=display_region,

--- a/app/templates/common-enter-room-number.html
+++ b/app/templates/common-enter-room-number.html
@@ -22,8 +22,6 @@
 
 {%- if 'error-room-number-len' in field_messages_dict -%}
     {%- set error_room_number = {'id': 'error-room-number-len', 'text': _('You have entered too many characters. Enter up to 10 characters')} -%}
-{%- elif 'error-room-number' in field_messages_dict -%}
-    {%- set error_room_number = {'id': 'error-room-number', 'text': _('Enter your flat or room number')} -%}
 {%- endif -%}
 
 {%- set question_title = _('What is your flat or room number?') -%}

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -2498,7 +2498,7 @@ class TestHelpers(RHTestCase):
                 self.assertIn(self.build_translation_link('select-how-to-receive', display_region, True), contents)
             self.check_text_select_how_to_receive(display_region, contents, 'individual', address_type)
 
-    async def add_room_number(self, url_get, url_post, display_region, user_type, return_page, no_data=False,
+    async def add_room_number(self, url_get, url_post, display_region, user_type, return_page,
                               data_over_length=False, check_for_value=False):
         with self.assertLogs('respondent-home', 'INFO') as cm, \
                 mock.patch('app.utils.AddressIndex.get_ai_postcode') as mocked_get_ai_postcode, mock.patch(
@@ -2519,12 +2519,8 @@ class TestHelpers(RHTestCase):
                 self.assertIn(self.build_translation_link('enter-flat-or-room-number', display_region), contents)
             self.check_text_enter_room_number(display_region, contents, check_for_value=check_for_value)
 
-            if no_data or data_over_length:
-                if no_data:
-                    response = await self.client.request('POST', url_post, data=self.common_room_number_input_empty)
-                else:
-                    response = await self.client.request('POST', url_post,
-                                                         data=self.common_room_number_input_over_length)
+            if data_over_length:
+                response = await self.client.request('POST', url_post, data=self.common_room_number_input_over_length)
                 self.assertLogEvent(cm, self.build_url_log_entry('enter-flat-or-room-number', display_region, 'POST'))
                 self.assertLogEvent(cm, self.build_url_log_entry('enter-flat-or-room-number', display_region, 'GET'))
 
@@ -2533,12 +2529,7 @@ class TestHelpers(RHTestCase):
                 self.assertIn(self.get_logo(display_region), contents)
                 if not display_region == 'ni':
                     self.assertIn(self.build_translation_link('enter-flat-or-room-number', display_region), contents)
-                if no_data:
-                    self.check_text_enter_room_number(display_region, contents,
-                                                      check_empty=True, check_over_length=False)
-                else:
-                    self.check_text_enter_room_number(display_region, contents,
-                                                      check_empty=False, check_over_length=True)
+                self.check_text_enter_room_number(display_region, contents, check_empty=False, check_over_length=True)
 
             else:
                 response = await self.client.request('POST', url_post, data=self.common_room_number_input_valid)

--- a/tests/unit/test_request_handlers_access_code.py
+++ b/tests/unit/test_request_handlers_access_code.py
@@ -7213,42 +7213,6 @@ class TestRequestHandlersAccessCode(TestHelpers):
             check_room_number=True)
 
     @unittest_run_loop
-    async def test_request_access_code_post_code_sent_post_add_room_early_empty_ce_r_ew_e(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
-        await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
-        await self.add_room_number(self.get_request_access_code_enter_room_number_en,
-                                   self.post_request_access_code_enter_room_number_en,
-                                   'en', 'individual', 'ConfirmAddress', no_data=True)
-
-    @unittest_run_loop
-    async def test_request_access_code_post_code_sent_post_add_room_early_empty_ce_r_ew_w(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
-        await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
-        await self.add_room_number(self.get_request_access_code_enter_room_number_en,
-                                   self.post_request_access_code_enter_room_number_en,
-                                   'en', 'individual', 'ConfirmAddress', no_data=True)
-
-    @unittest_run_loop
-    async def test_request_access_code_post_code_sent_post_add_room_early_empty_ce_r_cy(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_cy, 'cy')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
-        await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
-        await self.add_room_number(self.get_request_access_code_enter_room_number_cy,
-                                   self.post_request_access_code_enter_room_number_cy,
-                                   'cy', 'individual', 'ConfirmAddress', no_data=True)
-
-    @unittest_run_loop
-    async def test_request_access_code_post_code_sent_post_add_room_early_empty_ce_r_ni(self):
-        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
-        await self.add_room_number(self.get_request_access_code_enter_room_number_ni,
-                                   self.post_request_access_code_enter_room_number_ni,
-                                   'ni', 'individual', 'ConfirmAddress', no_data=True)
-
-    @unittest_run_loop
     async def test_request_access_code_post_code_sent_post_add_room_early_over_length_ce_r_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')

--- a/tests/unit/test_request_handlers_questionnaire.py
+++ b/tests/unit/test_request_handlers_questionnaire.py
@@ -3735,42 +3735,6 @@ class TestRequestHandlersPaperForm(TestHelpers):
             check_room_number=True)
 
     @unittest_run_loop
-    async def test_request_paper_questionnaire_sent_post_add_room_early_empty_ce_r_ew_e(self):
-        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
-        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
-        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'CE')
-        await self.add_room_number(self.get_request_paper_questionnaire_enter_room_number_en,
-                                   self.post_request_paper_questionnaire_enter_room_number_en,
-                                   'en', 'individual', 'ConfirmAddress', no_data=True)
-
-    @unittest_run_loop
-    async def test_request_paper_questionnaire_sent_post_add_room_early_empty_ce_r_ew_w(self):
-        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
-        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
-        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'CE')
-        await self.add_room_number(self.get_request_paper_questionnaire_enter_room_number_en,
-                                   self.post_request_paper_questionnaire_enter_room_number_en,
-                                   'en', 'individual', 'ConfirmAddress', no_data=True)
-
-    @unittest_run_loop
-    async def test_request_paper_questionnaire_sent_post_add_room_early_empty_ce_r_cy(self):
-        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_cy, 'cy')
-        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_cy, 'cy')
-        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_cy, 'cy', 'CE')
-        await self.add_room_number(self.get_request_paper_questionnaire_enter_room_number_cy,
-                                   self.post_request_paper_questionnaire_enter_room_number_cy,
-                                   'cy', 'individual', 'ConfirmAddress', no_data=True)
-
-    @unittest_run_loop
-    async def test_request_paper_questionnaire_sent_post_add_room_early_empty_ce_r_ni(self):
-        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_ni, 'ni')
-        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_ni, 'ni')
-        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_ni, 'ni', 'CE')
-        await self.add_room_number(self.get_request_paper_questionnaire_enter_room_number_ni,
-                                   self.post_request_paper_questionnaire_enter_room_number_ni,
-                                   'ni', 'individual', 'ConfirmAddress', no_data=True)
-
-    @unittest_run_loop
     async def test_request_paper_questionnaire_sent_post_add_room_early_over_length_ce_r_ew_e(self):
         await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')


### PR DESCRIPTION

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Removes the empty validation on room number

# What has changed
Removal of check and error for an empty room number
Removal of matching unit tests

No Cucumber updates required

# How to test?
Request a fulfilment for a CE. On Confirm Address click 'Add room number'. Add value, and click continue. Click change room number, blank the value and continue. Validation should allow an empty value, and the value should be removed from the Confirm Address screen

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1586

# Screenshots (if appropriate):