### PR TITLE
CR-1761 Number of People Issue

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -370,7 +370,7 @@ class ProcessNumberOfPeople:
                                                                    'number_of_people_empty'))
             number_of_people_valid = False
 
-        elif not (data.get('number_of_people')).isnumeric():
+        elif not (data.get('number_of_people')).isdigit():
             logger.info('number_of_people nan',
                         client_ip=request['client_ip'],
                         client_id=request['client_id'],

--- a/app/utils.py
+++ b/app/utils.py
@@ -352,8 +352,9 @@ class ProcessNumberOfPeople:
     def validate_number_of_people(request, data, display_region, request_type):
 
         number_of_people_valid = True
+        number_of_people_value = data.get('number_of_people')
 
-        if (data.get('number_of_people')) == '':
+        if (not number_of_people_value) or (number_of_people_value == ''):
             logger.info('number_of_people empty',
                         client_ip=request['client_ip'],
                         client_id=request['client_id'],
@@ -370,7 +371,7 @@ class ProcessNumberOfPeople:
                                                                    'number_of_people_empty'))
             number_of_people_valid = False
 
-        elif not (data.get('number_of_people')).isdigit():
+        elif not number_of_people_value.isdecimal():
             logger.info('number_of_people nan',
                         client_ip=request['client_ip'],
                         client_id=request['client_id'],
@@ -388,7 +389,7 @@ class ProcessNumberOfPeople:
             number_of_people_valid = False
 
         elif request_type == 'continuation-questionnaire':
-            if (display_region == 'ni') and (int(data.get('number_of_people')) < 7):
+            if (display_region == 'ni') and (int(number_of_people_value) < 7):
                 logger.info('number_of_people continuation less than 7',
                             client_ip=request['client_ip'],
                             client_id=request['client_id'],
@@ -400,7 +401,7 @@ class ProcessNumberOfPeople:
                                                                    'number_of_people_continuation_low'))
                 number_of_people_valid = False
 
-            elif (not display_region == 'ni') and (int(data.get('number_of_people')) < 6):
+            elif (not display_region == 'ni') and (int(number_of_people_value) < 6):
                 logger.info('number_of_people continuation less than 6',
                             client_ip=request['client_ip'],
                             client_id=request['client_id'],
@@ -417,7 +418,7 @@ class ProcessNumberOfPeople:
                                                                        'number_of_people_continuation_low'))
                 number_of_people_valid = False
 
-            elif int(data.get('number_of_people')) > 30:
+            elif int(number_of_people_value) > 30:
                 logger.info('number_of_people continuation greater than 30',
                             client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
                 if display_region == 'cy':
@@ -430,7 +431,7 @@ class ProcessNumberOfPeople:
                                                                        'number_of_people_continuation_high'))
                 number_of_people_valid = False
 
-        elif int(data.get('number_of_people')) > 30:
+        elif int(number_of_people_value) > 30:
             logger.info('number_of_people greater than 30',
                         client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
             if display_region == 'cy':

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1352,7 +1352,7 @@ class TestHelpers(RHTestCase):
                                                              display_region, 'POST', True))
             if number_of_people == '':
                 self.assertLogEvent(cm, "number_of_people empty")
-            elif not number_of_people.isnumeric():
+            elif not number_of_people.isdecimal():
                 self.assertLogEvent(cm, "number_of_people nan")
             elif self.sub_user_journey == 'continuation-questionnaire':
                 if display_region == 'ni' and int(number_of_people) < 7:
@@ -1372,7 +1372,7 @@ class TestHelpers(RHTestCase):
             if display_region == 'cy':
                 if number_of_people == '':
                     self.assertIn(self.content_request_questionnaire_people_in_household_error_empty_cy, contents)
-                elif not number_of_people.isnumeric():
+                elif not number_of_people.isdecimal():
                     self.assertIn(self.content_request_questionnaire_people_in_household_error_nan_cy, contents)
                 elif self.sub_user_journey == 'continuation-questionnaire' and int(number_of_people) < 6:
                     self.assertIn(
@@ -1384,7 +1384,7 @@ class TestHelpers(RHTestCase):
             else:
                 if number_of_people == '':
                     self.assertIn(self.content_request_questionnaire_people_in_household_error_empty_en, contents)
-                elif not number_of_people.isnumeric():
+                elif not number_of_people.isdecimal():
                     self.assertIn(self.content_request_questionnaire_people_in_household_error_nan_en, contents)
                 elif self.sub_user_journey == 'continuation-questionnaire':
                     if display_region == 'ni' and int(number_of_people) < 7:

--- a/tests/unit/test_request_handlers_questionnaire.py
+++ b/tests/unit/test_request_handlers_questionnaire.py
@@ -5219,3 +5219,99 @@ class TestRequestHandlersPaperForm(TestHelpers):
             self.post_request_paper_questionnaire_household_ni, 'ni')
         await self.check_post_people_in_household_invalid(
             self.post_request_paper_questionnaire_people_in_household_ni, 'ni', '31')
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_people_in_household_superscript_hh_ew_e(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'HH')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_questionnaire_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_en, 'en')
+        await self.check_post_people_in_household_invalid(
+            self.post_request_paper_questionnaire_people_in_household_en, 'en', '¹')
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_people_in_household_superscript_hh_ew_w(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'HH')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_questionnaire_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_en, 'en')
+        await self.check_post_people_in_household_invalid(
+            self.post_request_paper_questionnaire_people_in_household_en, 'en', '¹')
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_people_in_household_superscript_hh_cy(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_cy, 'cy', 'HH')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_questionnaire_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_cy, 'cy')
+        await self.check_post_people_in_household_invalid(
+            self.post_request_paper_questionnaire_people_in_household_cy, 'cy', '¹')
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_people_in_household_superscript_hh_ni(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_ni, 'ni', 'HH')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_questionnaire_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_ni, 'ni')
+        await self.check_post_people_in_household_invalid(
+            self.post_request_paper_questionnaire_people_in_household_ni, 'ni', '¹')
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_people_in_household_superscript_spg_ew_e(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'SPG')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_questionnaire_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_en, 'en')
+        await self.check_post_people_in_household_invalid(
+            self.post_request_paper_questionnaire_people_in_household_en, 'en', '¹')
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_people_in_household_superscript_spg_ew_w(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'SPG')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_questionnaire_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_en, 'en')
+        await self.check_post_people_in_household_invalid(
+            self.post_request_paper_questionnaire_people_in_household_en, 'en', '¹')
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_people_in_household_superscript_spg_cy(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_cy, 'cy', 'SPG')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_questionnaire_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_cy, 'cy')
+        await self.check_post_people_in_household_invalid(
+            self.post_request_paper_questionnaire_people_in_household_cy, 'cy', '¹')
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_people_in_household_superscript_spg_ni(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_ni, 'ni', 'SPG')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_questionnaire_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_ni, 'ni')
+        await self.check_post_people_in_household_invalid(
+            self.post_request_paper_questionnaire_people_in_household_ni, 'ni', '¹')


### PR DESCRIPTION
# Motivation and Context
Change isnumeric to ~~isdigit~~ isdecimal

# What has changed
The current 'isnumeric' test in 'number of people in household' allows non-integer numbers (superscript, foreign language numbers etc) - changing to ~~isdigit~~ isdecimal which only allows integers

No Cucumber updates required

# How to test?
Check page still functions and doesn't work with non integers 'numbers'

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1761
Explanation of the difference: https://lerner.co.il/2019/02/17/pythons-str-isdigit-vs-str-isnumeric/
