### PR TITLE
CR-1657 Change EQ Period ID

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -120,7 +120,7 @@ class EqPayloadConstructor(object):
             'user_id': self._user_id,
             'questionnaire_id': self._questionnaire_id,
             'eq_id': 'census',  # hardcoded for rehearsal
-            'period_id': '2019',  # hardcoded for rehearsal
+            'period_id': '2021',
             'form_type': self._form_type,
             'survey': 'CENSUS'  # hardcoded for rehearsal
         }

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -699,7 +699,7 @@ class RHTestCase(AioHTTPTestCase):
         self.uac_code = ''.join([str(n) for n in range(13)])
         self.uac1, self.uac2, self.uac3, self.uac4 = \
             self.uac_code[:4], self.uac_code[4:8], self.uac_code[8:12], self.uac_code[12:]
-        self.period_id = '2019'
+        self.period_id = '2021'
         self.uac = 'w4nwwpphjjptp7fn'
         self.uac_ce4 = 'ce4fghtykjuiplku'
         self.uacHash = self.uac_json_e['uacHash']


### PR DESCRIPTION
Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Change EQ period ID to 2021

# What has changed
Change value for EQ period_id to 2021, and matching test value

No Cucumber updates required

# How to test?

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1657