### PR TITLE
Cr 1724 add uac 401 trap

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,7 @@
 VERSION = '0.0.1'
 
+START_PAGE_TITLE_EN = 'Start census'
+START_PAGE_TITLE_CY = "Dechrau'r cyfrifiad"
 
 BAD_CODE_MSG = {'text': 'Enter an access code', 'clickable': True, 'level': 'ERROR', 'type': 'BAD_CODE', 'field': 'uac_empty'}  # NOQA
 INVALID_CODE_MSG = {'text': 'Enter a valid access code', 'clickable': True, 'level': 'ERROR', 'type': 'INVALID_CODE', 'field': 'uac_invalid'}  # NOQA

--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -152,7 +152,10 @@ async def not_found_error(request):
 
 
 async def invalid_access_code(request):
-    logger.warn('invalid access code entered')
+    logger.warn('invalid access code entered',
+                client_ip=request['client_ip'],
+                client_id=request['client_id'],
+                trace=request['trace'])
     attributes = check_display_region(request)
     if attributes['display_region'] == 'cy':
         attributes['page_title'] = View.page_title_error_prefix_cy + START_PAGE_TITLE_CY

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -57,3 +57,7 @@ class InvalidDataErrorWelsh(Exception):
     def __init__(self, message=None, message_type=None):
         super().__init__(message or "Mae'r gwerth rydych wedi'i roi yn annilys")
         self.message_type = message_type
+
+
+class InvalidAccessCode(Exception):
+    """Raised when an invalid UAC is entered"""

--- a/app/start_handlers.py
+++ b/app/start_handlers.py
@@ -9,11 +9,12 @@ from structlog import get_logger
 
 from . import (BAD_CODE_MSG, INVALID_CODE_MSG, NO_SELECTION_CHECK_MSG,
                START_LANGUAGE_OPTION_MSG,
-               BAD_CODE_MSG_CY, INVALID_CODE_MSG_CY, NO_SELECTION_CHECK_MSG_CY)
+               BAD_CODE_MSG_CY, INVALID_CODE_MSG_CY, NO_SELECTION_CHECK_MSG_CY,
+               START_PAGE_TITLE_EN, START_PAGE_TITLE_CY)
 
 from .flash import flash
 
-from .exceptions import InvalidEqPayLoad
+from .exceptions import InvalidEqPayLoad, InvalidAccessCode
 from .security import remember, get_permitted_session, forget, get_sha256_hash, invalidate
 from .session import get_session_value
 
@@ -71,12 +72,12 @@ class Start(StartCommon):
         self.log_entry(request, display_region + '/start')
         if display_region == 'cy':
             locale = 'cy'
-            page_title = "Dechrau'r cyfrifiad"
+            page_title = START_PAGE_TITLE_CY
             if request.get('flash'):
                 page_title = View.page_title_error_prefix_cy + page_title
         else:
             locale = 'en'
-            page_title = 'Start census'
+            page_title = START_PAGE_TITLE_EN
             if request.get('flash'):
                 page_title = View.page_title_error_prefix_en + page_title
 
@@ -153,7 +154,7 @@ class Start(StartCommon):
                     flash(request, INVALID_CODE_MSG_CY)
                 else:
                     flash(request, INVALID_CODE_MSG)
-                raise HTTPFound(request.app.router['Start:get'].url_for(display_region=display_region))
+                raise InvalidAccessCode
             else:
                 logger.error('error processing access code', client_ip=request['client_ip'])
                 raise ex

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -580,8 +580,10 @@ class RHTestCase(AioHTTPTestCase):
         self.content_start_exit_button_ni = 'href="/ni/start/exit/"'
 
         self.content_start_title_en = 'Start census'
+        self.content_start_page_title_error_en = '<title>Error: Start census - Census 2021</title>'
         self.content_start_uac_title_en = 'Enter your 16-character access code'
         self.content_start_title_cy = "Dechrau\\\'r cyfrifiad"
+        self.content_start_page_title_error_cy = '<title>Gwall: Dechrau&#39;r cyfrifiad - Cyfrifiad 2021</title>'
         self.content_start_uac_title_cy = "Rhowch eich cod mynediad, sy\\\'n cynnwys 16 nod"
 
         self.content_start_uac_expired_en = 'This access code has already been used'

--- a/tests/unit/test_start_handlers.py
+++ b/tests/unit/test_start_handlers.py
@@ -814,9 +814,11 @@ class TestStartHandlers(TestHelpers):
                                 'attempt to use an invalid access code',
                                 client_ip=None)
 
-        self.assertEqual(response.status, 200)
+        self.assertEqual(response.status, 401)
+        self.assertLogEvent(cm, 'invalid access code entered')
         contents = str(await response.content.read())
         self.assertIn(self.ons_logo_en, contents)
+        self.assertIn(self.content_start_page_title_error_en, contents)
         self.assertIn('<a href="/cy/start/" lang="cy" >Cymraeg</a>', contents)
         self.assertMessagePanel(INVALID_CODE_MSG, contents)
 
@@ -833,9 +835,11 @@ class TestStartHandlers(TestHelpers):
                                 'attempt to use an invalid access code',
                                 client_ip=None)
 
-        self.assertEqual(response.status, 200)
+        self.assertEqual(response.status, 401)
+        self.assertLogEvent(cm, 'invalid access code entered')
         contents = str(await response.content.read())
         self.assertIn(self.ons_logo_cy, contents)
+        self.assertIn(self.content_start_page_title_error_cy, contents)
         self.assertIn('<a href="/en/start/" lang="en" >English</a>', contents)
         self.assertMessagePanel(INVALID_CODE_MSG_CY, contents)
 
@@ -852,9 +856,11 @@ class TestStartHandlers(TestHelpers):
                                 'attempt to use an invalid access code',
                                 client_ip=None)
 
-        self.assertEqual(response.status, 200)
+        self.assertEqual(response.status, 401)
+        self.assertLogEvent(cm, 'invalid access code entered')
         contents = str(await response.content.read())
         self.assertIn(self.nisra_logo, contents)
+        self.assertIn(self.content_start_page_title_error_en, contents)
         self.assertMessagePanel(INVALID_CODE_MSG, contents)
 
     @unittest_run_loop


### PR DESCRIPTION
# Motivation and Context
Revert/update code to generate a 401 error when an invalid UAC is entered on /start

# What has changed
Changed UI response to RHSvc 404 on get_uac to trigger new error_handler that returns the start page, but triggers a 401 error

No Cucumber changes required

# How to test?
Enter invalid UAC. Check browser gets a 401 error. Check 401 error is logged

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1724