### PR TITLE
CR-1833 Fix for postcodes with unicode data

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -8,6 +8,7 @@ from .exceptions import InactiveCaseError, InvalidEqPayLoad, InvalidDataError, I
 from aiohttp.web import HTTPFound
 from datetime import datetime, date
 from pytz import timezone, utc
+from unicodedata import normalize
 
 from sdc.crypto.encrypter import encrypt
 from .eq import EqPayloadConstructor
@@ -203,6 +204,7 @@ class ProcessPostcode:
             postcode = postcode.replace(character, '')
 
         postcode = postcode.upper()
+        postcode = normalize('NFKD', postcode).encode('ascii', 'ignore').decode('utf8')
 
         if len(postcode) == 0:
             if locale == 'cy':

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -16,6 +16,14 @@ class TestUtils(RHTestCase):
         ProcessPostcode.validate_postcode(postcode, locale)
         # Nothing happens
 
+    def test_validate_postcode_valid_with_unicode(self):
+        postcode = 'BS２ ０FW'
+        locale = 'en'
+
+        # When validate_postcode is called
+        ProcessPostcode.validate_postcode(postcode, locale)
+        # Nothing happens
+
     def test_validate_postcode_empty(self):
         postcode = ''
         locale = 'en'


### PR DESCRIPTION
# Motivation and Context
Addition of unicode normalize to convert non-standard numbers so they can be processed by AIMS

# What has changed
Addition of line to process postcode input and convert non-standard digits to be readable by AIMS

No Cucumber updates required

# How to test?
Confirm that postcode BS２ ０FW works with AIMS, and all normal postcodes still work

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1833