### PR TITLE
Cr 1770 add missing session check

### DIFF
--- a/app/request_handlers.py
+++ b/app/request_handlers.py
@@ -98,6 +98,9 @@ class RequestIndividualForm(RequestCommon):
     @aiohttp_jinja2.template('request-questionnaire-individual.html')
     async def get(self, request):
         display_region = request.match_info['display_region']
+
+        await get_existing_session(request, 'request', 'paper-questionnaire')
+
         if display_region == 'cy':
             page_title = 'Gofyn am holiadur papur i unigolion'
             locale = 'cy'
@@ -133,6 +136,9 @@ class RequestCodeHousehold(RequestCommon):
     @aiohttp_jinja2.template('request-code-household.html')
     async def get(self, request):
         display_region = request.match_info['display_region']
+
+        await get_existing_session(request, 'request', 'access-code')
+
         if display_region == 'cy':
             page_title = 'Gofyn am god mynediad newydd ar gyfer y cartref'
             locale = 'cy'
@@ -167,6 +173,9 @@ class RequestHouseholdForm(RequestCommon):
     @aiohttp_jinja2.template('request-questionnaire-household.html')
     async def get(self, request):
         display_region = request.match_info['display_region']
+
+        await get_existing_session(request, 'request', 'paper-questionnaire')
+
         if display_region == 'cy':
             page_title = "Gofyn am holiadur papur y cartref"
             locale = 'cy'
@@ -243,6 +252,8 @@ class RequestCodeSelectHowToReceive(RequestCommon):
 
         request_type = request.match_info['request_type']
         display_region = request.match_info['display_region']
+
+        await get_existing_session(request, 'request', request_type)
 
         self.log_entry(request, display_region + '/request/' + request_type + '/select-how-to-receive')
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -351,27 +351,39 @@ class TestSessionHandling(TestHelpers):
 
     @unittest_run_loop
     async def test_no_direct_access_no_session_request_individual_form(self):
+        await self.assert_no_session('RequestIndividualForm', 'GET', 'en')
+        await self.assert_no_session('RequestIndividualForm', 'GET', 'cy', )
+        await self.assert_no_session('RequestIndividualForm', 'GET', 'ni')
         await self.assert_no_session('RequestIndividualForm', 'POST', 'en')
         await self.assert_no_session('RequestIndividualForm', 'POST', 'cy',)
         await self.assert_no_session('RequestIndividualForm', 'POST', 'ni')
 
     @unittest_run_loop
     async def test_no_direct_access_no_session_request_code_household(self):
+        await self.assert_no_session('RequestCodeHousehold', 'GET', 'en')
+        await self.assert_no_session('RequestCodeHousehold', 'GET', 'cy')
+        await self.assert_no_session('RequestCodeHousehold', 'GET', 'ni')
         await self.assert_no_session('RequestCodeHousehold', 'POST', 'en')
         await self.assert_no_session('RequestCodeHousehold', 'POST', 'cy')
         await self.assert_no_session('RequestCodeHousehold', 'POST', 'ni')
 
     @unittest_run_loop
     async def test_no_direct_access_no_session_request_household_form(self):
+        await self.assert_no_session('RequestHouseholdForm', 'GET', 'en')
+        await self.assert_no_session('RequestHouseholdForm', 'GET', 'cy')
+        await self.assert_no_session('RequestHouseholdForm', 'GET', 'ni')
         await self.assert_no_session('RequestHouseholdForm', 'POST', 'en')
         await self.assert_no_session('RequestHouseholdForm', 'POST', 'cy')
         await self.assert_no_session('RequestHouseholdForm', 'POST', 'ni')
 
     @unittest_run_loop
-    async def test_no_direct_access_no_session_request_code_select_how_to_recieve(self):
-        await self.assert_no_session('RequestCodeEnterMobile', 'GET', 'en', request_type='access-code')
-        await self.assert_no_session('RequestCodeEnterMobile', 'GET', 'cy', request_type='access-code')
-        await self.assert_no_session('RequestCodeEnterMobile', 'GET', 'ni', request_type='access-code')
+    async def test_no_direct_access_no_session_request_code_select_how_to_receive(self):
+        await self.assert_no_session('RequestCodeSelectHowToReceive', 'GET', 'en', request_type='access-code')
+        await self.assert_no_session('RequestCodeSelectHowToReceive', 'GET', 'cy', request_type='access-code')
+        await self.assert_no_session('RequestCodeSelectHowToReceive', 'GET', 'ni', request_type='access-code')
+        await self.assert_no_session('RequestCodeSelectHowToReceive', 'POST', 'en', request_type='access-code')
+        await self.assert_no_session('RequestCodeSelectHowToReceive', 'POST', 'cy', request_type='access-code')
+        await self.assert_no_session('RequestCodeSelectHowToReceive', 'POST', 'ni', request_type='access-code')
 
     @unittest_run_loop
     async def test_no_direct_access_no_session_request_code_enter_mobile(self):


### PR DESCRIPTION
# Motivation and Context
Some fulfilment journey pages are missing the session check (because they didn't call from the session), but this means they work for direct access, and don't get rejected. This adds missing session checks

# What has changed
Session checks added to code and questionnaire household pages, select how to receive and questionnaire individual. Note that check has not been added to code individual as this already had checks because it can be an entry point
Session unit tests updated to include updated pages

No Cucumber changes required

# How to test?
Try direct access of 
/en/request/paper-questionnaire/household/
/en/request/paper-questionnaire/individual/
/en/request/access-code/household/
and language variants - should fall with a session message

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1770