### PR TITLE
Cr 1826 fix name field spaces

### DIFF
--- a/app/common_handlers.py
+++ b/app/common_handlers.py
@@ -946,10 +946,10 @@ class CommonEnterRoomNumber(CommonCommon):
         data = await request.post()
 
         try:
-            room_number = data['form-enter-room-number'].strip()
+            room_number = data['form-enter-room-number']
             if len(room_number) > 10:
                 raise KeyError
-            attributes['roomNumber'] = room_number
+            attributes['roomNumber'] = room_number.strip()
             session.changed()
             try:
                 if attributes['first_name']:

--- a/app/common_handlers.py
+++ b/app/common_handlers.py
@@ -946,7 +946,7 @@ class CommonEnterRoomNumber(CommonCommon):
         data = await request.post()
 
         try:
-            room_number = data['form-enter-room-number']
+            room_number = data['form-enter-room-number'].strip()
             if len(room_number) > 10:
                 raise KeyError
             attributes['roomNumber'] = room_number

--- a/app/request_handlers.py
+++ b/app/request_handlers.py
@@ -576,8 +576,8 @@ class RequestCommonEnterName(RequestCommon):
                     request_type=request_type
                 ))
 
-        name_first_name = data['name_first_name']
-        name_last_name = data['name_last_name']
+        name_first_name = data['name_first_name'].strip()
+        name_last_name = data['name_last_name'].strip()
 
         attributes['first_name'] = name_first_name
         attributes['last_name'] = name_last_name

--- a/app/start_handlers.py
+++ b/app/start_handlers.py
@@ -558,10 +558,10 @@ class StartTransientEnterTownName(StartCommon):
         data = await request.post()
 
         try:
-            town_name = data['form-enter-town-name'].strip()
-            if not town_name:
+            town_name = data['form-enter-town-name']
+            if (not town_name) or (len(town_name.strip()) == 0):
                 raise KeyError
-            session['attributes']['transientTownName'] = town_name
+            session['attributes']['transientTownName'] = town_name.strip()
             session.changed()
 
             raise HTTPFound(

--- a/app/start_handlers.py
+++ b/app/start_handlers.py
@@ -558,7 +558,7 @@ class StartTransientEnterTownName(StartCommon):
         data = await request.post()
 
         try:
-            town_name = data['form-enter-town-name']
+            town_name = data['form-enter-town-name'].strip()
             if not town_name:
                 raise KeyError
             session['attributes']['transientTownName'] = town_name

--- a/app/utils.py
+++ b/app/utils.py
@@ -303,8 +303,10 @@ class ProcessName:
     def validate_name(request, data, display_region):
 
         name_valid = True
-        form_first_name = data.get('name_first_name')
-        form_last_name = data.get('name_last_name')
+        if data.get('name_first_name'):
+            form_first_name = data.get('name_first_name').strip()
+
+        form_last_name = data.get('name_last_name').strip()
 
         if not form_first_name:
             if display_region == 'cy':

--- a/app/utils.py
+++ b/app/utils.py
@@ -303,12 +303,10 @@ class ProcessName:
     def validate_name(request, data, display_region):
 
         name_valid = True
-        if data.get('name_first_name'):
-            form_first_name = data.get('name_first_name').strip()
+        form_first_name = data.get('name_first_name')
+        form_last_name = data.get('name_last_name')
 
-        form_last_name = data.get('name_last_name').strip()
-
-        if not form_first_name:
+        if (not form_first_name) or (len(form_first_name.strip()) == 0):
             if display_region == 'cy':
                 flash(request, {'text': "Rhowch eich enw cyntaf", 'level': 'ERROR', 'type': 'NAME_ENTER_ERROR',
                                 'field': 'error_first_name', 'value_first_name': form_first_name,
@@ -330,7 +328,7 @@ class ProcessName:
                                 'value_first_name': form_first_name, 'value_last_name': form_last_name})
             name_valid = False
 
-        if not form_last_name:
+        if (not form_last_name) or (len(form_last_name.strip()) == 0):
             if display_region == 'cy':
                 flash(request, {'text': "Rhowch eich cyfenw", 'level': 'ERROR', 'type': 'NAME_ENTER_ERROR',
                                 'field': 'error_last_name', 'value_first_name': form_first_name,

--- a/app/web_form_handlers.py
+++ b/app/web_form_handlers.py
@@ -86,7 +86,7 @@ class WebForm(View):
                 flash(request, WEBFORM_MISSING_DESCRIPTION_MSG)
             form_valid = False
 
-        if not data.get('name'):
+        if (not data.get('name')) or (len(data.get('name').strip()) == 0):
             if display_region == 'cy':
                 flash(request, WEBFORM_MISSING_NAME_MSG_CY)
             else:

--- a/app/webchat_handlers.py
+++ b/app/webchat_handlers.py
@@ -73,7 +73,7 @@ class WebChat(View):
 
         form_valid = True
 
-        if not data.get('screen_name'):
+        if (not data.get('screen_name')) or (len(data.get('screen_name').split()) == 0):
             if display_region == 'cy':
                 flash(request, {'text': 'Nodwch eich enw', 'clickable': True, 'level': 'ERROR', 'type': 'BAD_CODE',
                                 'field': 'error_screen_name', 'screen_name': data.get('screen_name'),

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -496,6 +496,9 @@ class RHTestCase(AioHTTPTestCase):
         self.common_room_number_input_over_length = {
             'form-enter-room-number': 'Room A8, Flat 47', 'action[save_continue]': '',
         }
+        self.common_room_number_input_only_space = {
+            'form-enter-room-number': ' ', 'action[save_continue]': '',
+        }
 
         self.content_common_register_address_title_en = \
             'Register an address'
@@ -1140,6 +1143,11 @@ class RHTestCase(AioHTTPTestCase):
 
         self.request_common_enter_name_form_data_long_surname = {
             'name_first_name': 'Bob', 'name_last_name': 'Bobbington-Fortesque-Smythe',
+            'action[save_continue]': '',
+        }
+
+        self.request_common_enter_name_form_data_only_spaces = {
+            'name_first_name': ' ', 'name_last_name': ' ',
             'action[save_continue]': '',
         }
 
@@ -2845,6 +2853,9 @@ class RHTestCase(AioHTTPTestCase):
         }
         self.start_transient_town_name_input_empty = {
             'form-enter-town-name': '', 'action[save_continue]': '',
+        }
+        self.start_transient_town_name_input_only_space = {
+            'form-enter-town-name': ' ', 'action[save_continue]': '',
         }
 
         self.start_transient_accommodation_type_input_barge_en = {

--- a/tests/unit/test_request_handlers_access_code.py
+++ b/tests/unit/test_request_handlers_access_code.py
@@ -3430,6 +3430,271 @@ class TestRequestHandlersAccessCode(TestHelpers):
                                                       self.common_form_data_empty)
 
     @unittest_run_loop
+    async def test_request_access_code_post_enter_name_empty_hh_ew_e(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'HH')
+        await self.check_post_confirm_address_input_yes_code(
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
+        await self.check_post_household_information_code(
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_en, 'en')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_hh_ew_w(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'HH')
+        await self.check_post_confirm_address_input_yes_code(
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
+        await self.check_post_household_information_code(
+            self.post_request_access_code_household_en, 'en', 'household', 'HH')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_en, 'en')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_hh_cy(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'HH')
+        await self.check_post_confirm_address_input_yes_code(
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
+        await self.check_post_household_information_code(
+            self.post_request_access_code_household_cy, 'cy', 'household', 'HH')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_cy, 'cy')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_hh_ni(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'HH')
+        await self.check_post_confirm_address_input_yes_code(
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
+        await self.check_post_household_information_code(
+            self.post_request_access_code_household_ni, 'ni', 'household', 'HH')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_ni, 'ni')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_spg_ew_e(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'SPG')
+        await self.check_post_confirm_address_input_yes_code(
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
+        await self.check_post_household_information_code(
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_en, 'en')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_spg_ew_w(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'SPG')
+        await self.check_post_confirm_address_input_yes_code(
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
+        await self.check_post_household_information_code(
+            self.post_request_access_code_household_en, 'en', 'household', 'SPG')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_en, 'en')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_spg_cy(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'SPG')
+        await self.check_post_confirm_address_input_yes_code(
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
+        await self.check_post_household_information_code(
+            self.post_request_access_code_household_cy, 'cy', 'household', 'SPG')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_cy, 'cy')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_spg_ni(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'SPG')
+        await self.check_post_confirm_address_input_yes_code(
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
+        await self.check_post_household_information_code(
+            self.post_request_access_code_household_ni, 'ni', 'household', 'SPG')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_ni, 'ni')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_select_manager_ce_m_ew_e(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
+        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_en,
+                                                           'en', self.rhsvc_case_by_uprn_ce_m_e)
+        await self.check_post_resident_or_manager(
+            self.post_request_access_code_resident_or_manager_en, 'en',
+            self.common_resident_or_manager_input_manager, 'manager')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_en, 'en')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_select_manager_ce_m_ew_w(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
+        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_en,
+                                                           'en', self.rhsvc_case_by_uprn_ce_m_w)
+        await self.check_post_resident_or_manager(
+            self.post_request_access_code_resident_or_manager_en, 'en',
+            self.common_resident_or_manager_input_manager, 'manager')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_en, 'en')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_select_manager_ce_m_cy(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
+        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_cy,
+                                                           'cy', self.rhsvc_case_by_uprn_ce_m_w)
+        await self.check_post_resident_or_manager(
+            self.post_request_access_code_resident_or_manager_cy, 'cy',
+            self.common_resident_or_manager_input_manager, 'manager')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_cy, 'cy')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_select_resident_ce_m_ew_e(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
+        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_en,
+                                                           'en', self.rhsvc_case_by_uprn_ce_m_e)
+        await self.check_post_resident_or_manager(
+            self.post_request_access_code_resident_or_manager_en, 'en',
+            self.common_resident_or_manager_input_resident, 'individual')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_en, 'en')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_select_resident_ce_m_ew_w(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
+        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_en,
+                                                           'en', self.rhsvc_case_by_uprn_ce_m_w)
+        await self.check_post_resident_or_manager(
+            self.post_request_access_code_resident_or_manager_en, 'en',
+            self.common_resident_or_manager_input_resident, 'individual')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_en, 'en')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_select_resident_ce_m_cy(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
+        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_cy,
+                                                           'cy', self.rhsvc_case_by_uprn_ce_m_w)
+        await self.check_post_resident_or_manager(
+            self.post_request_access_code_resident_or_manager_cy, 'cy',
+            self.common_resident_or_manager_input_resident, 'individual')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_cy, 'cy')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_select_resident_ce_m_ni(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
+        await self.check_post_confirm_address_input_yes_ce(self.post_request_access_code_confirm_address_ni,
+                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
+        await self.check_post_resident_or_manager(
+            self.post_request_access_code_resident_or_manager_ni, 'ni',
+            self.common_resident_or_manager_input_resident, 'individual')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_ni, 'ni')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_ce_r_ew_e(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
+        await self.check_post_confirm_address_input_yes_code_individual(
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e, 'individual', 'CE')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_en, 'en')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_ce_r_ew_w(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
+        await self.check_post_confirm_address_input_yes_code_individual(
+            self.post_request_access_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_en, 'en')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_ce_r_cy(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
+        await self.check_post_confirm_address_input_yes_code_individual(
+            self.post_request_access_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w, 'individual', 'CE')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_cy, 'cy')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_cy, 'cy',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_enter_name_only_spaces_ce_r_ni(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
+        await self.check_post_confirm_address_input_yes_code_individual(
+            self.post_request_access_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n, 'individual', 'CE')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_access_code_select_how_to_receive_ni, 'ni')
+        await self.check_post_enter_name_inputs_error(self.post_request_access_code_enter_name_ni, 'ni',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
     async def test_request_access_code_post_enter_name_no_first_hh_ew_e(self):
         await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
@@ -7301,6 +7566,42 @@ class TestRequestHandlersAccessCode(TestHelpers):
         await self.add_room_number(self.get_request_access_code_enter_room_number_ni,
                                    self.post_request_access_code_enter_room_number_ni,
                                    'ni', 'individual', 'ConfirmAddress', check_for_value=True)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_code_sent_post_add_room_early_only_space_ce_r_ew_e(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
+        await self.add_room_number(self.get_request_access_code_enter_room_number_en,
+                                   self.post_request_access_code_enter_room_number_en,
+                                   'en', 'individual', 'ConfirmAddress', check_for_value=False, data_only_space=True)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_code_sent_post_add_room_early_only_space_ce_r_ew_w(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_access_code_select_address_en, 'en', 'CE')
+        await self.add_room_number(self.get_request_access_code_enter_room_number_en,
+                                   self.post_request_access_code_enter_room_number_en,
+                                   'en', 'individual', 'ConfirmAddress', check_for_value=False, data_only_space=True)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_code_sent_post_add_room_early_only_space_ce_r_cy(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_access_code_select_address_cy, 'cy', 'CE')
+        await self.add_room_number(self.get_request_access_code_enter_room_number_cy,
+                                   self.post_request_access_code_enter_room_number_cy,
+                                   'cy', 'individual', 'ConfirmAddress', check_for_value=False, data_only_space=True)
+
+    @unittest_run_loop
+    async def test_request_access_code_post_code_sent_post_add_room_early_only_space_ce_r_ni(self):
+        await self.check_get_enter_address(self.get_request_access_code_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_access_code_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_access_code_select_address_ni, 'ni', 'CE')
+        await self.add_room_number(self.get_request_access_code_enter_room_number_ni,
+                                   self.post_request_access_code_enter_room_number_ni,
+                                   'ni', 'individual', 'ConfirmAddress', check_for_value=False, data_only_space=True)
 
     @unittest_run_loop
     async def test_request_access_code_post_code_sent_post_add_room_late_long_surname_ce_r_ew_e(self):

--- a/tests/unit/test_request_handlers_continuation.py
+++ b/tests/unit/test_request_handlers_continuation.py
@@ -518,6 +518,106 @@ class TestRequestHandlersContinuationQuestionnaire(TestHelpers):
                                                       self.common_form_data_empty)
 
     @unittest_run_loop
+    async def test_request_continuation_questionnaire_enter_name_only_spaces_hh_ew_e(self):
+        await self.check_get_enter_address(self.get_request_continuation_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_continuation_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_continuation_questionnaire_select_address_en, 'en', 'HH')
+        await self.check_post_confirm_address_input_yes_continuation(
+            self.post_request_continuation_questionnaire_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
+        await self.check_post_people_in_household(
+            self.post_request_continuation_questionnaire_people_in_household_en, 'en', '7')
+        await self.check_post_enter_name_inputs_error(self.post_request_continuation_questionnaire_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_continuation_questionnaire_enter_name_only_spaces_hh_ew_w(self):
+        await self.check_get_enter_address(self.get_request_continuation_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_continuation_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_continuation_questionnaire_select_address_en, 'en', 'HH')
+        await self.check_post_confirm_address_input_yes_continuation(
+            self.post_request_continuation_questionnaire_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
+        await self.check_post_people_in_household(
+            self.post_request_continuation_questionnaire_people_in_household_en, 'en', '7')
+        await self.check_post_enter_name_inputs_error(self.post_request_continuation_questionnaire_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_continuation_questionnaire_enter_name_only_spaces_hh_cy(self):
+        await self.check_get_enter_address(self.get_request_continuation_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_continuation_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_continuation_questionnaire_select_address_cy, 'cy', 'HH')
+        await self.check_post_confirm_address_input_yes_continuation(
+            self.post_request_continuation_questionnaire_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
+        await self.check_post_people_in_household(
+            self.post_request_continuation_questionnaire_people_in_household_cy, 'cy', '7')
+        await self.check_post_enter_name_inputs_error(self.post_request_continuation_questionnaire_enter_name_cy, 'cy',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_continuation_questionnaire_enter_name_only_spaces_hh_ni(self):
+        await self.check_get_enter_address(self.get_request_continuation_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_continuation_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_continuation_questionnaire_select_address_ni, 'ni', 'HH')
+        await self.check_post_confirm_address_input_yes_continuation(
+            self.post_request_continuation_questionnaire_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
+        await self.check_post_people_in_household(
+            self.post_request_continuation_questionnaire_people_in_household_ni, 'ni', '7')
+        await self.check_post_enter_name_inputs_error(self.post_request_continuation_questionnaire_enter_name_ni, 'ni',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_continuation_questionnaire_enter_name_only_spaces_spg_ew_e(self):
+        await self.check_get_enter_address(self.get_request_continuation_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_continuation_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(
+            self.post_request_continuation_questionnaire_select_address_en, 'en', 'SPG')
+        await self.check_post_confirm_address_input_yes_continuation(
+            self.post_request_continuation_questionnaire_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_e)
+        await self.check_post_people_in_household(
+            self.post_request_continuation_questionnaire_people_in_household_en, 'en', '7')
+        await self.check_post_enter_name_inputs_error(self.post_request_continuation_questionnaire_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_continuation_questionnaire_enter_name_only_spaces_spg_ew_w(self):
+        await self.check_get_enter_address(self.get_request_continuation_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_continuation_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(
+            self.post_request_continuation_questionnaire_select_address_en, 'en', 'SPG')
+        await self.check_post_confirm_address_input_yes_continuation(
+            self.post_request_continuation_questionnaire_confirm_address_en, 'en', self.rhsvc_case_by_uprn_spg_w)
+        await self.check_post_people_in_household(
+            self.post_request_continuation_questionnaire_people_in_household_en, 'en', '7')
+        await self.check_post_enter_name_inputs_error(self.post_request_continuation_questionnaire_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_continuation_questionnaire_enter_name_only_spaces_spg_cy(self):
+        await self.check_get_enter_address(self.get_request_continuation_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_continuation_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_select_address(
+            self.post_request_continuation_questionnaire_select_address_cy, 'cy', 'SPG')
+        await self.check_post_confirm_address_input_yes_continuation(
+            self.post_request_continuation_questionnaire_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_spg_w)
+        await self.check_post_people_in_household(
+            self.post_request_continuation_questionnaire_people_in_household_cy, 'cy', '7')
+        await self.check_post_enter_name_inputs_error(self.post_request_continuation_questionnaire_enter_name_cy, 'cy',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_continuation_questionnaire_enter_name_only_spaces_spg_ni(self):
+        await self.check_get_enter_address(self.get_request_continuation_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_continuation_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_select_address(
+            self.post_request_continuation_questionnaire_select_address_ni, 'ni', 'SPG')
+        await self.check_post_confirm_address_input_yes_continuation(
+            self.post_request_continuation_questionnaire_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_spg_n)
+        await self.check_post_people_in_household(
+            self.post_request_continuation_questionnaire_people_in_household_ni, 'ni', '7')
+        await self.check_post_enter_name_inputs_error(self.post_request_continuation_questionnaire_enter_name_ni, 'ni',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
     async def test_request_continuation_questionnaire_enter_name_no_first_hh_ew_e(self):
         await self.check_get_enter_address(self.get_request_continuation_questionnaire_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_continuation_questionnaire_enter_address_en, 'en')

--- a/tests/unit/test_request_handlers_individual_code.py
+++ b/tests/unit/test_request_handlers_individual_code.py
@@ -1030,6 +1030,62 @@ class TestRequestHandlersIndividualCode(TestHelpers):
                                                       self.common_form_data_empty)
 
     @unittest_run_loop
+    async def test_request_individual_code_post_enter_name_only_spaces_hh_ew_e(self):
+        await self.check_get_request_individual_code(self.get_request_individual_code_en, 'en')
+        await self.check_post_request_individual_code(self.post_request_individual_code_en, 'en')
+        await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
+        await self.check_post_confirm_address_input_yes_code_individual(
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e,
+            'individual', 'HH')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_individual_code_select_how_to_receive_en, 'en')
+        await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_individual_code_post_enter_name_only_spaces_hh_ew_w(self):
+        await self.check_get_request_individual_code(self.get_request_individual_code_en, 'en')
+        await self.check_post_request_individual_code(self.post_request_individual_code_en, 'en')
+        await self.check_post_enter_address(self.post_request_individual_code_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_individual_code_select_address_en, 'en', 'HH')
+        await self.check_post_confirm_address_input_yes_code_individual(
+            self.post_request_individual_code_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_individual_code_select_how_to_receive_en, 'en')
+        await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_individual_code_post_enter_name_only_spaces_hh_cy(self):
+        await self.check_get_request_individual_code(self.get_request_individual_code_cy, 'cy')
+        await self.check_post_request_individual_code(self.post_request_individual_code_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_individual_code_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_individual_code_select_address_cy, 'cy', 'HH')
+        await self.check_post_confirm_address_input_yes_code_individual(
+            self.post_request_individual_code_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w,
+            'individual', 'HH')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_individual_code_select_how_to_receive_cy, 'cy')
+        await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_cy, 'cy',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_individual_code_post_enter_name_only_spaces_hh_ni(self):
+        await self.check_get_request_individual_code(self.get_request_individual_code_ni, 'ni')
+        await self.check_post_request_individual_code(self.post_request_individual_code_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_individual_code_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_individual_code_select_address_ni, 'ni', 'HH')
+        await self.check_post_confirm_address_input_yes_code_individual(
+            self.post_request_individual_code_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n,
+            'individual', 'HH')
+        await self.check_post_select_how_to_receive_input_post(
+            self.post_request_individual_code_select_how_to_receive_ni, 'ni')
+        await self.check_post_enter_name_inputs_error(self.post_request_individual_code_enter_name_ni, 'ni',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
     async def test_request_individual_code_post_enter_name_no_first_hh_ew_e(self):
         await self.check_get_request_individual_code(self.get_request_individual_code_en, 'en')
         await self.check_post_request_individual_code(self.post_request_individual_code_en, 'en')

--- a/tests/unit/test_request_handlers_questionnaire.py
+++ b/tests/unit/test_request_handlers_questionnaire.py
@@ -741,6 +741,206 @@ class TestRequestHandlersPaperForm(TestHelpers):
                                                       self.common_form_data_empty)
 
     @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_hh_ew_e(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'HH')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_questionnaire_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_e)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_en, 'en')
+        await self.check_post_people_in_household(
+            self.post_request_paper_questionnaire_people_in_household_en, 'en', '4')
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_hh_ew_w(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'HH')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_questionnaire_confirm_address_en, 'en', self.rhsvc_case_by_uprn_hh_w)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_en, 'en')
+        await self.check_post_people_in_household(
+            self.post_request_paper_questionnaire_people_in_household_en, 'en', '4')
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_hh_cy(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_cy, 'cy', 'HH')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_questionnaire_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_hh_w)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_cy, 'cy')
+        await self.check_post_people_in_household(
+            self.post_request_paper_questionnaire_people_in_household_cy, 'cy', '4')
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_cy, 'cy',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_hh_ni(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_ni, 'ni', 'HH')
+        await self.check_post_confirm_address_input_yes_form(
+            self.post_request_paper_questionnaire_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_hh_n)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_ni, 'ni')
+        await self.check_post_people_in_household(
+            self.post_request_paper_questionnaire_people_in_household_ni, 'ni', '4')
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_ni, 'ni',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_spg_ew_e(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'SPG')
+        await self.check_post_confirm_address_input_yes_form(self.post_request_paper_questionnaire_confirm_address_en,
+                                                             'en', self.rhsvc_case_by_uprn_spg_e)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_en, 'en')
+        await self.check_post_people_in_household(
+            self.post_request_paper_questionnaire_people_in_household_en, 'en', '4')
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_spg_ew_w(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'SPG')
+        await self.check_post_confirm_address_input_yes_form(self.post_request_paper_questionnaire_confirm_address_en,
+                                                             'en', self.rhsvc_case_by_uprn_spg_w)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_en, 'en')
+        await self.check_post_people_in_household(
+            self.post_request_paper_questionnaire_people_in_household_en, 'en', '4')
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_spg_cy(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_cy, 'cy', 'SPG')
+        await self.check_post_confirm_address_input_yes_form(self.post_request_paper_questionnaire_confirm_address_cy,
+                                                             'cy', self.rhsvc_case_by_uprn_spg_w)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_cy, 'cy')
+        await self.check_post_people_in_household(
+            self.post_request_paper_questionnaire_people_in_household_cy, 'cy', '4')
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_cy, 'cy',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_spg_ni(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_ni, 'ni', 'SPG')
+        await self.check_post_confirm_address_input_yes_form(self.post_request_paper_questionnaire_confirm_address_ni,
+                                                             'ni', self.rhsvc_case_by_uprn_spg_n)
+        await self.check_post_household_information_form(
+            self.post_request_paper_questionnaire_household_ni, 'ni')
+        await self.check_post_people_in_household(
+            self.post_request_paper_questionnaire_people_in_household_ni, 'ni', '4')
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_ni, 'ni',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_select_resident_ce_m_ew_e(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'CE')
+        await self.check_post_confirm_address_input_yes_ce(self.post_request_paper_questionnaire_confirm_address_en,
+                                                           'en', self.rhsvc_case_by_uprn_ce_m_e)
+        await self.check_post_resident_or_manager_form_resident(
+            self.post_request_paper_questionnaire_resident_or_manager_en, 'en')
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_select_resident_ce_m_ew_w(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'CE')
+        await self.check_post_confirm_address_input_yes_ce(self.post_request_paper_questionnaire_confirm_address_en,
+                                                           'en', self.rhsvc_case_by_uprn_ce_m_w)
+        await self.check_post_resident_or_manager_form_resident(
+            self.post_request_paper_questionnaire_resident_or_manager_en, 'en')
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_select_resident_ce_m_cy(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_cy, 'cy', 'CE')
+        await self.check_post_confirm_address_input_yes_ce(self.post_request_paper_questionnaire_confirm_address_cy,
+                                                           'cy', self.rhsvc_case_by_uprn_ce_m_w)
+        await self.check_post_resident_or_manager_form_resident(
+            self.post_request_paper_questionnaire_resident_or_manager_cy, 'cy')
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_cy, 'cy',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_select_resident_ce_m_ni(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_ni, 'ni', 'CE')
+        await self.check_post_confirm_address_input_yes_ce(self.post_request_paper_questionnaire_confirm_address_ni,
+                                                           'ni', self.rhsvc_case_by_uprn_ce_m_n)
+        await self.check_post_resident_or_manager_form_resident(
+            self.post_request_paper_questionnaire_resident_or_manager_ni, 'ni')
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_ni, 'ni',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_ce_r_ew_e(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'CE')
+        await self.check_post_confirm_address_input_yes_form_individual(
+            self.post_request_paper_questionnaire_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_e)
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_ce_r_ew_w(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'CE')
+        await self.check_post_confirm_address_input_yes_form_individual(
+            self.post_request_paper_questionnaire_confirm_address_en, 'en', self.rhsvc_case_by_uprn_ce_r_w)
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_en, 'en',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_ce_r_cy(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_cy, 'cy', 'CE')
+        await self.check_post_confirm_address_input_yes_form_individual(
+            self.post_request_paper_questionnaire_confirm_address_cy, 'cy', self.rhsvc_case_by_uprn_ce_r_w)
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_cy, 'cy',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_enter_name_only_spaces_ce_r_ni(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_ni, 'ni', 'CE')
+        await self.check_post_confirm_address_input_yes_form_individual(
+            self.post_request_paper_questionnaire_confirm_address_ni, 'ni', self.rhsvc_case_by_uprn_ce_r_n)
+        await self.check_post_enter_name_inputs_error(self.post_request_paper_questionnaire_enter_name_ni, 'ni',
+                                                      self.request_common_enter_name_form_data_only_spaces)
+
+    @unittest_run_loop
     async def test_request_paper_questionnaire_enter_name_no_first_hh_ew_e(self):
         await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
         await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
@@ -3817,6 +4017,42 @@ class TestRequestHandlersPaperForm(TestHelpers):
         await self.add_room_number(self.get_request_paper_questionnaire_enter_room_number_ni,
                                    self.post_request_paper_questionnaire_enter_room_number_ni,
                                    'ni', 'individual', 'ConfirmAddress', check_for_value=True)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_sent_post_add_room_early_only_space_ce_r_ew_e(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'CE')
+        await self.add_room_number(self.get_request_paper_questionnaire_enter_room_number_en,
+                                   self.post_request_paper_questionnaire_enter_room_number_en,
+                                   'en', 'individual', 'ConfirmAddress', check_for_value=False, data_only_space=True)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_sent_post_add_room_early_only_space_ce_r_ew_w(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_en, 'en')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_en, 'en', 'CE')
+        await self.add_room_number(self.get_request_paper_questionnaire_enter_room_number_en,
+                                   self.post_request_paper_questionnaire_enter_room_number_en,
+                                   'en', 'individual', 'ConfirmAddress', check_for_value=False, data_only_space=True)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_sent_post_add_room_early_only_space_ce_r_cy(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_cy, 'cy')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_cy, 'cy', 'CE')
+        await self.add_room_number(self.get_request_paper_questionnaire_enter_room_number_cy,
+                                   self.post_request_paper_questionnaire_enter_room_number_cy,
+                                   'cy', 'individual', 'ConfirmAddress', check_for_value=False, data_only_space=True)
+
+    @unittest_run_loop
+    async def test_request_paper_questionnaire_sent_post_add_room_early_only_space_ce_r_ni(self):
+        await self.check_get_enter_address(self.get_request_paper_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_enter_address(self.post_request_paper_questionnaire_enter_address_ni, 'ni')
+        await self.check_post_select_address(self.post_request_paper_questionnaire_select_address_ni, 'ni', 'CE')
+        await self.add_room_number(self.get_request_paper_questionnaire_enter_room_number_ni,
+                                   self.post_request_paper_questionnaire_enter_room_number_ni,
+                                   'ni', 'individual', 'ConfirmAddress', check_for_value=False, data_only_space=True)
 
     @unittest_run_loop
     async def test_request_paper_questionnaire_sent_post_add_room_late_long_surname_ce_r_ew_e(self):

--- a/tests/unit/test_start_handlers_transient.py
+++ b/tests/unit/test_start_handlers_transient.py
@@ -65,6 +65,11 @@ class TestStartHandlersTransient(TestHelpers):
         await self.check_post_start_transient(display_region, region)
         await self.check_post_start_transient_enter_town_name_empty(display_region)
 
+    async def check_start_transient_town_name_only_space(self, display_region, region):
+        await self.check_get_start(display_region, adlocation=False)
+        await self.check_post_start_transient(display_region, region)
+        await self.check_post_start_transient_enter_town_name_only_space(display_region)
+
     async def check_start_transient_accommodation_type_empty(self, display_region, region):
         await self.check_get_start(display_region, adlocation=False)
         await self.check_post_start_transient(display_region, region)
@@ -352,6 +357,22 @@ class TestStartHandlersTransient(TestHelpers):
     @unittest_run_loop
     async def test_transient_town_name_empty_ni(self):
         await self.check_start_transient_town_name_empty('ni', 'N')
+
+    @unittest_run_loop
+    async def test_transient_town_name_only_space_ew_e(self):
+        await self.check_start_transient_town_name_only_space('en', 'E')
+
+    @unittest_run_loop
+    async def test_transient_town_name_only_space_ew_w(self):
+        await self.check_start_transient_town_name_only_space('en', 'W')
+
+    @unittest_run_loop
+    async def test_transient_town_name_only_space_cy(self):
+        await self.check_start_transient_town_name_only_space('cy', 'W')
+
+    @unittest_run_loop
+    async def test_transient_town_name_only_space_ni(self):
+        await self.check_start_transient_town_name_only_space('ni', 'N')
 
     @unittest_run_loop
     async def test_transient_accommodation_type_empty_ew_e(self):

--- a/tests/unit/test_web_form_handlers.py
+++ b/tests/unit/test_web_form_handlers.py
@@ -163,6 +163,28 @@ class TestWebFormHandlers(TestHelpers):
                 else:
                     self.assertMessagePanel(WEBFORM_MISSING_EMAIL_EMPTY_MSG, contents)
 
+    async def form_submission_name_invalid(self, url, display_region, name_value):
+        form_data = self.webform_form_data.copy()
+        form_data['name'] = name_value
+
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            response = await self.client.request('POST', url, data=form_data)
+            self.assertLogEvent(cm, self.build_url_log_entry('web-form', display_region, 'POST',
+                                                             include_sub_user_journey=False, include_page=False))
+            self.assertLogEvent(cm, 'web form submission error')
+
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.get_logo(display_region), contents)
+            if not display_region == 'ni':
+                self.assertIn(self.build_translation_link('web-form', display_region, include_sub_user_journey=False,
+                                                          include_page=False), contents)
+            self.check_text_web_form(display_region, contents, check_error=True)
+            if display_region == 'cy':
+                self.assertMessagePanel(WEBFORM_MISSING_NAME_MSG_CY, contents)
+            else:
+                self.assertMessagePanel(WEBFORM_MISSING_NAME_MSG, contents)
+
     async def form_submission_email_invalid(self, url, display_region, email_value):
         form_data = self.webform_form_data.copy()
         form_data['email'] = email_value
@@ -220,6 +242,15 @@ class TestWebFormHandlers(TestHelpers):
         await self.form_submission_incomplete(self.post_webform_en, 'en', 'email')
         await self.form_submission_incomplete(self.post_webform_cy, 'cy', 'email')
         await self.form_submission_incomplete(self.post_webform_ni, 'ni', 'email')
+
+    @unittest_run_loop
+    async def test_form_submission_name_invalid(self):
+        await self.form_submission_name_invalid(self.post_webform_en, 'en', '')
+        await self.form_submission_name_invalid(self.post_webform_cy, 'cy', '')
+        await self.form_submission_name_invalid(self.post_webform_ni, 'ni', '')
+        await self.form_submission_name_invalid(self.post_webform_en, 'en', ' ')
+        await self.form_submission_name_invalid(self.post_webform_cy, 'cy', ' ')
+        await self.form_submission_name_invalid(self.post_webform_ni, 'ni', ' ')
 
     @unittest_run_loop
     async def test_form_submission_email_invalid(self):

--- a/tests/unit/test_webchat_handlers.py
+++ b/tests/unit/test_webchat_handlers.py
@@ -419,6 +419,78 @@ class TestWebChatHandlers(RHTestCase):
             self.assertIn(self.content_webchat_error_selected_query, contents)
 
     @unittest_run_loop
+    async def test_post_webchat_name_only_space_en(self):
+        with mock.patch('app.webchat_handlers.WebChat.get_now_utc') as mocked_get_now_utc:
+            mocked_get_now_utc.return_value = datetime.datetime(2019, 6, 15, 9, 30)
+            form_data = self.webchat_form_data_en.copy()
+            form_data['screen_name'] = ' '
+
+            with self.assertLogs('respondent-home', 'INFO') as cm:
+                response = await self.client.request('POST',
+                                                     self.post_webchat_en,
+                                                     data=form_data)
+            self.assertLogEvent(cm, 'form submission error')
+
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.ons_logo_en, contents)
+            self.assertIn(self.content_webchat_form_page_title_error_en, contents)
+            self.assertIn(self.content_webchat_form_title_en, contents)
+            self.assertIn(self.content_common_error_panel_answer_en, contents)
+            self.assertIn(self.content_webchat_error_enter_your_name_en, contents)
+            self.assertNotIn(self.content_webchat_error_selected_screen_name, contents)
+            self.assertIn(self.content_webchat_error_selected_country_en, contents)
+            self.assertIn(self.content_webchat_error_selected_query, contents)
+
+    @unittest_run_loop
+    async def test_post_webchat_name_only_space_cy(self):
+        with mock.patch('app.webchat_handlers.WebChat.get_now_utc') as mocked_get_now_utc:
+            mocked_get_now_utc.return_value = datetime.datetime(2019, 6, 15, 9, 30)
+            form_data = self.webchat_form_data_cy.copy()
+            form_data['screen_name'] = ' '
+
+            with self.assertLogs('respondent-home', 'INFO') as cm:
+                response = await self.client.request('POST',
+                                                     self.post_webchat_cy,
+                                                     data=form_data)
+            self.assertLogEvent(cm, 'form submission error')
+
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.ons_logo_cy, contents)
+            self.assertIn(self.content_webchat_form_page_title_error_cy, contents)
+            self.assertIn(self.content_webchat_form_title_cy, contents)
+            self.assertIn(self.content_common_error_panel_answer_cy, contents)
+            self.assertIn(self.content_webchat_error_enter_your_name_cy, contents)
+            self.assertNotIn(self.content_webchat_error_selected_screen_name, contents)
+            self.assertIn(self.content_webchat_error_selected_country_cy, contents)
+            self.assertIn(self.content_webchat_error_selected_query, contents)
+
+    @unittest_run_loop
+    async def test_post_webchat_name_only_space_ni(self):
+        with mock.patch('app.webchat_handlers.WebChat.get_now_utc') as mocked_get_now_utc:
+            mocked_get_now_utc.return_value = datetime.datetime(2019, 6, 15, 9, 30)
+            form_data = self.webchat_form_data_ni.copy()
+            form_data['screen_name'] = ' '
+
+            with self.assertLogs('respondent-home', 'INFO') as cm:
+                response = await self.client.request('POST',
+                                                     self.post_webchat_ni,
+                                                     data=form_data)
+            self.assertLogEvent(cm, 'form submission error')
+
+            self.assertEqual(response.status, 200)
+            contents = str(await response.content.read())
+            self.assertIn(self.nisra_logo, contents)
+            self.assertIn(self.content_webchat_form_page_title_error_en, contents)
+            self.assertIn(self.content_webchat_form_title_en, contents)
+            self.assertIn(self.content_common_error_panel_answer_en, contents)
+            self.assertIn(self.content_webchat_error_enter_your_name_en, contents)
+            self.assertNotIn(self.content_webchat_error_selected_screen_name, contents)
+            self.assertIn(self.content_webchat_error_selected_country_ni, contents)
+            self.assertIn(self.content_webchat_error_selected_query, contents)
+
+    @unittest_run_loop
     async def test_post_webchat_open_en(self):
         mocked_now_utc = datetime.datetime(2019, 6, 15, 9, 30)
         await self.should_be_open_to_post(self.post_webchat_en, 'Web Chat', self.ons_logo_en, mocked_now_utc,


### PR DESCRIPTION
# Motivation and Context
Adds trapping for spaces only and removal of leading/trailing spaces in non-regex checked fields

# What has changed
Update to response validation for first name, last name in all 'Enter name' pages (all postal fulfilment journeys)
Update to response validation for town name in transient journey
Update to response validation for 'add room number' in CE fulfilment journeys (note room number field can be empty, but should disregard just spaces)
Update to response validation for web form 'name' field
Update to response validation for web chat 'screen name' field
New and updated unit tests for above

No Cucumber updates required

Other text fields in the authentication and fulfilment journeys do not require an update as they are covered by their existing regexes

# How to test?
Try entering just spaces in the fields - check that response is treated as if the field is empty

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1826