### PR TITLE
CR-1664 Increase Session Timeout

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -64,7 +64,7 @@ class BaseConfig:
     REDIS_POOL_MIN = env('REDIS_POOL_MIN', default='50')
     REDIS_POOL_MAX = env('REDIS_POOL_MAX', default='500')
 
-    SESSION_AGE = env('SESSION_AGE', default='600')
+    SESSION_AGE = env('SESSION_AGE', default='2700')  # 45 minutes
 
     WEBCHAT_SVC_URL = env('WEBCHAT_SVC_URL')
 
@@ -116,7 +116,7 @@ class DevelopmentConfig:
     REDIS_POOL_MIN = env('REDIS_POOL_MIN', default='50')
     REDIS_POOL_MAX = env('REDIS_POOL_MAX', default='500')
 
-    SESSION_AGE = env('SESSION_AGE', default='300')  # 5 minutes
+    SESSION_AGE = env('SESSION_AGE', default='2700')  # 45 minutes
 
     WEBCHAT_SVC_URL = env.str(
         'WEBCHAT_SVC_URL',


### PR DESCRIPTION
Up timeout to 45 minutes

Signed-off-by: Paul-Joel <paul.joel@ons.gov.uk>

# Motivation and Context
Increases the session timeout to 45 minutes

# What has changed
Updated the session timeout values in the config.py

No Cucumber updates required

# How to test?
Start a session in RH. View the RH_SESSION cookie, and check that it will expire in 45 minutes.

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1664