### PR TITLE
CR-1573 Start Invalid Message

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,8 +1,8 @@
 VERSION = '0.0.1'
 
 
-BAD_CODE_MSG = {'text': 'Enter an access code', 'clickable': True, 'level': 'ERROR', 'type': 'BAD_CODE', 'field': 'uac'}  # NOQA
-INVALID_CODE_MSG = {'text': 'Enter a valid access code', 'clickable': True, 'level': 'ERROR', 'type': 'INVALID_CODE', 'field': 'uac'}  # NOQA
+BAD_CODE_MSG = {'text': 'Enter an access code', 'clickable': True, 'level': 'ERROR', 'type': 'BAD_CODE', 'field': 'uac_empty'}  # NOQA
+INVALID_CODE_MSG = {'text': 'Enter a valid access code', 'clickable': True, 'level': 'ERROR', 'type': 'INVALID_CODE', 'field': 'uac_invalid'}  # NOQA
 ADDRESS_CHECK_MSG = {'text': 'Select an answer', 'level': 'ERROR', 'type': 'ADDRESS_CONFIRMATION_ERROR', 'field': 'address'}  # NOQA
 WEBCHAT_MISSING_NAME_MSG = {'text': 'Enter your name', 'clickable': True, 'level': 'ERROR', 'type': 'BAD_CODE', 'field': 'error_screen_name'}  # NOQA
 WEBCHAT_MISSING_COUNTRY_MSG = {'text': 'Select your country', 'clickable': True, 'level': 'ERROR', 'type': 'BAD_CODE', 'field': 'error_country'}  # NOQA
@@ -19,9 +19,9 @@ ADDRESS_SELECT_CHECK_MSG = {'text': 'Select an address', 'level': 'ERROR', 'type
 START_LANGUAGE_OPTION_MSG = {'text': 'Select a language option', 'level': 'ERROR', 'type': 'START_LANGUAGE_OPTION_MSG', 'field': 'error-language-option'}  # NOQA
 NO_SELECTION_CHECK_MSG = {'text': 'Select an answer', 'level': 'ERROR', 'type': 'NO_SELECTION_ERROR', 'field': 'no-selection'}  # NOQA
 
-BAD_CODE_MSG_CY = {'text': 'Rhowch god mynediad', 'clickable': True, 'level': 'ERROR', 'type': 'BAD_CODE', 'field': 'uac'}  # NOQA
+BAD_CODE_MSG_CY = {'text': 'Rhowch god mynediad', 'clickable': True, 'level': 'ERROR', 'type': 'BAD_CODE', 'field': 'uac_empty'}  # NOQA
 # TODO ADD WELSH TRANSLATION
-INVALID_CODE_MSG_CY = {'text': 'Enter a valid access code', 'clickable': True, 'level': 'ERROR', 'type': 'INVALID_CODE', 'field': 'uac'}  # NOQA
+INVALID_CODE_MSG_CY = {'text': 'Enter a valid access code', 'clickable': True, 'level': 'ERROR', 'type': 'INVALID_CODE', 'field': 'uac_invalid'}  # NOQA
 # TODO ADD WELSH TRANSLATION
 ADDRESS_CHECK_MSG_CY = {'text': "Select an answer", 'level': 'ERROR', 'type': 'ADDRESS_CONFIRMATION_ERROR', 'field': 'address'}  # NOQA
 WEBCHAT_MISSING_NAME_MSG_CY = {'text': 'Nodwch eich enw', 'clickable': True, 'level': 'ERROR', 'type': 'BAD_CODE', 'field': 'error_screen_name'}  # NOQA

--- a/app/templates/start.html
+++ b/app/templates/start.html
@@ -22,12 +22,10 @@
     }
 } %}
 
-{%- if 'uac' in field_messages_dict -%}
-    {%- set error_uac = {
-                    'id': 'uac',
-                    'text': _('Enter an access code')
-                }
-    -%}
+{%- if 'uac_empty' in field_messages_dict -%}
+    {%- set error_uac = {'id': 'uac_empty', 'text': _('Enter an access code')} -%}
+{%- elif 'uac_invalid' in field_messages_dict -%}
+    {%- set error_uac = {'id': 'uac_invalid', 'text': _('Enter a valid access code')} -%}
 {%- endif -%}
 
 {% if display_region == 'ni' %}

--- a/tests/unit/test_start_handlers.py
+++ b/tests/unit/test_start_handlers.py
@@ -331,7 +331,7 @@ class TestStartHandlers(TestHelpers):
         contents = str(await response.content.read())
         self.assertIn(self.ons_logo_en, contents)
         self.assertIn('<a href="/cy/start/" lang="cy" >Cymraeg</a>', contents)
-        self.assertMessagePanel(BAD_CODE_MSG, contents)
+        self.assertMessagePanel(INVALID_CODE_MSG, contents)
 
     @unittest_run_loop
     async def test_post_start_invalid_text_url_cy(self):
@@ -348,7 +348,7 @@ class TestStartHandlers(TestHelpers):
         contents = str(await response.content.read())
         self.assertIn(self.ons_logo_cy, contents)
         self.assertIn('<a href="/en/start/" lang="en" >English</a>', contents)
-        self.assertMessagePanel(BAD_CODE_MSG_CY, contents)
+        self.assertMessagePanel(INVALID_CODE_MSG_CY, contents)
 
     @unittest_run_loop
     async def test_post_start_invalid_text_url_ni(self):
@@ -364,7 +364,7 @@ class TestStartHandlers(TestHelpers):
         self.assertEqual(response.status, 200)
         contents = str(await response.content.read())
         self.assertIn(self.nisra_logo, contents)
-        self.assertMessagePanel(BAD_CODE_MSG, contents)
+        self.assertMessagePanel(INVALID_CODE_MSG, contents)
 
     @unittest_run_loop
     async def test_post_start_invalid_text_random_ew(self):
@@ -381,7 +381,7 @@ class TestStartHandlers(TestHelpers):
         contents = str(await response.content.read())
         self.assertIn(self.ons_logo_en, contents)
         self.assertIn('<a href="/cy/start/" lang="cy" >Cymraeg</a>', contents)
-        self.assertMessagePanel(BAD_CODE_MSG, contents)
+        self.assertMessagePanel(INVALID_CODE_MSG, contents)
 
     @unittest_run_loop
     async def test_post_start_invalid_text_random_cy(self):
@@ -398,7 +398,7 @@ class TestStartHandlers(TestHelpers):
         contents = str(await response.content.read())
         self.assertIn(self.ons_logo_cy, contents)
         self.assertIn('<a href="/en/start/" lang="en" >English</a>', contents)
-        self.assertMessagePanel(BAD_CODE_MSG_CY, contents)
+        self.assertMessagePanel(INVALID_CODE_MSG_CY, contents)
 
     @unittest_run_loop
     async def test_post_start_invalid_text_random_ni(self):
@@ -414,7 +414,7 @@ class TestStartHandlers(TestHelpers):
         self.assertEqual(response.status, 200)
         contents = str(await response.content.read())
         self.assertIn(self.nisra_logo, contents)
-        self.assertMessagePanel(BAD_CODE_MSG, contents)
+        self.assertMessagePanel(INVALID_CODE_MSG, contents)
 
     @unittest_run_loop
     async def test_post_start_uac_active_missing_ew_e(self):


### PR DESCRIPTION
# Motivation and Context
Fix to UAC input to ensure correct error message is displayed

# What has changed
Change to make the 2 possible error messages on the uac input box trigger correctly

No Cucumber changes required

# How to test?
Test 1: Submit an empty UAC field - error message above UAC input panel should be 'Enter an access code'
Test 2: Enter a partial or invalid UAC into the field (not empty, but not 16 characters, or containing symbols)- error message should now be 'Enter a valid access code'

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1573