### PR TITLE
Cr 1800 ds gtm update

### DIFF
--- a/app/templates/partials/gtm.html
+++ b/app/templates/partials/gtm.html
@@ -1,12 +1,15 @@
 <!-- Google Tag Manager -->
 <script nonce="{{ cspNonce }}">
-    var a = /^(.*)?\s*'usage':true\s*[^;]+(.*)?$/;
-    if (document.cookie.match(a)) {
+    function loadGTM() {
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth={{ gtm_auth }}&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','{{ gtm_cont_id }}');
+    }
+    var a = /^(.*)?\s*'usage':true\s*[^;]+(.*)?$/;
+    if (document.cookie.match(a)) {
+        loadGTM();
     }
 </script>
 <!-- End Google Tag Manager -->

--- a/scripts/load_templates.sh
+++ b/scripts/load_templates.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "${DIR}"/.. || exit
 
-DESIGN_SYSTEM_VERSION="31.4.17"
+DESIGN_SYSTEM_VERSION="32.0.3-census"
 
 TEMP_DIR=$(mktemp -d)
 


### PR DESCRIPTION
# Motivation and Context
DS Update to enable tweak to GTM code javascript

# What has changed
DS Update
Adjustment to GTM javascript to enable tracking to work as soon as cookie button is clicked

No Cucumber updates required
Need to update local DS version for test

# How to test?
Check no unwanted side effects (business will sign off GTM update)

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1800