### PR TITLE
Cr 1835 web chat census weekend text removal

### DIFF
--- a/app/templates/webchat-form.html
+++ b/app/templates/webchat-form.html
@@ -43,8 +43,7 @@
         <p>
             {{_('Monday to Friday, %(open_time)s to %(close_time)s', open_time=rhTime({'time': weekday_open }), close_time=rhTime({'time': weekday_close }) )|safe }}<br/>
             {{_('Saturday, %(open_time)s to %(close_time)s', open_time=rhTime({'time': saturday_open }), close_time=rhTime({'time': saturday_close }) )|safe }}<br/>
-            {{_('Sunday, closed') }}<br>
-            {{_('Census weekend (20 - 21 March), %(open_time)s to %(close_time)s', open_time=rhTime({'time': census_sunday_open }), close_time=rhTime({'time': census_sunday_close }) )|safe }}
+            {{_('Sunday, closed') }}
         </p>
 
     {% else %}


### PR DESCRIPTION
# Motivation and Context
Remove the redundant 'Census weekend' text from the web chat closed text

# What has changed
Removed line of text from the template

No Cucumber updates required (tested in dev when chat should have been closed)

# How to test?
View web chat page when it should be closed - check the line about Census weekend has been removed

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1835