### PR TITLE
CR-1766_Reduce_HTTP_429_responses_to_warn

### DIFF
--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -141,7 +141,10 @@ async def key_error(request, error):
 
 
 async def response_error(request):
-    logger.error('response error')
+    logger.error('response error',
+                 client_ip=request['client_ip'],
+                 client_id=request['client_id'],
+                 trace=request['trace'])
     attributes = check_display_region(request)
     return jinja.render_template('error.html', request, attributes, status=500)
 

--- a/app/request.py
+++ b/app/request.py
@@ -114,13 +114,20 @@ class RetryRequest:
                             attempts=attempts)
                 return await self._request_basic()
         except ClientResponseError as ex:
-            if not ex.status == 404:
+            if ex.status not in [404, 429]:
                 logger.error('error in response',
                              client_ip=self.request['client_ip'],
                              client_id=self.request['client_id'],
                              trace=self.request['trace'],
                              url=self.url,
                              status_code=ex.status)
+            elif ex.status == 429:
+                logger.warn('too many requests',
+                            client_ip=self.request['client_ip'],
+                            client_id=self.request['client_id'],
+                            trace=self.request['trace'],
+                            url=self.url,
+                            status_code=ex.status)
             raise ex
         except (ClientConnectionError, ClientConnectorError) as ex:
             logger.error('client failed to connect',

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1729,7 +1729,7 @@ class TestHelpers(RHTestCase):
 
             response = await self.client.request('POST', url, data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, self.build_url_log_entry('confirm-send-by-text', display_region, 'POST'))
-            self.assertLogEvent(cm, 'error in response', status_code=429)
+            self.assertLogEvent(cm, 'too many requests', status_code=429)
 
             self.assertEqual(response.status, 429)
             contents = str(await response.content.read())
@@ -2420,7 +2420,7 @@ class TestHelpers(RHTestCase):
 
             response = await self.client.request('POST', url, data=self.request_common_confirm_send_by_post_data_yes)
             self.assertLogEvent(cm, self.build_url_log_entry('confirm-send-by-post', display_region, 'POST'))
-            self.assertLogEvent(cm, 'error in response', status_code=429)
+            self.assertLogEvent(cm, 'too many requests', status_code=429)
 
             self.assertEqual(response.status, 429)
             contents = str(await response.content.read())
@@ -2441,7 +2441,7 @@ class TestHelpers(RHTestCase):
 
             response = await self.client.request('POST', url, data=self.request_common_confirm_send_by_post_data_yes)
             self.assertLogEvent(cm, self.build_url_log_entry('confirm-send-by-post', display_region, 'POST'))
-            self.assertLogEvent(cm, 'error in response', status_code=429)
+            self.assertLogEvent(cm, 'too many requests', status_code=429)
 
             self.assertEqual(response.status, 429)
             contents = str(await response.content.read())

--- a/tests/unit/test_start_handlers.py
+++ b/tests/unit/test_start_handlers.py
@@ -1346,13 +1346,13 @@ class TestStartHandlers(TestHelpers):
                                                  data=self.start_data_valid)
             self.assertEqual(response.status, 200)
 
-            with self.assertLogs('respondent-home', 'ERROR') as cm:
+            with self.assertLogs('respondent-home', 'WARN') as cm:
                 response = await self.client.request(
                     'POST',
                     self.post_start_confirm_address_en,
                     allow_redirects=False,
                     data=self.start_confirm_address_data_yes)
-            self.assertLogEvent(cm, 'error in response', status_code=429)
+            self.assertLogEvent(cm, 'too many requests', status_code=429)
 
             self.assertEqual(response.status, 429)
             contents = str(await response.content.read())
@@ -1370,13 +1370,13 @@ class TestStartHandlers(TestHelpers):
                                                  data=self.start_data_valid)
             self.assertEqual(response.status, 200)
 
-            with self.assertLogs('respondent-home', 'ERROR') as cm:
+            with self.assertLogs('respondent-home', 'WARN') as cm:
                 response = await self.client.request(
                     'POST',
                     self.post_start_confirm_address_en,
                     allow_redirects=False,
                     data=self.start_confirm_address_data_yes)
-            self.assertLogEvent(cm, 'error in response', status_code=429)
+            self.assertLogEvent(cm, 'too many requests', status_code=429)
 
             self.assertEqual(response.status, 429)
             contents = str(await response.content.read())
@@ -1394,13 +1394,13 @@ class TestStartHandlers(TestHelpers):
                                                  data=self.start_data_valid)
             self.assertEqual(response.status, 200)
 
-            with self.assertLogs('respondent-home', 'ERROR') as cm:
+            with self.assertLogs('respondent-home', 'WARN') as cm:
                 response = await self.client.request(
                     'POST',
                     self.post_start_confirm_address_cy,
                     allow_redirects=False,
                     data=self.start_confirm_address_data_yes)
-            self.assertLogEvent(cm, 'error in response', status_code=429)
+            self.assertLogEvent(cm, 'too many requests', status_code=429)
 
             self.assertEqual(response.status, 429)
             contents = str(await response.content.read())
@@ -1421,13 +1421,13 @@ class TestStartHandlers(TestHelpers):
             await self.client.request('POST', self.post_start_language_options_ni,
                                       data=self.start_ni_language_option_data_no)
 
-            with self.assertLogs('respondent-home', 'ERROR') as cm:
+            with self.assertLogs('respondent-home', 'WARN') as cm:
                 response = await self.client.request(
                     'POST',
                     self.post_start_select_language_ni,
                     allow_redirects=False,
                     data=self.start_ni_select_language_data_ul)
-            self.assertLogEvent(cm, 'error in response', status_code=429)
+            self.assertLogEvent(cm, 'too many requests', status_code=429)
 
             self.assertEqual(response.status, 429)
             contents = str(await response.content.read())

--- a/tests/unit/test_web_form_handlers.py
+++ b/tests/unit/test_web_form_handlers.py
@@ -109,7 +109,7 @@ class TestWebFormHandlers(TestHelpers):
             response = await self.client.request('POST', url, data=form_data)
             self.assertLogEvent(cm, self.build_url_log_entry('web-form', display_region, 'POST',
                                                              include_sub_user_journey=False, include_page=False))
-            self.assertLogEvent(cm, 'error in response', status_code=429)
+            self.assertLogEvent(cm, 'too many requests', status_code=429)
 
             self.assertEqual(response.status, 429)
             contents = str(await response.content.read())


### PR DESCRIPTION
# Motivation and Context
Reduce the high number of misleading error logs for situations where a request was legitimately rate limited.

# What has changed
Client responses to RHUI with HTTP status 429 have been reduced from being logged as an error to a warn.

# How to test?
Unit tests amended. Cucumber run.

# Links
JIRA: https://collaborate2.ons.gov.uk/jira/browse/CR-1766