### PR TITLE
CR-1697 NI large print

### DIFF
--- a/app/templates/request-common-confirm-send-by-post.html
+++ b/app/templates/request-common-confirm-send-by-post.html
@@ -78,9 +78,9 @@
 {%- endif -%}
 
 {%- if (display_region == 'ni') -%}
-    {%- set large_print = 'Large print – suitable for visually impaired' -%}
+    {%- set large_print_legend = 'Large print – suitable for visually impaired' -%}
 {%- else -%}
-    {%- set large_print = _('Large print') -%}
+    {%- set large_print_legend = _('Large print') -%}
 {%- endif -%}
 
 {%- block main -%}
@@ -142,7 +142,7 @@
 
             {{
                 onsCheckboxes({
-                    'legend': large_print,
+                    'legend': large_print_legend,
                     'legendClasses': 'u-fs-m u-mt-l',
                     'checkboxes': [
                         {

--- a/app/templates/request-common-confirm-send-by-post.html
+++ b/app/templates/request-common-confirm-send-by-post.html
@@ -77,6 +77,12 @@
     {%- set question_title = _('Do you want to send a new household access code to this address?') -%}
 {%- endif -%}
 
+{%- if (display_region == 'ni') -%}
+    {%- set large_print = 'Large print – suitable for visually impaired' -%}
+{%- else -%}
+    {%- set large_print = _('Large print') -%}
+{%- endif -%}
+
 {%- block main -%}
 
     {%- if messages_dict -%}
@@ -136,7 +142,7 @@
 
             {{
                 onsCheckboxes({
-                    'legend': _('Large print'),
+                    'legend': large_print,
                     'legendClasses': 'u-fs-m u-mt-l',
                     'checkboxes': [
                         {

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2336,6 +2336,11 @@ class RHTestCase(AioHTTPTestCase):
         self.content_request_questionnaire_confirm_send_by_post_option_no_en = 'No, cancel and return'
         self.content_request_questionnaire_confirm_send_by_post_large_print_checkbox_en = \
             'I need a large-print questionnaire'
+        self.content_request_questionnaire_confirm_send_by_post_large_print_legend_en = \
+            'Large print'
+
+        self.content_request_questionnaire_confirm_send_by_post_large_print_legend_ni = \
+            'Large print \\xe2\\x80\\x93 suitable for visually impaired'
 
         self.content_request_questionnaire_confirm_send_by_post_page_title_cy = \
             '<title>Cadarnhau i anfon holiadur papur y cartref - Cyfrifiad 2021</title>'
@@ -2354,6 +2359,8 @@ class RHTestCase(AioHTTPTestCase):
         self.content_request_questionnaire_confirm_send_by_post_option_no_cy = "Nac ydw, rwyf am ganslo a dychwelyd"
         self.content_request_questionnaire_confirm_send_by_post_large_print_checkbox_cy = \
             'Mae angen holiadur print mawr arnaf'
+        self.content_request_questionnaire_confirm_send_by_post_large_print_legend_cy = \
+            'Print mawr'
 
         self.content_request_questionnaire_manager_title_en = \
             'We cannot send communal establishment paper questionnaires to managers'

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -529,6 +529,8 @@ class TestHelpers(RHTestCase):
                 else:
                     self.assertIn(self.content_request_questionnaire_confirm_send_by_post_large_print_checkbox_cy,
                                   contents)
+                    self.assertIn(self.content_request_questionnaire_confirm_send_by_post_large_print_legend_cy,
+                                  contents)
             else:
                 self.assertIn(self.content_request_code_confirm_send_by_post_option_yes_cy, contents)
                 self.assertIn(self.content_request_code_confirm_send_by_post_option_no_cy, contents)
@@ -626,6 +628,12 @@ class TestHelpers(RHTestCase):
                 else:
                     self.assertIn(self.content_request_questionnaire_confirm_send_by_post_large_print_checkbox_en,
                                   contents)
+                    if display_region == 'ni':
+                        self.assertIn(self.content_request_questionnaire_confirm_send_by_post_large_print_legend_ni,
+                                      contents)
+                    else:
+                        self.assertIn(self.content_request_questionnaire_confirm_send_by_post_large_print_legend_en,
+                                      contents)
             else:
                 self.assertIn(self.content_request_code_confirm_send_by_post_option_yes_en, contents)
                 self.assertIn(self.content_request_code_confirm_send_by_post_option_no_en, contents)


### PR DESCRIPTION
# Motivation and Context
Amend template request-common-confirm-send-by-post.html large print check box legend to "Large print – suitable for visually impaired" for NI requests only.

# How to test?
Unit tests amended to check text. Run against cucumber without errors.

# Links
JIRA https://collaborate2.ons.gov.uk/jira/browse/CR-1697
