### PR TITLE
Cr 1745 uac none type

### DIFF
--- a/app/start_handlers.py
+++ b/app/start_handlers.py
@@ -129,7 +129,7 @@ class Start(StartCommon):
 
         data = await request.post()
 
-        if data.get('uac') == '':
+        if (not data.get('uac')) or (data.get('uac') == ''):
             logger.info('access code not supplied',
                         client_ip=request['client_ip'],
                         client_id=request['client_id'],


### PR DESCRIPTION
# Motivation and Context
UAC input has had a nonetype error returned - change strengthens the value test

# What has changed
Expands 'empty test' of UAC input to include none-type return

# How to test?
Open /en/start/
Right click the uac input box and select 'inspect'
Delete the input box in the inspector so that the input box disappears on screen
Submit the form
Page should return the empty field error

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1745