### PR TITLE
Web chat time change

### DIFF
--- a/app/webchat_handlers.py
+++ b/app/webchat_handlers.py
@@ -31,7 +31,7 @@ census_sunday_close = 20
 saturday_open = 8
 saturday_close = 13
 
-weekday_open = 10
+weekday_open = 8
 weekday_close = 20
 
 uk_zone = timezone('Europe/London')

--- a/tests/unit/test_webchat_handlers.py
+++ b/tests/unit/test_webchat_handlers.py
@@ -44,14 +44,14 @@ class TestWebChatHandlers(RHTestCase):
 
     def test_check_open_weekday_open(self):
         self.should_be_open(2019, 6, 17, 11, 30)    # 2019 BST summer
-        self.should_be_open(2020, 8, 12, 9, 1)     # 2020 BST summer just after opening
+        self.should_be_open(2020, 8, 12, 7, 1)     # 2020 BST summer just after opening
         self.should_be_open(2020, 8, 12, 18, 59)    # 2020 BST summer just before closing
-        self.should_be_open(2020, 11, 10, 10, 1)    # 2020 GMT winter just after opening
+        self.should_be_open(2020, 11, 10, 8, 1)    # 2020 GMT winter just after opening
         self.should_be_open(2020, 11, 10, 19, 59)   # 2020 GMT winter just before closing
-        self.should_be_open(2021, 3, 26, 10, 1)     # 2021 GMT spring just after opening
+        self.should_be_open(2021, 3, 26, 8, 1)     # 2021 GMT spring just after opening
         self.should_be_open(2021, 3, 26, 17, 30)    # 2021 GMT spring mid evening
         self.should_be_open(2021, 3, 26, 19, 59)    # 2021 GMT spring just before closing
-        self.should_be_open(2021, 3, 29, 10, 1)     # 2021 BST summer just after opening
+        self.should_be_open(2021, 3, 29, 7, 1)     # 2021 BST summer just after opening
         self.should_be_open(2021, 3, 29, 18, 30)    # 2021 BST summer mid evening
         self.should_be_open(2021, 3, 29, 18, 59)    # 2021 BST summer just before closing
 

--- a/tests/unit/test_webchat_handlers.py
+++ b/tests/unit/test_webchat_handlers.py
@@ -58,13 +58,13 @@ class TestWebChatHandlers(RHTestCase):
     def test_check_open_weekday_closed(self):
         self.should_be_closed(2019, 6, 16, 10, 30)  # 2019 BST summer before opening
         self.should_be_closed(2019, 6, 16, 19, 30)  # 2019 BST summer after closing
-        self.should_be_closed(2020, 8, 12, 8, 59)  # 2020 BST summer just before opening
+        self.should_be_closed(2020, 8, 12, 6, 59)  # 2020 BST summer just before opening
         self.should_be_closed(2020, 8, 12, 19, 1)   # 2020 BST summer just after closing
-        self.should_be_closed(2020, 11, 10, 9, 59) # 2020 GMT winter just before opening
+        self.should_be_closed(2020, 11, 10, 7, 59) # 2020 GMT winter just before opening
         self.should_be_closed(2020, 11, 10, 20, 1)  # 2020 GMT winter just after closing
-        self.should_be_closed(2021, 3, 26, 9, 59)  # 2021 GMT spring just before opening
+        self.should_be_closed(2021, 3, 26, 7, 59)  # 2021 GMT spring just before opening
         self.should_be_closed(2021, 3, 26, 20, 1)   # 2021 GMT spring just after closing
-        self.should_be_closed(2021, 3, 29, 8, 59)  # 2021 BST summer just before opening
+        self.should_be_closed(2021, 3, 29, 6, 59)  # 2021 BST summer just before opening
         self.should_be_closed(2021, 3, 29, 19, 1)   # 2021 BST summer just after closing
 
     def test_check_open_saturday_open(self):


### PR DESCRIPTION
# Motivation and Context
Change web chat weekday opening hours to 8am (previously 10am)

# What has changed
Change of configured weekday opening time
Update of weekday opening and closing tests to account for change

# How to test?
Can only be tested around 8am on a weekday
