### PR TITLE
CR-1456 Add log identifier

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -21,6 +21,7 @@ from . import routes
 from . import security
 from . import session
 from . import settings
+from . import trace
 from .app_logging import logger_initial_config
 
 logger = get_logger('respondent-home')
@@ -83,6 +84,7 @@ def create_app(config_name=None) -> Application:
             security.nonce_middleware,
             session.setup(app_config),
             flash.flash_middleware,
+            trace.trace_middleware
         ],
         router=routing.ResourceRouter(),
     )

--- a/app/common_handlers.py
+++ b/app/common_handlers.py
@@ -651,7 +651,10 @@ class CommonConfirmAddress(CommonCommon):
                     hashed_uac_value = session['case']['uacHash']
                     if ex.status == 404:
                         logger.info('uac linking error - unable to find uac (' + str(ex.status) + ')',
-                                    client_ip=request['client_ip'], status_code=ex.status, uac_hashed=hashed_uac_value)
+                                    client_ip=request['client_ip'],
+                                    client_id=request['client_id'],
+                                    trace=request['trace'],
+                                    status_code=ex.status, uac_hashed=hashed_uac_value)
                     elif ex.status == 400:
                         logger.info('uac linking error - invalid request (' + str(ex.status) + ')',
                                     client_ip=request['client_ip'],

--- a/app/common_handlers.py
+++ b/app/common_handlers.py
@@ -63,7 +63,6 @@ class CommonAddressInScotland(CommonCommon):
     """
     @aiohttp_jinja2.template('common-address-in-scotland.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         user_journey = request.match_info['user_journey']
 
@@ -96,7 +95,6 @@ class CommonAddressInNorthernIreland(CommonCommon):
     """
     @aiohttp_jinja2.template('common-address-in-northern-ireland.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         user_journey = request.match_info['user_journey']
 
@@ -126,7 +124,6 @@ class CommonAddressInEngland(CommonCommon):
     """
     @aiohttp_jinja2.template('common-address-in-england.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = 'ni'
         user_journey = request.match_info['user_journey']
 
@@ -151,7 +148,6 @@ class CommonAddressInWales(CommonCommon):
     """
     @aiohttp_jinja2.template('common-address-in-wales.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = 'ni'
         user_journey = request.match_info['user_journey']
 
@@ -176,7 +172,6 @@ class CommonRegisterAddress(CommonCommon):
     """
     @aiohttp_jinja2.template('common-register-address.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         user_journey = request.match_info['user_journey']
         sub_user_journey = request.match_info['sub_user_journey']
@@ -208,7 +203,6 @@ class CommonCallContactCentre(CommonCommon):
     """
     @aiohttp_jinja2.template('common-contact-centre.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         user_journey = request.match_info['user_journey']
         error = request.match_info['error']
@@ -241,7 +235,6 @@ class CommonEnterAddress(CommonCommon):
     """
     @aiohttp_jinja2.template('common-enter-address.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         user_journey = request.match_info['user_journey']
         sub_user_journey = request.match_info['sub_user_journey']
@@ -290,7 +283,6 @@ class CommonEnterAddress(CommonCommon):
         }
 
     async def post(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         user_journey = request.match_info['user_journey']
         sub_user_journey = request.match_info['sub_user_journey']
@@ -306,11 +298,16 @@ class CommonEnterAddress(CommonCommon):
 
         try:
             postcode = ProcessPostcode.validate_postcode(data['form-enter-address-postcode'], display_region)
-            logger.info('valid postcode', client_ip=request['client_ip'],
-                        postcode_entered=postcode, region_of_site=display_region)
+            logger.info('valid postcode',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        postcode_entered=postcode,
+                        region_of_site=display_region)
 
         except (InvalidDataError, InvalidDataErrorWelsh) as exc:
-            logger.info('invalid postcode', client_ip=request['client_ip'])
+            logger.info('invalid postcode',
+                        client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
             if exc.message_type == 'empty':
                 flash_message = FlashMessage.generate_flash_message(str(exc), 'ERROR', 'POSTCODE_ENTER_ERROR',
                                                                     'error_postcode_empty')
@@ -344,7 +341,6 @@ class CommonSelectAddress(CommonCommon):
     """
     @aiohttp_jinja2.template('common-select-address.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         user_journey = request.match_info['user_journey']
         sub_user_journey = request.match_info['sub_user_journey']
@@ -382,7 +378,6 @@ class CommonSelectAddress(CommonCommon):
         return address_content
 
     async def post(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         user_journey = request.match_info['user_journey']
         sub_user_journey = request.match_info['sub_user_journey']
@@ -401,8 +396,12 @@ class CommonSelectAddress(CommonCommon):
         try:
             selected_uprn = data['form-pick-address']
         except KeyError:
-            logger.info('no address selected', client_ip=request['client_ip'],
-                        region_of_site=display_region, journey_requiring_address=user_journey)
+            logger.info('no address selected',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        region_of_site=display_region,
+                        journey_requiring_address=user_journey)
             if display_region == 'cy':
                 flash(request, ADDRESS_SELECT_CHECK_MSG_CY)
             else:
@@ -423,8 +422,12 @@ class CommonSelectAddress(CommonCommon):
         else:
             attributes['uprn'] = selected_uprn
             session.changed()
-            logger.info('session updated', client_ip=request['client_ip'],
-                        uprn_selected=selected_uprn, region_of_site=display_region)
+            logger.info('session updated',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        uprn_selected=selected_uprn,
+                        region_of_site=display_region)
 
         raise HTTPFound(
             request.app.router['CommonConfirmAddress:get'].url_for(
@@ -442,7 +445,6 @@ class CommonConfirmAddress(CommonCommon):
     """
     @aiohttp_jinja2.template('common-confirm-address.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         user_journey = request.match_info['user_journey']
         sub_user_journey = request.match_info['sub_user_journey']
@@ -504,7 +506,6 @@ class CommonConfirmAddress(CommonCommon):
         }
 
     async def post(self, request):
-        self.setup_request(request)
 
         display_region = request.match_info['display_region']
         user_journey = request.match_info['user_journey']
@@ -526,6 +527,8 @@ class CommonConfirmAddress(CommonCommon):
         except KeyError:
             logger.info('address confirmation error',
                         client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
                         region_of_site=display_region)
             if display_region == 'cy':
                 flash(request, NO_SELECTION_CHECK_MSG_CY)
@@ -543,21 +546,28 @@ class CommonConfirmAddress(CommonCommon):
             try:
                 census_address_type_value = attributes['censusAddressType']
                 if census_address_type_value == 'NA':
-                    logger.info('censusAddressType is NA', client_ip=request['client_ip'],
+                    logger.info('censusAddressType is NA',
+                                client_ip=request['client_ip'],
+                                client_id=request['client_id'],
+                                trace=request['trace'],
                                 user_selection=address_confirmation)
                     raise HTTPFound(
                         request.app.router['CommonCallContactCentre:get'].url_for(
                             display_region=display_region, user_journey=user_journey, error='unable-to-match-address'))
                 elif (census_address_type_value == 'CE') and \
                         (sub_user_journey == 'continuation-questionnaire'):
-                    logger.info('continuation form for a CE - rejecting', client_ip=request['client_ip'],
+                    logger.info('continuation form for a CE - rejecting',
+                                client_ip=request['client_ip'],
+                                client_id=request['client_id'],
+                                trace=request['trace'],
                                 sub_journey=sub_user_journey,
                                 census_addr_type=census_address_type_value)
                     raise HTTPFound(
                         request.app.router['RequestContinuationNotAHousehold:get'].url_for(
                             display_region=display_region))
             except KeyError:
-                logger.info('unable to check censusAddressType', client_ip=request['client_ip'])
+                logger.info('unable to check censusAddressType',
+                            client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
                 raise HTTPFound(
                     request.app.router['CommonCallContactCentre:get'].url_for(
                         display_region=display_region, user_journey=user_journey, error='unable-to-match-address'))
@@ -566,14 +576,20 @@ class CommonConfirmAddress(CommonCommon):
                 country_code_value = attributes['countryCode']
                 uprn = attributes['uprn']
                 if country_code_value == 'S':
-                    logger.info('address is in Scotland', client_ip=request['client_ip'],
-                                country_code_found=country_code_value, uprn_value=uprn)
+                    logger.info('address is in Scotland',
+                                client_ip=request['client_ip'],
+                                client_id=request['client_id'],
+                                trace=request['trace'],
+                                country_code_found=country_code_value,
+                                uprn_value=uprn)
                     raise HTTPFound(
                         request.app.router['CommonAddressInScotland:get'].
                         url_for(display_region=display_region, user_journey=user_journey))
                 elif country_code_value == 'N' and display_region != 'ni':
                     logger.info('address is in Northern Ireland but not display_region ni',
                                 client_ip=request['client_ip'],
+                                client_id=request['client_id'],
+                                trace=request['trace'],
                                 country_code_found=country_code_value,
                                 region_of_site=display_region,
                                 uprn_value=uprn)
@@ -584,6 +600,8 @@ class CommonConfirmAddress(CommonCommon):
                     logger.info('address is in Wales but display_region ni',
                                 client_ip=request['client_ip'],
                                 country_code_found=country_code_value,
+                                client_id=request['client_id'],
+                                trace=request['trace'],
                                 region_of_site=display_region,
                                 uprn_value=uprn)
                     raise HTTPFound(
@@ -592,6 +610,8 @@ class CommonConfirmAddress(CommonCommon):
                 elif display_region == 'ni' and country_code_value == 'E':
                     logger.info('address is in England but display_region ni',
                                 client_ip=request['client_ip'],
+                                client_id=request['client_id'],
+                                trace=request['trace'],
                                 country_code_found=country_code_value,
                                 region_of_site=display_region,
                                 uprn_value=uprn)
@@ -599,7 +619,8 @@ class CommonConfirmAddress(CommonCommon):
                         request.app.router['CommonAddressInEngland:get'].
                         url_for(display_region=display_region, user_journey=user_journey))
             except KeyError:
-                logger.info('unable to check for region', client_ip=request['client_ip'])
+                logger.info('unable to check for region',
+                            client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
 
             if sub_user_journey == 'link-address' or sub_user_journey == 'change-address':
                 try:
@@ -633,10 +654,18 @@ class CommonConfirmAddress(CommonCommon):
                                     client_ip=request['client_ip'], status_code=ex.status, uac_hashed=hashed_uac_value)
                     elif ex.status == 400:
                         logger.info('uac linking error - invalid request (' + str(ex.status) + ')',
-                                    client_ip=request['client_ip'], status_code=ex.status, uac_hashed=hashed_uac_value)
+                                    client_ip=request['client_ip'],
+                                    client_id=request['client_id'],
+                                    trace=request['trace'],
+                                    status_code=ex.status,
+                                    uac_hashed=hashed_uac_value)
                     else:
                         logger.error('uac linking error - unknown issue (' + str(ex.status) + ')',
-                                     client_ip=request['client_ip'], status_code=ex.status, uac_hashed=hashed_uac_value)
+                                     client_ip=request['client_ip'],
+                                     client_id=request['client_id'],
+                                     trace=request['trace'],
+                                     status_code=ex.status,
+                                     uac_hashed=hashed_uac_value)
 
                     cc_error = ''
                     if sub_user_journey == 'link-address':
@@ -668,8 +697,14 @@ class CommonConfirmAddress(CommonCommon):
                 except ClientResponseError as ex:
                     if ex.status == 404:
                         logger.info('get cases by uprn error - unable to match uprn (404)',
-                                    client_ip=request['client_ip'], unmatched_uprn=attributes['uprn'])
-                        logger.info('requesting new case', client_ip=request['client_ip'])
+                                    client_ip=request['client_ip'],
+                                    client_id=request['client_id'],
+                                    trace=request['trace'],
+                                    unmatched_uprn=attributes['uprn'])
+                        logger.info('requesting new case',
+                                    client_ip=request['client_ip'],
+                                    client_id=request['client_id'],
+                                    trace=request['trace'])
                         try:
                             case_creation_return = await RHService.post_case_create(request, attributes)
                             attributes['case_id'] = case_creation_return['caseId']
@@ -687,7 +722,10 @@ class CommonConfirmAddress(CommonCommon):
                                                                        attributes['individual'])
 
                         except ClientResponseError as ex:
-                            logger.warn('error requesting new case', client_ip=request['client_ip'])
+                            logger.warn('error requesting new case',
+                                        client_ip=request['client_ip'],
+                                        client_id=request['client_id'],
+                                        trace=request['trace'])
                             raise ex
                     else:
                         raise ex
@@ -702,7 +740,10 @@ class CommonConfirmAddress(CommonCommon):
         else:
             # catch all just in case, should never get here
             logger.info('address confirmation error',
-                        client_ip=request['client_ip'], user_selection=address_confirmation)
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        user_selection=address_confirmation)
             flash(request, NO_SELECTION_CHECK_MSG)
             raise HTTPFound(
                 request.app.router['CommonConfirmAddress:get'].url_for(
@@ -720,7 +761,6 @@ class CommonCEMangerQuestion(CommonCommon):
     """
     @aiohttp_jinja2.template('common-resident-or-manager.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         user_journey = request.match_info['user_journey']
         sub_user_journey = request.match_info['sub_user_journey']
@@ -756,7 +796,6 @@ class CommonCEMangerQuestion(CommonCommon):
         }
 
     async def post(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         user_journey = request.match_info['user_journey']
         sub_user_journey = request.match_info['sub_user_journey']
@@ -772,7 +811,7 @@ class CommonCEMangerQuestion(CommonCommon):
             resident_or_manager = data['form-resident-or-manager']
         except KeyError:
             logger.info('resident or manager question error',
-                        client_ip=request['client_ip'])
+                        client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
             if display_region == 'cy':
                 flash(request, NO_SELECTION_CHECK_MSG_CY)
             else:
@@ -825,6 +864,8 @@ class CommonCEMangerQuestion(CommonCommon):
             # catch all just in case, should never get here
             logger.info('resident or manager question error',
                         client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
                         manager_or_resident=resident_or_manager)
             if display_region == 'cy':
                 flash(request, NO_SELECTION_CHECK_MSG_CY)
@@ -846,7 +887,6 @@ class CommonEnterRoomNumber(CommonCommon):
     """
     @aiohttp_jinja2.template('common-enter-room-number.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         user_journey = request.match_info['user_journey']
         sub_user_journey = request.match_info['sub_user_journey']
@@ -888,7 +928,6 @@ class CommonEnterRoomNumber(CommonCommon):
         }
 
     async def post(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         user_journey = request.match_info['user_journey']
         sub_user_journey = request.match_info['sub_user_journey']
@@ -925,7 +964,10 @@ class CommonEnterRoomNumber(CommonCommon):
 
         except KeyError:
             room_number_entered = data['form-enter-room-number']
-            logger.info('room number question error', client_ip=request['client_ip'],
+            logger.info('room number question error',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
                         room_number_given=room_number_entered)
             if len(room_number_entered) > 10:
                 if display_region == 'cy':

--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -39,7 +39,10 @@ def create_error_middleware(overrides):
                 display_region = 'en'
 
             if request.path + '/' == index_resource.canonical.replace('{display_region}', display_region):
-                logger.debug('redirecting to index', path=request.path)
+                logger.debug('redirecting to index',
+                             client_id=request['client_id'],
+                             trace=request['trace'],
+                             path=request.path)
                 raise web.HTTPMovedPermanently(index_resource.url_for(display_region=display_region))
             return await not_found_error(request)
         except web.HTTPForbidden:
@@ -73,7 +76,7 @@ def create_error_middleware(overrides):
 
 
 async def inactive_case(request, case_type):
-    logger.warn('attempt to use an inactive access code')
+    logger.warn('attempt to use an inactive access code', client_id=request['client_id'], trace=request['trace'])
     attributes = check_display_region(request)
     attributes['case_type'] = case_type
     return jinja.render_template('start-expired.html', request, attributes)
@@ -81,31 +84,45 @@ async def inactive_case(request, case_type):
 
 async def ce_closed(request, collex_id):
     logger.warn('attempt to access collection exercise that has already ended',
+                client_id=request['client_id'],
+                trace=request['trace'],
                 collex_id=collex_id)
     attributes = check_display_region(request)
     return jinja.render_template('closed.html', request, attributes)
 
 
 async def eq_error(request, message: str):
-    logger.error('service failed to build eq payload', exception=message)
+    logger.error('service failed to build eq payload',
+                 client_id=request['client_id'],
+                 trace=request['trace'],
+                 exception=message)
     attributes = check_display_region(request)
     return jinja.render_template('error.html', request, attributes, status=500)
 
 
 async def connection_error(request, message: str):
-    logger.error('service connection error', exception=message)
+    logger.error('service connection error',
+                 client_id=request['client_id'],
+                 trace=request['trace'],
+                 exception=message)
     attributes = check_display_region(request)
     return jinja.render_template('error.html', request, attributes, status=500)
 
 
 async def payload_error(request, url: str):
-    logger.error('service failed to return expected json payload', url=url)
+    logger.error('service failed to return expected json payload',
+                 client_id=request['client_id'],
+                 trace=request['trace'],
+                 url=url)
     attributes = check_display_region(request)
     return jinja.render_template('error.html', request, attributes, status=500)
 
 
 async def key_error(request, error):
-    logger.error('required value ' + str(error) + ' missing', missing_key=error)
+    logger.error('required value ' + str(error) + ' missing',
+                 client_id=request['client_id'],
+                 trace=request['trace'],
+                 missing_key=error)
     attributes = check_display_region(request)
     return jinja.render_template('error.html', request, attributes, status=500)
 

--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -40,6 +40,7 @@ def create_error_middleware(overrides):
 
             if request.path + '/' == index_resource.canonical.replace('{display_region}', display_region):
                 logger.debug('redirecting to index',
+                             client_ip=request['client_ip'],
                              client_id=request['client_id'],
                              trace=request['trace'],
                              path=request.path)
@@ -76,7 +77,10 @@ def create_error_middleware(overrides):
 
 
 async def inactive_case(request, case_type):
-    logger.warn('attempt to use an inactive access code', client_id=request['client_id'], trace=request['trace'])
+    logger.warn('attempt to use an inactive access code',
+                client_ip=request['client_ip'],
+                client_id=request['client_id'],
+                trace=request['trace'])
     attributes = check_display_region(request)
     attributes['case_type'] = case_type
     return jinja.render_template('start-expired.html', request, attributes)
@@ -84,6 +88,7 @@ async def inactive_case(request, case_type):
 
 async def ce_closed(request, collex_id):
     logger.warn('attempt to access collection exercise that has already ended',
+                client_ip=request['client_ip'],
                 client_id=request['client_id'],
                 trace=request['trace'],
                 collex_id=collex_id)
@@ -93,6 +98,7 @@ async def ce_closed(request, collex_id):
 
 async def eq_error(request, message: str):
     logger.error('service failed to build eq payload',
+                 client_ip=request['client_ip'],
                  client_id=request['client_id'],
                  trace=request['trace'],
                  exception=message)
@@ -102,6 +108,7 @@ async def eq_error(request, message: str):
 
 async def connection_error(request, message: str):
     logger.error('service connection error',
+                 client_ip=request['client_ip'],
                  client_id=request['client_id'],
                  trace=request['trace'],
                  exception=message)
@@ -111,6 +118,7 @@ async def connection_error(request, message: str):
 
 async def payload_error(request, url: str):
     logger.error('service failed to return expected json payload',
+                 client_ip=request['client_ip'],
                  client_id=request['client_id'],
                  trace=request['trace'],
                  url=url)
@@ -120,6 +128,7 @@ async def payload_error(request, url: str):
 
 async def key_error(request, error):
     logger.error('required value ' + str(error) + ' missing',
+                 client_ip=request['client_ip'],
                  client_id=request['client_id'],
                  trace=request['trace'],
                  missing_key=error)

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -14,7 +14,6 @@ static_routes = RouteTableDef()
 @static_routes.view('/info', use_prefix=False)
 class Info(View):
     async def get(self, request):
-        self.setup_request(request)
         info = {
             'name': 'respondent-home-ui',
             'version': VERSION,
@@ -28,7 +27,6 @@ class Info(View):
 class LaunchEQ(View):
     @aiohttp_jinja2.template('start-launch-eq.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         self.log_entry(request, display_region + '/start/launch-eq')
         if display_region == 'cy':
@@ -47,7 +45,6 @@ class LaunchEQ(View):
 
     @aiohttp_jinja2.template('start-launch-eq.html')
     async def post(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         self.log_entry(request, display_region + '/start/launch-eq')
 
@@ -55,7 +52,11 @@ class LaunchEQ(View):
 
         token = data.get('token')
 
-        logger.info('redirecting to eq', client_ip=request['client_ip'], region_of_site=display_region)
+        logger.info('redirecting to eq',
+                    client_ip=request['client_ip'],
+                    client_id=request['client_id'],
+                    trace=request['trace'],
+                    region_of_site=display_region)
         eq_url = request.app['EQ_URL']
         raise HTTPFound(f'{eq_url}/session?token={token}')
 
@@ -64,7 +65,6 @@ class LaunchEQ(View):
 class SignedOut(View):
     @aiohttp_jinja2.template('signed-out.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         self.log_entry(request, display_region + '/signed-out')
         if display_region == 'cy':

--- a/app/request.py
+++ b/app/request.py
@@ -50,6 +50,7 @@ class RetryRequest:
             raise ex
         else:
             logger.debug('successfully connected to service',
+                         client_ip=self.request['client_ip'],
                          client_id=self.request['client_id'],
                          trace=self.request['trace'],
                          url=self.url)
@@ -61,7 +62,10 @@ class RetryRequest:
                                                                                        ClientConnectorError))))
     async def _request_basic(self):
         # basic request without keep-alive to avoid terminating service.
-        logger.info('request using basic connection', client_id=self.request['client_id'], trace=self.request['trace'])
+        logger.info('request using basic connection',
+                    client_ip=self.request['client_ip'],
+                    client_id=self.request['client_id'],
+                    trace=self.request['trace'])
 
         async with aiohttp.request(
                 self.method, self.url, auth=self.auth, json=self.json, headers=self.headers) as resp:
@@ -93,6 +97,7 @@ class RetryRequest:
         Finally the error will be propagated.
         """
         logger.debug('making request with handler',
+                     client_ip=self.request['client_ip'],
                      client_id=self.request['client_id'],
                      trace=self.request['trace'],
                      method=self.method,
@@ -103,6 +108,7 @@ class RetryRequest:
             except RetryError as retry_ex:
                 attempts = retry_ex.last_attempt.attempt_number
                 logger.warn('Could not make request using normal pooled connection',
+                            client_ip=self.request['client_ip'],
                             client_id=self.request['client_id'],
                             trace=self.request['trace'],
                             attempts=attempts)
@@ -110,6 +116,7 @@ class RetryRequest:
         except ClientResponseError as ex:
             if not ex.status == 404:
                 logger.error('error in response',
+                             client_ip=self.request['client_ip'],
                              client_id=self.request['client_id'],
                              trace=self.request['trace'],
                              url=self.url,

--- a/app/request.py
+++ b/app/request.py
@@ -49,7 +49,10 @@ class RetryRequest:
         except ClientResponseError as ex:
             raise ex
         else:
-            logger.debug('successfully connected to service', url=self.url)
+            logger.debug('successfully connected to service',
+                         client_id=self.request['client_id'],
+                         trace=self.request['trace'],
+                         url=self.url)
 
     @retry(reraise=True, stop=stop_after_attempt(basic_attempt_limit),
            wait=wait_exponential(multiplier=wait_multiplier, exp_base=25),
@@ -58,7 +61,7 @@ class RetryRequest:
                                                                                        ClientConnectorError))))
     async def _request_basic(self):
         # basic request without keep-alive to avoid terminating service.
-        logger.info('request using basic connection')
+        logger.info('request using basic connection', client_id=self.request['client_id'], trace=self.request['trace'])
 
         async with aiohttp.request(
                 self.method, self.url, auth=self.auth, json=self.json, headers=self.headers) as resp:
@@ -90,6 +93,8 @@ class RetryRequest:
         Finally the error will be propagated.
         """
         logger.debug('making request with handler',
+                     client_id=self.request['client_id'],
+                     trace=self.request['trace'],
                      method=self.method,
                      url=self.url)
         try:
@@ -97,16 +102,23 @@ class RetryRequest:
                 return await self._request_using_pool()
             except RetryError as retry_ex:
                 attempts = retry_ex.last_attempt.attempt_number
-                logger.warn('Could not make request using normal pooled connection', attempts=attempts)
+                logger.warn('Could not make request using normal pooled connection',
+                            client_id=self.request['client_id'],
+                            trace=self.request['trace'],
+                            attempts=attempts)
                 return await self._request_basic()
         except ClientResponseError as ex:
             if not ex.status == 404:
                 logger.error('error in response',
+                             client_id=self.request['client_id'],
+                             trace=self.request['trace'],
                              url=self.url,
                              status_code=ex.status)
             raise ex
         except (ClientConnectionError, ClientConnectorError) as ex:
             logger.error('client failed to connect',
-                         url=self.url,
-                         client_ip=self.request['client_ip'])
+                         client_ip=self.request['client_ip'],
+                         client_id=self.request['client_id'],
+                         trace=self.request['trace'],
+                         url=self.url)
             raise ex

--- a/app/request_handlers.py
+++ b/app/request_handlers.py
@@ -35,7 +35,6 @@ class RequestCommon(View):
 class RequestCodeIndividual(RequestCommon):
     @aiohttp_jinja2.template('request-code-individual.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         if display_region == 'cy':
             page_title = 'Gofyn am god mynediad unigol'
@@ -53,7 +52,6 @@ class RequestCodeIndividual(RequestCommon):
         }
 
     async def post(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         request_type = 'access-code'
         self.log_entry(request, display_region + '/request/access-code/individual')
@@ -69,6 +67,8 @@ class RequestCodeIndividual(RequestCommon):
                 case_type_value = attributes['case_type']
                 if case_type_value:
                     logger.info('have session and case_type - directing to select method',
+                                client_id=request['client_id'],
+                                trace=request['trace'],
                                 is_individual=session['attributes']['individual'],
                                 type_of_case=case_type_value)
                     raise HTTPFound(
@@ -81,7 +81,8 @@ class RequestCodeIndividual(RequestCommon):
         except KeyError:
             attributes = {'individual': True}
             session['attributes'] = attributes
-            logger.info('no session - directing to enter address', session_attributes=attributes)
+            logger.info('no session - directing to enter address',
+                        client_id=request['client_id'], trace=request['trace'], session_attributes=attributes)
             raise HTTPFound(
                 request.app.router['CommonEnterAddress:get'].url_for(user_journey='request',
                                                                      sub_user_journey=request_type,
@@ -92,7 +93,6 @@ class RequestCodeIndividual(RequestCommon):
 class RequestIndividualForm(RequestCommon):
     @aiohttp_jinja2.template('request-questionnaire-individual.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         if display_region == 'cy':
             page_title = 'Gofyn am holiadur papur i unigolion'
@@ -110,7 +110,6 @@ class RequestIndividualForm(RequestCommon):
         }
 
     async def post(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         request_type = 'paper-questionnaire'
         self.log_entry(request, display_region + '/request/paper-questionnaire/individual')
@@ -129,7 +128,6 @@ class RequestIndividualForm(RequestCommon):
 class RequestCodeHousehold(RequestCommon):
     @aiohttp_jinja2.template('request-code-household.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         if display_region == 'cy':
             page_title = 'Gofyn am god mynediad newydd ar gyfer y cartref'
@@ -147,7 +145,6 @@ class RequestCodeHousehold(RequestCommon):
         }
 
     async def post(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         request_type = 'access-code'
         self.log_entry(request, display_region + '/request/access-code/household')
@@ -165,7 +162,6 @@ class RequestCodeHousehold(RequestCommon):
 class RequestHouseholdForm(RequestCommon):
     @aiohttp_jinja2.template('request-questionnaire-household.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         if display_region == 'cy':
             page_title = "Gofyn am holiadur papur y cartref"
@@ -183,7 +179,6 @@ class RequestHouseholdForm(RequestCommon):
         }
 
     async def post(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         self.log_entry(request, display_region + '/request/paper-questionnaire/household')
 
@@ -201,7 +196,6 @@ class RequestHouseholdForm(RequestCommon):
 class RequestCodeSelectHowToReceive(RequestCommon):
     @aiohttp_jinja2.template('request-code-select-how-to-receive.html')
     async def get(self, request):
-        self.setup_request(request)
 
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
@@ -242,7 +236,6 @@ class RequestCodeSelectHowToReceive(RequestCommon):
         return attributes
 
     async def post(self, request):
-        self.setup_request(request)
 
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
@@ -254,7 +247,7 @@ class RequestCodeSelectHowToReceive(RequestCommon):
             request_method = data['form-select-method']
         except KeyError:
             logger.info('request method selection error',
-                        client_ip=request['client_ip'])
+                        client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
             if display_region == 'cy':
                 flash(request, NO_SELECTION_CHECK_MSG_CY)
             else:
@@ -278,7 +271,10 @@ class RequestCodeSelectHowToReceive(RequestCommon):
         else:
             # catch all just in case, should never get here
             logger.info('request method selection error',
-                        client_ip=request['client_ip'], method_selected=request_method)
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        method_selected=request_method)
             if display_region == 'cy':
                 flash(request, NO_SELECTION_CHECK_MSG_CY)
             else:
@@ -295,7 +291,6 @@ class RequestCodeSelectHowToReceive(RequestCommon):
 class RequestCodeEnterMobile(RequestCommon):
     @aiohttp_jinja2.template('request-code-enter-mobile.html')
     async def get(self, request):
-        self.setup_request(request)
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
 
@@ -324,7 +319,6 @@ class RequestCodeEnterMobile(RequestCommon):
         return attributes
 
     async def post(self, request):
-        self.setup_request(request)
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
 
@@ -345,7 +339,7 @@ class RequestCodeEnterMobile(RequestCommon):
                                                                                 locale)
 
             logger.info('valid mobile number',
-                        client_ip=request['client_ip'])
+                        client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
 
             attributes['mobile_number'] = mobile_number
             attributes['submitted_mobile_number'] = data['request-mobile-number']
@@ -356,7 +350,7 @@ class RequestCodeEnterMobile(RequestCommon):
                                                                                display_region=display_region))
 
         except (InvalidDataError, InvalidDataErrorWelsh) as exc:
-            logger.info(exc, client_ip=request['client_ip'])
+            logger.info(exc, client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
             if exc.message_type == 'empty':
                 flash_message = FlashMessage.generate_flash_message(str(exc), 'ERROR', 'MOBILE_ENTER_ERROR',
                                                                     'mobile_empty')
@@ -376,7 +370,6 @@ class RequestCodeEnterMobile(RequestCommon):
 class RequestCodeConfirmSendByText(RequestCommon):
     @aiohttp_jinja2.template('request-code-confirm-send-by-text.html')
     async def get(self, request):
-        self.setup_request(request)
 
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
@@ -416,7 +409,6 @@ class RequestCodeConfirmSendByText(RequestCommon):
         return attributes
 
     async def post(self, request):
-        self.setup_request(request)
 
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
@@ -431,7 +423,7 @@ class RequestCodeConfirmSendByText(RequestCommon):
             mobile_confirmation = data['request-mobile-confirmation']
         except KeyError:
             logger.info('mobile confirmation error',
-                        client_ip=request['client_ip'])
+                        client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
             if display_region == 'cy':
                 flash(request, NO_SELECTION_CHECK_MSG_CY)
             else:
@@ -456,7 +448,10 @@ class RequestCodeConfirmSendByText(RequestCommon):
 
             logger.info(f"fulfilment query: case_type={attributes['case_type']}, region={attributes['region']}, "
                         f"individual={fulfilment_individual}",
-                        client_ip=request['client_ip'], postcode=attributes['postcode'])
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        postcode=attributes['postcode'])
 
             fulfilment_code_array = []
 
@@ -495,7 +490,10 @@ class RequestCodeConfirmSendByText(RequestCommon):
         else:
             # catch all just in case, should never get here
             logger.info('mobile confirmation error',
-                        client_ip=request['client_ip'], user_selection=mobile_confirmation)
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        user_selection=mobile_confirmation)
             flash(request, NO_SELECTION_CHECK_MSG)
             raise HTTPFound(
                 request.app.router['RequestCodeConfirmSendByText:get'].url_for(
@@ -509,7 +507,6 @@ class RequestCodeConfirmSendByText(RequestCommon):
 class RequestCommonEnterName(RequestCommon):
     @aiohttp_jinja2.template('request-common-enter-name.html')
     async def get(self, request):
-        self.setup_request(request)
 
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
@@ -539,7 +536,6 @@ class RequestCommonEnterName(RequestCommon):
         return attributes
 
     async def post(self, request):
-        self.setup_request(request)
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
 
@@ -555,6 +551,8 @@ class RequestCommonEnterName(RequestCommon):
         if not form_valid:
             logger.info('form submission error',
                         client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
                         region_of_site=display_region,
                         type_of_request=request_type)
             raise HTTPFound(
@@ -580,7 +578,6 @@ class RequestCommonEnterName(RequestCommon):
 class RequestCommonConfirmSendByPost(RequestCommon):
     @aiohttp_jinja2.template('request-common-confirm-send-by-post.html')
     async def get(self, request):
-        self.setup_request(request)
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
 
@@ -653,7 +650,6 @@ class RequestCommonConfirmSendByPost(RequestCommon):
         }
 
     async def post(self, request):
-        self.setup_request(request)
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
 
@@ -668,6 +664,8 @@ class RequestCommonConfirmSendByPost(RequestCommon):
         except KeyError:
             logger.info('name confirmation error',
                         client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
                         type_of_request=request_type,
                         region_of_site=display_region)
             if display_region == 'cy':
@@ -726,7 +724,10 @@ class RequestCommonConfirmSendByPost(RequestCommon):
                         f"fulfilment query: case_type={attributes['case_type']}, "
                         f"fulfilment_type={fulfilment_type_array}, "
                         f"region={attributes['region']}, individual={fulfilment_individual}",
-                        client_ip=request['client_ip'], postcode=attributes['postcode'],
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        postcode=attributes['postcode'],
                         room_number_entered=room_number_value)
 
                     if room_number_value:
@@ -788,7 +789,8 @@ class RequestCommonConfirmSendByPost(RequestCommon):
                     attributes['region'], attributes['number_of_people'],
                     include_household=include_household, large_print=large_print)
 
-                logger.info(required_forms, client_ip=request['client_ip'])
+                logger.info(required_forms,
+                            client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
 
                 number_of_household_forms = required_forms['number_of_household_forms']
                 number_of_continuation_forms = required_forms['number_of_continuation_forms']
@@ -863,7 +865,10 @@ class RequestCommonConfirmSendByPost(RequestCommon):
                         f"fulfilment query: case_type={attributes['case_type']}, "
                         f"fulfilment_type={fulfilment_type_array}, "
                         f"region={attributes['region']}, individual={fulfilment_individual}",
-                        client_ip=request['client_ip'], case_id=attributes['case_id'])
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        case_id=attributes['case_id'])
 
                     try:
                         await RHService.request_fulfilment_post(request,
@@ -903,8 +908,12 @@ class RequestCommonConfirmSendByPost(RequestCommon):
         else:
             # catch all just in case, should never get here
             logger.info('name confirmation error',
-                        client_ip=request['client_ip'], user_selection=name_address_confirmation,
-                        region_of_site=display_region, type_of_request=request_type)
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        user_selection=name_address_confirmation,
+                        region_of_site=display_region,
+                        type_of_request=request_type)
             if display_region == 'cy':
                 flash(request, FlashMessage.generate_flash_message('Dewiswch ateb',
                                                                    'ERROR',
@@ -926,7 +935,6 @@ class RequestCommonConfirmSendByPost(RequestCommon):
 class RequestCodeSentByText(RequestCommon):
     @aiohttp_jinja2.template('request-code-sent-by-text.html')
     async def get(self, request):
-        self.setup_request(request)
 
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
@@ -969,7 +977,6 @@ class RequestCodeSentByText(RequestCommon):
 class RequestCodeSentByPost(RequestCommon):
     @aiohttp_jinja2.template('request-code-sent-by-post.html')
     async def get(self, request):
-        self.setup_request(request)
 
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
@@ -1024,7 +1031,6 @@ class RequestCodeSentByPost(RequestCommon):
 class RequestCommonPeopleInHousehold(RequestCommon):
     @aiohttp_jinja2.template('request-common-people-in-household.html')
     async def get(self, request):
-        self.setup_request(request)
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
 
@@ -1050,7 +1056,6 @@ class RequestCommonPeopleInHousehold(RequestCommon):
         }
 
     async def post(self, request):
-        self.setup_request(request)
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
 
@@ -1066,6 +1071,8 @@ class RequestCommonPeopleInHousehold(RequestCommon):
         if not form_valid:
             logger.info('form submission error',
                         client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
                         region_of_site=display_region,
                         type_of_request=request_type)
             raise HTTPFound(
@@ -1084,7 +1091,6 @@ class RequestCommonPeopleInHousehold(RequestCommon):
 class RequestQuestionnaireManager(RequestCommon):
     @aiohttp_jinja2.template('request-questionnaire-manager.html')
     async def get(self, request):
-        self.setup_request(request)
 
         request_type = 'paper-questionnaire'
         display_region = request.match_info['display_region']
@@ -1113,7 +1119,6 @@ class RequestQuestionnaireManager(RequestCommon):
 class RequestQuestionnaireCancelled(RequestCommon):
     @aiohttp_jinja2.template('request-questionnaire-cancelled.html')
     async def get(self, request):
-        self.setup_request(request)
 
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
@@ -1147,7 +1152,6 @@ class RequestQuestionnaireCancelled(RequestCommon):
 class RequestQuestionnaireSent(RequestCommon):
     @aiohttp_jinja2.template('request-questionnaire-sent.html')
     async def get(self, request):
-        self.setup_request(request)
 
         request_type = 'paper-questionnaire'
         display_region = request.match_info['display_region']
@@ -1194,7 +1198,6 @@ class RequestQuestionnaireSent(RequestCommon):
 class RequestContinuationSent(RequestCommon):
     @aiohttp_jinja2.template('request-questionnaire-sent.html')
     async def get(self, request):
-        self.setup_request(request)
 
         request_type = 'continuation-questionnaire'
         display_region = request.match_info['display_region']
@@ -1235,7 +1238,6 @@ class RequestContinuationSent(RequestCommon):
 class RequestLargePrintSentPost(RequestCommon):
     @aiohttp_jinja2.template('request-questionnaire-sent.html')
     async def get(self, request):
-        self.setup_request(request)
 
         request_type = 'large-print'
         display_region = request.match_info['display_region']
@@ -1282,7 +1284,6 @@ class RequestLargePrintSentPost(RequestCommon):
 class RequestCodeNIManager(RequestCommon):
     @aiohttp_jinja2.template('request-code-nisra-manager.html')
     async def get(self, request):
-        self.setup_request(request)
 
         display_region = 'ni'
         page_title = 'You need to visit the Communal Establishment Manager Portal'
@@ -1300,7 +1301,6 @@ class RequestCodeNIManager(RequestCommon):
 class RequestFormNIManager(RequestCommon):
     @aiohttp_jinja2.template('request-questionnaire-nisra-manager.html')
     async def get(self, request):
-        self.setup_request(request)
 
         display_region = 'ni'
         page_title = 'You need to visit the Communal Establishment Manager Portal'
@@ -1318,7 +1318,6 @@ class RequestFormNIManager(RequestCommon):
 class RequestContinuationNotAHousehold(RequestCommon):
     @aiohttp_jinja2.template('request-continuation-not-a-household.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         if display_region == 'cy':
             page_title = "Nid yw'r cyfeiriad hwn yn gyfeiriad cartref"

--- a/app/request_handlers.py
+++ b/app/request_handlers.py
@@ -67,6 +67,7 @@ class RequestCodeIndividual(RequestCommon):
                 case_type_value = attributes['case_type']
                 if case_type_value:
                     logger.info('have session and case_type - directing to select method',
+                                client_ip=request['client_ip'],
                                 client_id=request['client_id'],
                                 trace=request['trace'],
                                 is_individual=session['attributes']['individual'],
@@ -82,7 +83,10 @@ class RequestCodeIndividual(RequestCommon):
             attributes = {'individual': True}
             session['attributes'] = attributes
             logger.info('no session - directing to enter address',
-                        client_id=request['client_id'], trace=request['trace'], session_attributes=attributes)
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        session_attributes=attributes)
             raise HTTPFound(
                 request.app.router['CommonEnterAddress:get'].url_for(user_journey='request',
                                                                      sub_user_journey=request_type,

--- a/app/security.py
+++ b/app/security.py
@@ -125,14 +125,18 @@ async def get_permitted_session(request) -> Session:
     try:
         identity = session[SESSION_KEY]
         logger.info('permission granted',
+                    client_ip=request['client_ip'],
+                    client_id=request['client_id'],
+                    trace=request['trace'],
                     identity=identity,
-                    url=request.rel_url.human_repr(),
-                    client_ip=request['client_ip'])
+                    url=request.rel_url.human_repr())
         return session
     except KeyError:
         logger.warn('permission denied',
-                    url=request.rel_url.human_repr(),
-                    client_ip=request['client_ip'])
+                    client_ip=request['client_ip'],
+                    client_id=request['client_id'],
+                    trace=request['trace'],
+                    url=request.rel_url.human_repr())
         raise HTTPForbidden
 
 
@@ -146,12 +150,16 @@ async def forget(request):
         identity = session[SESSION_KEY]
         session.pop(SESSION_KEY, None)
         logger.info('identity forgotten',
-                    identity=identity,
-                    client_ip=request['client_ip'])
+                    client_ip=request['client_ip'],
+                    client_id=request['client_id'],
+                    trace=request['trace'],
+                    identity=identity)
     except KeyError:
         logger.warn('identity not previously remembered',
-                    url=request.rel_url.human_repr(),
-                    client_ip=request['client_ip'])
+                    client_ip=request['client_ip'],
+                    client_id=request['client_id'],
+                    trace=request['trace'],
+                    url=request.rel_url.human_repr())
 
 
 async def remember(identity, request):
@@ -163,6 +171,8 @@ async def remember(identity, request):
     session[SESSION_KEY] = identity
     logger.info('identity remembered',
                 client_ip=request['client_ip'],
+                client_id=request['client_id'],
+                trace=request['trace'],
                 identity=identity)
 
 
@@ -174,10 +184,14 @@ async def invalidate(request):
     try:
         session.invalidate()
         logger.info('session invalidated',
-                    client_ip=request['client_ip'])
+                    client_ip=request['client_ip'],
+                    client_id=request['client_id'],
+                    trace=request['trace'])
     except KeyError:
         logger.warn('session already invalidated',
-                    client_ip=request['client_ip'])
+                    client_ip=request['client_ip'],
+                    client_id=request['client_id'],
+                    trace=request['trace'])
 
 
 def get_sha256_hash(uac: str):

--- a/app/session.py
+++ b/app/session.py
@@ -68,7 +68,10 @@ async def get_existing_session(request, user_journey, sub_user_journey=None) -> 
     if not session.new:
         return session
     else:
-        logger.warn('session timed out', client_ip=request['client_ip'])
+        logger.warn('session timed out',
+                    client_ip=request['client_ip'],
+                    client_id=request['client_id'],
+                    trace=request['trace'])
         raise SessionTimeout(user_journey, sub_user_journey)
 
 
@@ -76,5 +79,5 @@ def get_session_value(session, key, user_journey, sub_user_journey=None):
     try:
         return session[key]
     except KeyError:
-        logger.info(f'Failed to extract session key {key}')
+        logger.info(f'Failed to extract session key {key}', client_id=session['client_id'])
         raise SessionTimeout(user_journey, sub_user_journey)

--- a/app/start_handlers.py
+++ b/app/start_handlers.py
@@ -106,7 +106,10 @@ class Start(StartCommon):
                 }
         except KeyError:
             logger.info('no adlocation present',
-                        client_id=request['client_id'], trace=request['trace'], region_of_site=display_region)
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        region_of_site=display_region)
             return {
                 'display_region': display_region,
                 'page_title': page_title,

--- a/app/support_centre_handlers.py
+++ b/app/support_centre_handlers.py
@@ -15,7 +15,6 @@ support_centre_routes = RouteTableDef()
 class SupportCentreEnterPostcode(View):
     @aiohttp_jinja2.template('support_centre_enter_postcode.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
 
         self.log_entry(request, display_region + '/find-a-support-centre')
@@ -39,7 +38,6 @@ class SupportCentreEnterPostcode(View):
 
     @aiohttp_jinja2.template('support_centre_enter_postcode.html')
     async def post(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
 
         if display_region == 'cy':
@@ -53,11 +51,19 @@ class SupportCentreEnterPostcode(View):
 
         try:
             postcode = ProcessPostcode.validate_postcode(data['form-enter-address-postcode'], locale)
-            logger.info('valid postcode', client_ip=request['client_ip'],
-                        valid_postcode=postcode, region_of_site=display_region)
+            logger.info('valid postcode',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        valid_postcode=postcode,
+                        region_of_site=display_region)
 
         except (InvalidDataError, InvalidDataErrorWelsh) as exc:
-            logger.info('invalid postcode', client_ip=request['client_ip'], region_of_site=display_region)
+            logger.info('invalid postcode',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        region_of_site=display_region)
             flash_message = FlashMessage.generate_flash_message(str(exc), 'ERROR', 'POSTCODE_ENTER_ERROR', 'postcode')
             flash(request, flash_message)
             raise HTTPFound(
@@ -76,7 +82,6 @@ class SupportCentreEnterPostcode(View):
 class SupportCentreListCentres(View):
     @aiohttp_jinja2.template('support_centre_list_of_centres.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
 
         if display_region == 'cy':
@@ -86,11 +91,19 @@ class SupportCentreListCentres(View):
 
         try:
             postcode_value = ProcessPostcode.validate_postcode(request.match_info['postcode'], locale)
-            logger.info('valid postcode', client_ip=request['client_ip'],
-                        valid_postcode=postcode_value, region_of_site=display_region)
+            logger.info('valid postcode',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        valid_postcode=postcode_value,
+                        region_of_site=display_region)
 
         except (InvalidDataError, InvalidDataErrorWelsh):
-            logger.info('invalid postcode', client_ip=request['client_ip'], region_of_site=display_region)
+            logger.info('invalid postcode',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        region_of_site=display_region)
             attributes = {
                 'page_title': 'Error',
                 'display_region': display_region,
@@ -116,10 +129,12 @@ class SupportCentreListCentres(View):
                 'page_url': View.gen_page_url(request)
             }
             if ex.status == 404:
-                logger.warn('AD Lookup API returned as postcode not existing', client_ip=request['client_ip'])
+                logger.warn('AD Lookup API returned as postcode not existing',
+                            client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
                 return aiohttp_jinja2.render_template('404.html', request, attributes, status=404)
             else:
-                logger.error('AD Lookup API not responding', client_ip=request['client_ip'])
+                logger.error('AD Lookup API not responding',
+                             client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
                 return aiohttp_jinja2.render_template('error.html', request, attributes, status=500)
 
         list_of_centres_content = {

--- a/app/trace.py
+++ b/app/trace.py
@@ -1,0 +1,23 @@
+from aiohttp import web
+from aiohttp_session import get_session
+from uuid import uuid4
+
+
+def get_trace(headers):
+    try:
+        trace, span = headers.get("X-Cloud-Trace-Context").split("/")
+    except (ValueError, AttributeError):
+        return None
+    return trace
+
+
+@web.middleware
+async def trace_middleware(request, handler):
+    request['trace'] = get_trace(request.headers)
+    request['client_ip'] = request.headers.get('X-Forwarded-For')
+    session = await get_session(request)
+    if 'client_id' in session:
+        request['client_id'] = session['client_id']
+    else:
+        session['client_id'] = request['client_id'] = str(uuid4())
+    return await handler(request)

--- a/app/utils.py
+++ b/app/utils.py
@@ -67,6 +67,7 @@ class View:
     def log_entry(request, endpoint):
         method = request.method
         logger.info(f"received {method} on endpoint '{endpoint}'",
+                    client_ip=request['client_ip'],
                     client_id=request['client_id'],
                     trace=request['trace'],
                     method=request.method,

--- a/app/utils.py
+++ b/app/utils.py
@@ -42,10 +42,6 @@ class View:
     page_title_error_prefix_cy = 'Gwall: '
 
     @staticmethod
-    def setup_request(request):
-        request['client_ip'] = request.headers.get('X-Forwarded-For', None)
-
-    @staticmethod
     def get_now_utc():
         return datetime.utcnow()
 
@@ -57,7 +53,9 @@ class View:
             if ip_validation_pattern.fullmatch(client_ip) and client_ip.count(',') > 1:
                 single_ip = client_ip.split(', ', -1)[-3]
             else:
-                logger.warn('clientIP failed validation. Provided IP - ' + client_ip)
+                logger.warn('clientIP failed validation. Provided IP - ' + client_ip,
+                            client_id=request['client_id'],
+                            trace=request['trace'])
                 single_ip = ''
         elif request.headers.get('Origin', None) and 'localhost' in request.headers.get('Origin', None):
             single_ip = '127.0.0.1'
@@ -69,6 +67,8 @@ class View:
     def log_entry(request, endpoint):
         method = request.method
         logger.info(f"received {method} on endpoint '{endpoint}'",
+                    client_id=request['client_id'],
+                    trace=request['trace'],
                     method=request.method,
                     path=request.path)
 
@@ -177,7 +177,8 @@ class View:
             else:
                 raise ex
 
-        logger.info('redirecting to eq', client_ip=request['client_ip'])
+        logger.info('redirecting to eq',
+                    client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
         eq_url = app['EQ_URL']
         raise HTTPFound(f'{eq_url}/session?token={token}')
 
@@ -352,7 +353,11 @@ class ProcessNumberOfPeople:
         number_of_people_valid = True
 
         if (data.get('number_of_people')) == '':
-            logger.info('number_of_people empty', client_ip=request['client_ip'], region_of_site=display_region,
+            logger.info('number_of_people empty',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        region_of_site=display_region,
                         type_of_request=request_type)
             if display_region == 'cy':
                 flash(request, FlashMessage.generate_flash_message("Rhowch nifer y bobl yn eich cartref",
@@ -365,7 +370,11 @@ class ProcessNumberOfPeople:
             number_of_people_valid = False
 
         elif not (data.get('number_of_people')).isnumeric():
-            logger.info('number_of_people nan', client_ip=request['client_ip'], region_of_site=display_region,
+            logger.info('number_of_people nan',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        region_of_site=display_region,
                         type_of_request=request_type)
             if display_region == 'cy':
                 flash(request, FlashMessage.generate_flash_message("Rhowch rif",
@@ -379,7 +388,10 @@ class ProcessNumberOfPeople:
 
         elif request_type == 'continuation-questionnaire':
             if (display_region == 'ni') and (int(data.get('number_of_people')) < 7):
-                logger.info('number_of_people continuation less than 7', client_ip=request['client_ip'],
+                logger.info('number_of_people continuation less than 7',
+                            client_ip=request['client_ip'],
+                            client_id=request['client_id'],
+                            trace=request['trace'],
                             region_of_site=display_region,
                             type_of_request=request_type)
                 flash(request, FlashMessage.generate_flash_message('Enter a number greater than 6',
@@ -388,7 +400,10 @@ class ProcessNumberOfPeople:
                 number_of_people_valid = False
 
             elif (not display_region == 'ni') and (int(data.get('number_of_people')) < 6):
-                logger.info('number_of_people continuation less than 6', client_ip=request['client_ip'],
+                logger.info('number_of_people continuation less than 6',
+                            client_ip=request['client_ip'],
+                            client_id=request['client_id'],
+                            trace=request['trace'],
                             region_of_site=display_region,
                             type_of_request=request_type)
                 if display_region == 'cy':
@@ -402,7 +417,8 @@ class ProcessNumberOfPeople:
                 number_of_people_valid = False
 
             elif int(data.get('number_of_people')) > 30:
-                logger.info('number_of_people continuation greater than 30', client_ip=request['client_ip'])
+                logger.info('number_of_people continuation greater than 30',
+                            client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
                 if display_region == 'cy':
                     flash(request, FlashMessage.generate_flash_message("Rhowch rif sy'n llai na 31",
                                                                        'ERROR', 'NUMBER_OF_PEOPLE_ERROR',
@@ -414,7 +430,8 @@ class ProcessNumberOfPeople:
                 number_of_people_valid = False
 
         elif int(data.get('number_of_people')) > 30:
-            logger.info('number_of_people greater than 30', client_ip=request['client_ip'])
+            logger.info('number_of_people greater than 30',
+                        client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
             if display_region == 'cy':
                 flash(request, FlashMessage.generate_flash_message("Rhowch rif sy'n llai na 31",
                                                                    'ERROR', 'NUMBER_OF_PEOPLE_ERROR',
@@ -540,6 +557,8 @@ class RHService(View):
         logger.info('request linked case',
                     uac_hash=uac_hash,
                     client_ip=request['client_ip'],
+                    client_id=request['client_id'],
+                    trace=request['trace'],
                     country_code=address['countryCode'],
                     postcode_value=address['postcode'],
                     uprn_value=address['uprn'])
@@ -614,8 +633,10 @@ class RHService(View):
     async def get_uac_details(request):
         uac_hash = request['uac_hash']
         logger.info('making get request for uac',
-                    uac_hash=uac_hash,
-                    client_ip=request['client_ip'])
+                    client_ip=request['client_ip'],
+                    client_id=request['client_id'],
+                    trace=request['trace'],
+                    uac_hash=uac_hash)
         rhsvc_url = request.app['RHSVC_URL']
         return await View._make_request(request,
                                         'GET',

--- a/app/web_form_handlers.py
+++ b/app/web_form_handlers.py
@@ -30,7 +30,6 @@ web_form_routes = RouteTableDef()
 class WebForm(View):
     @aiohttp_jinja2.template('web-form.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         if display_region == 'cy':
             page_title = 'Gwe-ffurflen'
@@ -55,7 +54,6 @@ class WebForm(View):
 
     @aiohttp_jinja2.template('web-form.html')
     async def post(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         self.log_entry(request, display_region + '/web-form')
 
@@ -110,12 +108,20 @@ class WebForm(View):
             form_valid = False
 
         if not form_valid:
-            logger.info('web form submission error', client_ip=request['client_ip'], region_of_site=display_region)
+            logger.info('web form submission error',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        region_of_site=display_region)
             raise HTTPFound(
                 request.app.router['WebForm:get'].url_for(display_region=display_region))
 
         else:
-            logger.info('call web form endpoint', client_ip=request['client_ip'], region_of_site=display_region)
+            logger.info('call web form endpoint',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        region_of_site=display_region)
             if display_region == 'cy':
                 language = 'CY'
             else:
@@ -145,7 +151,6 @@ class WebForm(View):
 class WebFormSuccess(View):
     @aiohttp_jinja2.template('web-form-success.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         if display_region == 'cy':
             page_title = "Diolch am gysylltu â ni"

--- a/app/webchat_handlers.py
+++ b/app/webchat_handlers.py
@@ -113,7 +113,6 @@ class WebChat(View):
 class WebChat(WebChat):
     @aiohttp_jinja2.template('webchat-form.html')
     async def get(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         if display_region == 'cy':
             page_title = 'Gwe-sgwrs'
@@ -135,7 +134,11 @@ class WebChat(WebChat):
                 'privacy_link': View.get_campaign_site_link(request, display_region, 'privacy')
             }
         else:
-            logger.info('webchat closed', client_ip=request['client_ip'], region_of_site=display_region)
+            logger.info('webchat closed',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        region_of_site=display_region)
             return {
                 'webchat_status': 'closed',
                 'display_region': display_region,
@@ -154,7 +157,6 @@ class WebChat(WebChat):
 
     @aiohttp_jinja2.template('webchat-form.html')
     async def post(self, request):
-        self.setup_request(request)
         display_region = request.match_info['display_region']
         if display_region == 'cy':
             page_title = 'Gwe-sgwrs'
@@ -171,6 +173,8 @@ class WebChat(WebChat):
         if not form_valid:
             logger.info('form submission error',
                         client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
                         region_of_site=display_region)
             raise HTTPFound(
                 request.app.router['WebChat:get'].url_for(display_region=display_region))
@@ -187,12 +191,20 @@ class WebChat(WebChat):
             'page_url': View.gen_page_url(request)
         }
 
-        logger.info('date/time check', client_ip=request['client_ip'], region_of_site=display_region)
+        logger.info('date/time check',
+                    client_ip=request['client_ip'],
+                    client_id=request['client_id'],
+                    trace=request['trace'],
+                    region_of_site=display_region)
         if WebChat.check_open():
             return aiohttp_jinja2.render_template('webchat-window.html',
                                                   request, context)
         else:
-            logger.info('webchat closed', client_ip=request['client_ip'], region_of_site=display_region)
+            logger.info('webchat closed',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        region_of_site=display_region)
             return {
                 'webchat_status': 'closed',
                 'display_region': display_region,

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -208,7 +208,7 @@ class RHTestCase(AioHTTPTestCase):
                 if (event in record.message
                         and all(record.__dict__[key] == val
                                 for key, val in kwargs.items())):
-                    break
+                    return record
             except KeyError:
                 pass
         else:

--- a/tests/unit/test_error_handlers.py
+++ b/tests/unit/test_error_handlers.py
@@ -1,6 +1,5 @@
 from aiohttp.test_utils import unittest_run_loop
 
-from app.app import create_app
 from . import RHTestCase
 
 

--- a/tests/unit/test_trace.py
+++ b/tests/unit/test_trace.py
@@ -1,0 +1,66 @@
+from app.trace import get_trace
+from .helpers import TestHelpers
+from aiohttp.test_utils import unittest_run_loop
+from uuid import UUID
+
+
+def test_get_trace():
+    header = {"X-Cloud-Trace-Context": "0123456789/0123456789012345678901;o=1"}
+    trace = get_trace(header)
+    assert trace == "0123456789"
+
+
+def test_get_trace_no_xcloud_header():
+    header = {}
+    trace = get_trace(header)
+    assert trace is None
+
+
+def test_get_trace_malformed_xcloud_header():
+    header = {"X-Cloud-Trace-Context": "not a real trace context"}
+    trace = get_trace(header)
+    assert trace is None
+
+
+class TestTraceHandling(TestHelpers):
+
+    def clear_session(self):
+        """
+        Ensure session cleared from previous requests
+        """
+        jar = self.client._session.cookie_jar
+        jar.clear()
+
+    def validate_uuid4(self, uuid_string):
+        """
+        Validate that a UUID string is in fact a valid uuid4
+        """
+        try:
+            UUID(uuid_string, version=4)
+            return True
+        except ValueError:
+            # If it's a value error, then the string
+            # is not a valid hex code for a UUID.
+            return False
+
+    @unittest_run_loop
+    async def test_client_id_in_session(self):
+        self.clear_session()
+        cookie = {'RH_SESSION': '{ "session": {"client_id": "36be6b97-b4de-4718-8a74-8b27fb03ca8c"}}'}
+        header = {"X-Cloud-Trace-Context": "0123456789/0123456789012345678901;o=1"}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            await self.client.request('GET', '/en/start/',
+                                      allow_redirects=False, cookies=cookie, headers=header)
+            self.assertLogEvent(cm, "received GET on endpoint 'en/start'",
+                                client_id='36be6b97-b4de-4718-8a74-8b27fb03ca8c',
+                                trace='0123456789')
+
+    @unittest_run_loop
+    async def test_client_id_not_in_session(self):
+        self.clear_session()
+        header = {"X-Cloud-Trace-Context": "0123456789/0123456789012345678901;o=1"}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            await self.client.request('GET', '/en/start/',
+                                      allow_redirects=False, headers=header)
+            log_record = self.assertLogEvent(cm, "received GET on endpoint 'en/start'", trace='0123456789')
+            self.assertTrue(self.validate_uuid4(log_record.__dict__['client_id']))


### PR DESCRIPTION
# Motivation and Context
Enable logs to be filtered to associate previous log statements generated from an individual client and provide context in investigating client errors, warnings.

# What has changed
Middleware has been introduced so that for every request a client_id and trace are added to the request object and available to log statements.
The trace is taken from the X-Cloud-Trace-Context header which is added to a request by Google and has the specification `X-Cloud-Trace-Context: TRACE_ID/SPAN_ID;o=TRACE_TRUE`. A trace is unique to a client request and is used to group logs within a client request process. A span would represent a unit of work within a trace, if for instance we were using OpenTelemetry or OpenCensus client libraries to instrument the code and generate logs and metrics and display latency data in Cloud Trace. Using these could have performance implications in production and not to be considered at this stage, so I have simply added the trace to log statements to group request logs and ignored span as unnecessary noise with no purpose for production.
The client_id is used to group all requests from a client during a session. It is stored within a session and made available by adding to the incoming request if available in the session, or created if not.
I have also taken the opportunity to make the client_ip available in the same manner, removing the frequent calls to `self.setup_request(request)` in each view handler.

# How to test?
New unit tests added. Run against cucumber tests. I have currently deployed this code to the development environment so you can generate log statements and see the client_id and trace in the jsonPayload data. 

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1456