### PR TITLE
CR-1608 Remove Web Chat Link

### DIFF
--- a/app/templates/start.html
+++ b/app/templates/start.html
@@ -137,13 +137,4 @@
         {{ content | safe }}
     {% endcall %}
 
-    {{ onsButton({
-        'text': _('Web chat'),
-        "type": 'button',
-        "classes": 'u-mb-m, u-mt-s',
-        "url": webchat_link,
-        "newWindow": true
-        })
-    }}
-
 {% endblock %}


### PR DESCRIPTION
# Motivation and Context
Removes the start page Web Chat link

# What has changed
Removed Web Chat button in Start page - Web Chat can now only be reached directly

Cucumber update already deployed

# How to test?
Check 'start' - check Web chat button is removed

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1608