### PR TITLE
Cr 1754 uac case incompatible logging

### DIFF
--- a/app/request.py
+++ b/app/request.py
@@ -129,7 +129,7 @@ class RetryRequest:
                             url=self.url,
                             status_code=ex.status)
             elif ex.status == 400:
-                logger.info('bad request',
+                logger.warn('bad request',
                             client_ip=self.request['client_ip'],
                             client_id=self.request['client_id'],
                             trace=self.request['trace'],

--- a/app/request.py
+++ b/app/request.py
@@ -114,7 +114,7 @@ class RetryRequest:
                             attempts=attempts)
                 return await self._request_basic()
         except ClientResponseError as ex:
-            if ex.status not in [404, 429]:
+            if ex.status not in [400, 404, 429]:
                 logger.error('error in response',
                              client_ip=self.request['client_ip'],
                              client_id=self.request['client_id'],
@@ -123,6 +123,13 @@ class RetryRequest:
                              status_code=ex.status)
             elif ex.status == 429:
                 logger.warn('too many requests',
+                            client_ip=self.request['client_ip'],
+                            client_id=self.request['client_id'],
+                            trace=self.request['trace'],
+                            url=self.url,
+                            status_code=ex.status)
+            elif ex.status == 400:
+                logger.info('bad request',
                             client_ip=self.request['client_ip'],
                             client_id=self.request['client_id'],
                             trace=self.request['trace'],

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1264,7 +1264,7 @@ class TestHelpers(RHTestCase):
 
             response = await self.client.request('POST', url, data=self.common_confirm_address_input_yes)
             self.assertLogEvent(cm, self.build_url_log_entry('confirm-address', display_region, 'POST'))
-            self.assertLogEvent(cm, 'error in response', status_code=400)
+            self.assertLogEvent(cm, 'bad request', status_code=400)
 
             self.assertEqual(response.status, 500)
             contents = str(await response.content.read())
@@ -1286,7 +1286,7 @@ class TestHelpers(RHTestCase):
             self.assertLogEvent(cm, self.build_url_log_entry('confirm-address', display_region, 'POST'))
             self.assertLogEvent(cm, 'get cases by uprn error - unable to match uprn (404)')
             self.assertLogEvent(cm, 'requesting new case')
-            self.assertLogEvent(cm, 'error in response', status_code=400)
+            self.assertLogEvent(cm, 'bad request', status_code=400)
 
             self.assertEqual(response.status, 500)
             contents = str(await response.content.read())
@@ -1675,7 +1675,7 @@ class TestHelpers(RHTestCase):
 
             response = await self.client.request('POST', url, data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, self.build_url_log_entry('confirm-send-by-text', display_region, 'POST'))
-            self.assertLogEvent(cm, 'error in response', status_code=400)
+            self.assertLogEvent(cm, 'bad request', status_code=400)
 
             self.assertEqual(response.status, 500)
             contents = str(await response.content.read())
@@ -1707,7 +1707,7 @@ class TestHelpers(RHTestCase):
 
             response = await self.client.request('POST', url, data=self.request_code_mobile_confirmation_data_yes)
             self.assertLogEvent(cm, self.build_url_log_entry('confirm-send-by-text', display_region, 'POST'))
-            self.assertLogEvent(cm, 'error in response', status_code=400)
+            self.assertLogEvent(cm, 'bad request', status_code=400)
 
             self.assertEqual(response.status, 500)
             contents = str(await response.content.read())
@@ -1756,7 +1756,10 @@ class TestHelpers(RHTestCase):
 
             await self.client.request('GET', get_url)
             response = await self.client.request('POST', post_url, data=self.common_postcode_input_valid)
-            self.assertLogEvent(cm, 'error in response', status_code=status)
+            if status==400:
+                self.assertLogEvent(cm, 'bad request', status_code=status)
+            else:
+                self.assertLogEvent(cm, 'error in response', status_code=status)
 
             self.assertEqual(response.status, 500)
             contents = str(await response.content.read())
@@ -2380,7 +2383,7 @@ class TestHelpers(RHTestCase):
 
             response = await self.client.request('POST', url, data=self.request_common_confirm_send_by_post_data_yes)
             self.assertLogEvent(cm, self.build_url_log_entry('confirm-send-by-post', display_region, 'POST'))
-            self.assertLogEvent(cm, 'error in response', status_code=400)
+            self.assertLogEvent(cm, 'bad request', status_code=400)
 
             self.assertEqual(response.status, 500)
             contents = str(await response.content.read())
@@ -2398,7 +2401,7 @@ class TestHelpers(RHTestCase):
 
             response = await self.client.request('POST', url, data=self.request_common_confirm_send_by_post_data_yes)
             self.assertLogEvent(cm, self.build_url_log_entry('confirm-send-by-post', display_region, 'POST'))
-            self.assertLogEvent(cm, 'error in response', status_code=400)
+            self.assertLogEvent(cm, 'bad request', status_code=400)
 
             self.assertEqual(response.status, 500)
             contents = str(await response.content.read())

--- a/tests/unit/test_start_handlers.py
+++ b/tests/unit/test_start_handlers.py
@@ -968,7 +968,7 @@ class TestStartHandlers(TestHelpers):
                 response = await self.client.request('POST',
                                                      self.post_start_en,
                                                      data=self.start_data_valid)
-            self.assertLogEvent(cm, 'error in response', status_code=400)
+            self.assertLogEvent(cm, 'bad request', status_code=400)
 
             self.assertEqual(response.status, 500)
             contents = str(await response.content.read())
@@ -984,7 +984,7 @@ class TestStartHandlers(TestHelpers):
                 response = await self.client.request('POST',
                                                      self.post_start_cy,
                                                      data=self.start_data_valid)
-            self.assertLogEvent(cm, 'error in response', status_code=400)
+            self.assertLogEvent(cm, 'bad request', status_code=400)
 
             self.assertEqual(response.status, 500)
             contents = str(await response.content.read())
@@ -1000,7 +1000,7 @@ class TestStartHandlers(TestHelpers):
                 response = await self.client.request('POST',
                                                      self.post_start_ni,
                                                      data=self.start_data_valid)
-            self.assertLogEvent(cm, 'error in response', status_code=400)
+            self.assertLogEvent(cm, 'bad request', status_code=400)
 
             self.assertEqual(response.status, 500)
             contents = str(await response.content.read())

--- a/tests/unit/test_web_form_handlers.py
+++ b/tests/unit/test_web_form_handlers.py
@@ -92,7 +92,7 @@ class TestWebFormHandlers(TestHelpers):
             response = await self.client.request('POST', url, data=form_data)
             self.assertLogEvent(cm, self.build_url_log_entry('web-form', display_region, 'POST',
                                                              include_sub_user_journey=False, include_page=False))
-            self.assertLogEvent(cm, 'error in response', status_code=status)
+            self.assertLogEvent(cm, 'bad request', status_code=status)
 
             self.assertEqual(response.status, 500)
             contents = str(await response.content.read())


### PR DESCRIPTION
# Motivation and Context
RH Svc replies with a HTTP 400 BAD REQUEST for requests to link a UAC form type to an ineligible case type. As a bad request response is legitimate in this instance and not an error the make_request function no longer automatically logs bad request responses as an error. It leaves the calling code to handle the raised exception and log appropriately if an error. If the calling code does not handle the raised exception, the error_handlers.py HTTP Bad Request override will cause the response_error function to be triggered and an error logged that can be linked in the logs to the original make_request log now at info level.

# What has changed
Logging level of HTTP 400 responses lowered to info in generic make_request function. Units tests amended as appropriate.

# How to test?
Unit tests run, RH cucumber tests passed.

# Links
JIRA:  https://collaborate2.ons.gov.uk/jira/browse/CR-1754
