### PR TITLE
Cr 1769 csp update

### DIFF
--- a/app/security.py
+++ b/app/security.py
@@ -24,8 +24,8 @@ CSP = {
     'script-src': [
         "'self'",
         'https://www.googletagmanager.com',
-        "https://www.google-analytics.com",
-        "https://ssl.google-analytics.com",
+        'https://www.google-analytics.com',
+        'https://ssl.google-analytics.com',
         'https://cdn.census.gov.uk',
     ],
     'style-src': [

--- a/app/security.py
+++ b/app/security.py
@@ -24,8 +24,8 @@ CSP = {
     'script-src': [
         "'self'",
         'https://www.googletagmanager.com',
-        "'unsafe-inline'",
-        "'unsafe-eval'",
+        "https://www.google-analytics.com",
+        "https://ssl.google-analytics.com",
         'https://cdn.census.gov.uk',
     ],
     'style-src': [

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -49,8 +49,8 @@ class TestCreateApp(AioHTTPTestCase):
         self.assertIn("font-src 'self' data: https://fonts.gstatic.com https://cdn.census.gov.uk",
                       response.headers['Content-Security-Policy'])
         self.assertIn(
-            f"script-src 'self' https://www.googletagmanager.com 'unsafe-inline' 'unsafe-eval' "
-            f"https://cdn.census.gov.uk 'nonce-{nonce}'",
+            f"script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com "
+            f"https://ssl.google-analytics.com https://cdn.census.gov.uk 'nonce-{nonce}'",
             response.headers['Content-Security-Policy'])
         self.assertIn(
             "connect-src 'self' https://cdn.census.gov.uk https://www.google-analytics.com",
@@ -69,8 +69,8 @@ class TestCreateApp(AioHTTPTestCase):
         self.assertIn("font-src 'self' data: https://fonts.gstatic.com https://cdn.census.gov.uk",
                       response.headers['X-Content-Security-Policy'])
         self.assertIn(
-            f"script-src 'self' https://www.googletagmanager.com 'unsafe-inline' 'unsafe-eval' "
-            f"https://cdn.census.gov.uk 'nonce-{nonce}'",
+            f"script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com "
+            f"https://ssl.google-analytics.com https://cdn.census.gov.uk 'nonce-{nonce}'",
             response.headers['X-Content-Security-Policy'])
         self.assertIn(
             "connect-src 'self' https://cdn.census.gov.uk https://www.google-analytics.com",


### PR DESCRIPTION
# Motivation and Context
Tweak to CSP settings to prevent dropout

# What has changed
Change to the urls in the CSP settings to match EQ and website, that should prevent dropout, and update to matching unit tests
Andy Pitt will validate update in WL

No Cucumber updates required

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1769